### PR TITLE
Add print url to client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Several global settings for the client can be configured via the [`gis-client-co
 | keycloak.realm | The Keycloak realm that should be used for authentication, e.g. `SHOGun` | null |
 | keycloak.clientId | The Keycloak client that should be used for authentication, e.g. `shogun-client` | null |
 | keycloak.onLoadAction | See [here](https://www.keycloak.org/docs/latest/securing_apps/#_javascript_adapter) for details | 'check-sso' |
+| print.url | The url of the MapFish Print servlet | '/print' |
 
 The configuration file is not bundled and will be loaded before application start from `./gis-client-config.js`. Typically you want to override the file in a production environment and you can pass a custom file by mounting the desired one directly into the nginx container of the client. For example:
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,8 +22,12 @@ module.exports = {
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/jest/fileMock.js',
-    '^.+\\.(css|less)$': '<rootDir>/jest/cssTransform.js'
+    '^.+\\.(css|less)$': '<rootDir>/jest/cssTransform.js',
+    'clientConfig': '<rootDir>/resources/config/gis-client-config.js'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
-  reporters: [ "default", "@casualbot/jest-sonar-reporter" ]
+  reporters: [
+    'default',
+    '@casualbot/jest-sonar-reporter'
+  ]
 };

--- a/resources/config/gis-client-config.js
+++ b/resources/config/gis-client-config.js
@@ -7,5 +7,8 @@ var clientConfig = {
     clientId: null,
     onLoadAction: 'check-sso'
   },
+  print: {
+    url: '/print'
+  },
   plugins: []
 };

--- a/src/components/Permalink/index.tsx
+++ b/src/components/Permalink/index.tsx
@@ -109,8 +109,7 @@ export const Permalink: React.FC<PermalinkProps> = () => {
       eventKeys.push(layerGroup.getLayers().on('add', updateLayersInPermalink));
       // @ts-ignore
       eventKeys.push(layerGroup.getLayers().on('remove', updateLayersInPermalink));
-
-    })
+    });
 
     const listenerKeyCenter = map.getView().on('change:center', updatePermalink);
     const listenerKeyResolution = map.getView().on('change:resolution', updatePermalink);

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -30,6 +30,8 @@ import {
   ItemType
 } from 'antd/lib/menu/hooks/useItems';
 
+import ClientConfiguration from 'clientConfig';
+
 import OlLayerGroup from 'ol/layer/Group';
 import OlLayer from 'ol/layer/Layer';
 import OlSource from 'ol/source/Source';
@@ -140,7 +142,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
 
   const initializeMapProvider = useCallback(async () => {
     const pManager: MapFishPrintV3Manager = new MapFishPrintV3Manager({
-      url: '/print',
+      url: ClientConfiguration.print?.url || '/print',
       map,
       timeout: 60000,
       layerFilter,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -20,6 +20,9 @@ declare module 'clientConfig' {
       clientId?: string;
       onLoadAction?: KeycloakOnLoad;
     };
+    print?: {
+      url?: string;
+    };
     plugins: PluginConfiguration[];
   };
   const config: ClientConfiguration;


### PR DESCRIPTION
This makes the url to the print servlet configurable via the `gis-client-config.js`

Please review @terrestris/devs 