### PR TITLE
Optimize loading of plugins with multiple exposed paths

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -9,7 +9,7 @@ declare module 'clientConfig' {
   type PluginConfiguration = {
     name: string;
     resourcePath: string;
-    exposedPath: string;
+    exposedPaths: string[];
   };
   type ClientConfiguration = {
     shogunBase?: string;


### PR DESCRIPTION
This optimizes the handling of a client plugin with multiple exposed paths by loading the source file only once.

The configuration has slightly changed (and became simpler) which might be considered as a breaking change, but as the plugin feature is treated as experimental, I suggest to handle it as a fix.

Before:

```js
plugins: [{
  name: 'MyAppPlugin',
  exposedPath: './ExposedSubPathOne',
  resourcePath: '/client-plugins/index.js'
}, {
  name: 'MyAppPlugin',
  exposedPath: './ExposedSubPathTwo',
  resourcePath: '/client-plugins/index.js'
}]
```

After:

```js
plugins: [{
  name: 'MyAppPlugin',
  exposedPaths: [
    './ExposedSubPathOne',
    './ExposedSubPathTwo'
  ],
  resourcePath: '/client-plugins/index.js'
}]
```

Please review @terrestris/devs.