### PR TITLE
Set `publishConfig` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,9 @@
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.10.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "devEngines": {
     "node": ">=14",
     "npm": ">=7"

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
     "dist"
   ],
   "scripts": {
-    "build:analyze": "BUNDLE_ANALYZE=true npm run build",
     "build": "webpack --config webpack.prod.js",
+    "build:analyze": "BUNDLE_ANALYZE=true npm run build",
     "check": "npm run typecheck && npm run lint && npm run test && npm run test:ui",
     "husky": "husky install",
     "lint": "eslint -c .eslintrc.js --ext .ts,.tsx src/",
     "prepare": "npm run husky",
-    "start": "webpack serve --config webpack.dev.js",
     "semantic-release": "npm run clean; npm run build; npx semantic-release",
-    "test:ui": "playwright test",
+    "start": "webpack serve --config webpack.dev.js",
     "test": "jest --coverage",
+    "test:ui": "playwright test",
     "tsc": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },


### PR DESCRIPTION
This sets the `publishConfig` as suggested in [#512](https://github.com/semantic-release/semantic-release/issues/512) to fix the first npm deployment that is [currently failing](https://github.com/terrestris/shogun-gis-client/runs/7968124373?check_suite_focus=true#step:6:1086).

Please note @terrestris/devs.