### PR TITLE
Publish artifact files to npm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .github
 coverage
 dist
+build
 node_modules
 test-results
 .dockerignore

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout sources 🔰
       uses: actions/checkout@v2
 
-    - name: Setup Node.js 16
+    - name: Setup Node.js 16 🧮
       uses: actions/setup-node@v1
       with:
         node-version: 16

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages
-        folder: dist
+        folder: build
         target-folder: latest
 
   sonarqube:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -40,5 +40,5 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages
-        folder: dist
+        folder: build
         target-folder: v${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,19 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout 🔰
         uses: actions/checkout@v2
 
-      - name: Setup Node.js
+      - name: Setup Node.js 🧮
         uses: actions/setup-node@v1
         with:
           node-version: 16
 
       - name: Install dependencies ⏬
         run: npm ci
+
+      - name: Build (dist) artifacts 🏗️
+        run: npm run tsc
 
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2
@@ -28,14 +31,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Login to Nexus
+      - name: Login to Nexus ⌨️
         uses: docker/login-action@v1
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.NEXUS_USERNAME }}
           password: ${{ secrets.NEXUS_PASSWORD }}
 
-      - name: Build docker image (latest)
+      - name: Build docker image (latest) 🏗️
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -43,7 +46,7 @@ jobs:
             ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:latest
           load: true
 
-      - name: Build docker image (version)
+      - name: Build docker image (version) 🏗️
         if: steps.semantic.outputs.new_release_published == 'true'
         uses: docker/build-push-action@v2
         with:
@@ -52,11 +55,11 @@ jobs:
             ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:${{ steps.semantic.outputs.new_release_version }}
           load: true
 
-      - name: Push docker image to Nexus (latest)
+      - name: Push docker image to Nexus (latest) 📠
         run: |
           docker push ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:latest
 
-      - name: Push docker image to Nexus (version)
+      - name: Push docker image to Nexus (version) 📠
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
           docker push ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:${{ steps.semantic.outputs.new_release_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ test-results
 # SonarQube
 sonar-project.properties
 .scannerwork/
+
+# webpack output directory
+build

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -97,12 +97,7 @@
         }
       }
     ],
-    [
-      "@semantic-release/npm",
-      {
-        "npmPublish": false
-      }
-    ],
+    "@semantic-release/npm",
     "@semantic-release/changelog",
     [
       "@semantic-release/git",

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm run build
 
 FROM nginx:1.21.1-alpine
 
-COPY --from=build /app/dist /usr/share/nginx/html
+COPY --from=build /app/build /usr/share/nginx/html
 COPY default.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:ui": "playwright test",
     "test": "jest --coverage",
     "tsc": "tsc -p tsconfig.json",
-    "typecheck": "tsc --noEmit --project tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "browserslist": [
     "defaults",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,6 @@
 declare module '*.png';
 
+declare const PROJECT_VERSION: string;
 declare const KEYCLOAK_HOST: string;
 declare const KEYCLOAK_REALM: string;
 declare const KEYCLOAK_CLIENT_ID: string;

--- a/src/hooks/useVersion.ts
+++ b/src/hooks/useVersion.ts
@@ -1,6 +1,3 @@
-import * as packageInfoClient from '../../package.json';
-
 export const useClientVersion = () => {
-  // @ts-ignore
-  return packageInfoClient.default.version;
+  return PROJECT_VERSION;
 };

--- a/src/store/addLayerModal/index.ts
+++ b/src/store/addLayerModal/index.ts
@@ -2,7 +2,7 @@ import {
   createSlice
 } from '@reduxjs/toolkit';
 
-interface AddLayerModalState {
+export interface AddLayerModalState {
   visible: boolean;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
 
     /* Emit */
-    "declaration": false,                                /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -104,6 +104,7 @@
     "node_modules",
     "node_modules/**",
     "dist",
+    "build",
     "**.spec.**",
     "**.config.js"
   ]

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -75,6 +75,7 @@ module.exports = {
       }]
     }),
     new webpack.DefinePlugin({
+      PROJECT_VERSION: JSON.stringify(require('./package.json').version),
       KEYCLOAK_HOST: JSON.stringify(process.env.KEYCLOAK_HOST),
       KEYCLOAK_REALM: JSON.stringify(process.env.KEYCLOAK_REALM),
       KEYCLOAK_CLIENT_ID: JSON.stringify(process.env.KEYCLOAK_CLIENT_ID)

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -46,7 +46,7 @@ module.exports = {
     ]
   },
   output: {
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(__dirname, 'build'),
     clean: true
   },
   plugins: [


### PR DESCRIPTION
This suggests to publish the artifact files (built via `tsc`) to the npm registry.

The published files can be useful for external apps, especially plugins (see #250), to make use of the typings, utils and others.

~TODO: The name of the project should be adjusted first, see #274.~

Please review @terrestris/devs.

