### PR TITLE
use docker-public.terrestris.de registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on: [workflow_dispatch]
 
 env:
-  DOCKER_REGISTRY: nexus.terrestris.de/repository/terrestris-public
+  DOCKER_REGISTRY: docker-public.terrestris.de/terrestris
 
 jobs:
   release:


### PR DESCRIPTION
Switches to docker-public.terrestris.de so the image will be available publicly.

@terrestris/devs Please note.