### PR TITLE
Fix: broken assets path gh-pages

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -28,6 +28,9 @@ jobs:
     - name: Install dependencies ⏬
       run: npm ci
 
+    - name: Adapt base path for gh-pages :twisted_rightwards_arrows:
+      run: sed -i 's/\htmlWebpackPlugin.options.appPrefix/\/latest\//' resources/public/index.ejs
+
     - name: Build artifacts 🏗️
       run: npm run build
 

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -29,7 +29,7 @@ jobs:
       run: npm ci
 
     - name: Adapt base path for gh-pages 🔀
-      run: sed -i 's/\htmlWebpackPlugin.options.appPrefix/\/latest\//' resources/public/index.ejs
+      run: sed -i 's/<%= htmlWebpackPlugin.options.appPrefix %>/\/latest\//' resources/public/index.ejs
 
     - name: Build artifacts 🏗️
       run: npm run build

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies ⏬
       run: npm ci
 
-    - name: Adapt base path for gh-pages :twisted_rightwards_arrows:
+    - name: Adapt base path for gh-pages 🔀
       run: sed -i 's/\htmlWebpackPlugin.options.appPrefix/\/latest\//' resources/public/index.ejs
 
     - name: Build artifacts 🏗️


### PR DESCRIPTION
This adapts the base path in index.ejs template before building the gh-pages.  
Other Alternatives would be, e.g.
  - extra webpack-common for gh-pages

What do you think @terrestris/devs ?