### PR TITLE
feat: generates a new permalink whenever a layer is added

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -286,19 +286,13 @@ const setupSHOGunMap = async (application: Application) => {
 
   view.setConstrainResolution(true);
 
-  const processLayerGroup = new OlLayerGroup({
-    layers: []
-  });
-  processLayerGroup.set('name', i18n.t('BasicMapComponent.processedLayersFolder'));
-  processLayerGroup.setVisible(false);
-
   const externalWmsLayerGroup = new OlLayerGroup({
     layers: []
   });
   externalWmsLayerGroup.set('name', i18n.t('AddLayerModal.externalWmsFolder'));
   externalWmsLayerGroup.setVisible(false);
 
-  layers?.getLayers().extend([processLayerGroup, externalWmsLayerGroup]);
+  layers?.getLayers().extend([externalWmsLayerGroup]);
 
   return new OlMap({
     view,
@@ -331,11 +325,12 @@ const setupDefaultMap = () => {
     hoverable: true
   });
 
-  const processLayerGroup = new OlLayerGroup({
+  const externalLayerGroup = new OlLayerGroup({
     layers: []
   });
-  processLayerGroup.set('name', i18n.t('BasicMapComponent.processedLayersFolder'));
-  processLayerGroup.setVisible(false);
+  externalLayerGroup.set('name', i18n.t('AddLayerModal.externalWmsFolder'));
+  externalLayerGroup.set('isGroupForImportedLayers', true);
+  externalLayerGroup.setVisible(false);
 
   const eoLayerGroup = new OlLayerGroup({
     layers: [temperatureLayer]
@@ -354,7 +349,7 @@ const setupDefaultMap = () => {
       center: center,
       zoom: 0
     }),
-    layers: [backgroundLayerGroup, eoLayerGroup, processLayerGroup],
+    layers: [backgroundLayerGroup, eoLayerGroup, externalLayerGroup],
     controls: OlControlDefaults({
       zoom: false
     })

--- a/src/components/AddLayerModal/index.tsx
+++ b/src/components/AddLayerModal/index.tsx
@@ -118,6 +118,7 @@ export const AddLayerModal: React.FC<AddLayerModalProps> = ({
     layersToAdd.forEach(layerToAdd => {
       if (!targetGroup.getLayers().getArray().includes(layerToAdd)) {
         layerToAdd.set('isExternalLayer', true);
+        layerToAdd.set('isImported', true);
         const layerUrl = layerToAdd instanceof TileLayer || layerToAdd instanceof ImageLayer ? layerToAdd.getSource().getUrl() : '';
 
         const layerConfig = {

--- a/src/components/BasicMapComponent/index.tsx
+++ b/src/components/BasicMapComponent/index.tsx
@@ -53,10 +53,8 @@ export const BasicMapComponent: React.FC<Partial<MapComponentProps>> = ({
     if (!map) {
       return;
     }
-    const processedFolderName = t('BasicMapComponent.processedLayersFolder');
-    const processedLayerGroup = MapUtil.getLayerByName(map, processedFolderName) as LayerGroup;
-    const externalFolderName = t('AddLayerModal.externalWmsFolder');
-    const externalLayerGroup = MapUtil.getLayerByName(map, externalFolderName) as LayerGroup;
+
+    const externalLayerGroup = MapUtil.getLayerByName(map, t('AddLayerModal.externalWmsFolder')) as LayerGroup;
 
     try {
       const config = JSON.parse(configString);
@@ -76,9 +74,14 @@ export const BasicMapComponent: React.FC<Partial<MapComponentProps>> = ({
           if (cfg.isExternalLayer) {
             externalLayerGroup.getLayers().extend([olLayer]);
             externalLayerGroup.setVisible(true);
-          } else if (cfg.isProcessedLayer) {
-            processedLayerGroup.getLayers().extend([olLayer]);
-            processedLayerGroup.setVisible(true);
+          } else {
+            const customFolderName = cfg.groupName;
+            const customLayerGroup = MapUtil.getLayerByName(map, customFolderName) as LayerGroup;
+
+            if (customLayerGroup) {
+              customLayerGroup.getLayers().extend([olLayer]);
+              customLayerGroup.setVisible(true);
+            }
           }
         }
       }

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -9,7 +9,6 @@ import OlBaseLayer from 'ol/layer/Base';
 import OlLayerGroup from 'ol/layer/Group';
 import OlLayer from 'ol/layer/Layer';
 import OlSource from 'ol/source/Source';
-import OlSourceVector from 'ol/source/Vector';
 
 import {
   useTranslation
@@ -46,23 +45,17 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
   const [visibleLegendsIds, setVisibleLegendsIds] = useState<string[]>([]);
 
   const treeFilterFunction = (layer: OlLayer<OlSource> | OlLayerGroup) => {
-    if (layer instanceof OlLayerGroup && !layer.getVisible() && layer.getLayers().getLength() === 0) {
-      return false;
-    }
 
-    if (layer.get('name') === 'react-geo_digitize') {
-      return false;
-    }
-
-    if (layer instanceof OlLayerGroup) {
+    // @ts-ignore
+    if (layer.getLayers) {
       return !layer.get('hideInLayerTree');
     }
 
-    if (layer.getSource && layer.getSource() instanceof OlSourceVector) {
+    // @ts-ignore
+    if (layer.getSource && layer.getSource().forEachFeature) {
       return false;
     }
-
-    return !layer.get('isBackgroundLayer') && !(layer.getSource && layer.getSource() instanceof OlSourceVector);
+    return true;
   };
 
   const treeNodeTitleRenderer = (layer: OlBaseLayer) => {
@@ -75,7 +68,8 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
     const resolution = mapView.getResolution();
     const scale = resolution ? MapUtil.getScaleForResolution(resolution, unit) : undefined;
 
-    if (layer instanceof OlLayerGroup) {
+    // @ts-ignore
+    if (layer.getLayers) {
       return (
         <div>
           {layer.get('name')}


### PR DESCRIPTION
A new permalink is generated every time the zoom-level, the extent or the layer constellation changes.
This MR removes all project specific components out of the GIS-client and let's the GIS-client handle new imports in a generalized way.