### PR TITLE
Add support for header plugins

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,6 +3,13 @@ import React from 'react';
 import {
   useAppSelector
 } from '../../hooks/useAppSelector';
+import {
+  usePlugins
+} from '../../hooks/usePlugins';
+
+import {
+  HeaderPlacementOrientation
+} from '../../plugin';
 
 import BasicNominatimSearch from '../BasicNominatimSearch';
 
@@ -17,6 +24,70 @@ export const Header: React.FC<HeaderProps> = ({
 }): JSX.Element => {
   const title = useAppSelector((state) => state.title);
   const logoPath = useAppSelector((state) => state.logoPath);
+  const plugins = usePlugins();
+
+  const insertPlugins = (itemPosition: HeaderPlacementOrientation, items: JSX.Element[]) => {
+    plugins
+      .filter(plugin => plugin.integration?.placement === 'header' &&
+        plugin.integration?.placementOrientation === itemPosition)
+      .forEach(plugin => {
+        const {
+          key,
+          wrappedComponent: WrappedPluginComponent
+        } = plugin;
+
+        items.splice(plugin.integration?.insertionIndex || 0, 0,
+          <WrappedPluginComponent
+            key={key}
+          />
+        );
+      });
+  };
+
+  const getLeftItems = () => {
+    const items = [(
+      <img
+        key="logo"
+        className="logo"
+        src={logoPath}
+      />
+    ), (
+      <div
+        key="title"
+        className="title"
+      >
+        {title}
+      </div>
+    )];
+
+    insertPlugins('left', items);
+
+    return items;
+  };
+
+  const getCenterItems = () => {
+    const items = [
+      <BasicNominatimSearch
+        key="search"
+      />
+    ];
+
+    insertPlugins('center', items);
+
+    return items;
+  };
+
+  const getRightItems = () => {
+    const items = [
+      <UserMenu
+        key="user-menu"
+      />
+    ];
+
+    insertPlugins('right', items);
+
+    return items;
+  };
 
   return (
     <div
@@ -26,25 +97,23 @@ export const Header: React.FC<HeaderProps> = ({
       <div
         className="item-container left-items"
       >
-        <img
-          className="logo"
-          src={logoPath}
-        />
-        <div
-          className="title"
-        >
-          {title}
-        </div>
+        {
+          getLeftItems()
+        }
       </div>
       <div
         className="item-container center-items"
       >
-        <BasicNominatimSearch />
+        {
+          getCenterItems()
+        }
       </div>
       <div
         className="item-container right-items"
       >
-        <UserMenu />
+        {
+          getRightItems()
+        }
       </div>
     </div>
   );

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -43,9 +43,17 @@ export type ClientPluginIntegrationToolMenu = ClientPluginIntegration &
   theme?: 'dark' | 'light';
 };
 
+export type HeaderPlacementOrientation = 'left' | 'center' | 'right';
+
+export type ClientPluginIntegrationHeader = ClientPluginIntegration & {
+  placement: 'header';
+  placementOrientation: HeaderPlacementOrientation;
+  insertionIndex?: number;
+};
+
 export type ClientPlugin = {
   key: string;
-  integration?: ClientPluginIntegrationToolMenu;
+  integration?: ClientPluginIntegrationToolMenu | ClientPluginIntegrationHeader;
   component: React.FunctionComponent<ClientPluginComponentProps>;
   i18n?: ClientPluginLocale;
   reducers?: {


### PR DESCRIPTION
This adds support for integrating plugins to the header bar.

Example:

```
const MyHeaderPlugin: ClientPlugin = {
  key: 'my-header-plugin',
  integration: {
    placement: 'header',
    placementOrientation: 'right',
    insertionIndex: 0
  },
  component: MyPlugin,
  i18n: i18n
};
```

![image](https://user-images.githubusercontent.com/1137620/188567315-cf076ec4-3c86-4ffc-bed2-30215f8963ac.png)

Please review @terrestris/devs.