### PR TITLE
feat: Nominatim: add viewbox config if extent is given

### DIFF
--- a/src/components/BasicNominatimSearch/index.tsx
+++ b/src/components/BasicNominatimSearch/index.tsx
@@ -1,5 +1,13 @@
-import React from 'react';
+import React, {
+  useEffect, useState
+} from 'react';
 
+import {
+  Extent as OlExtent
+} from 'ol/extent';
+import {
+  transformExtent
+} from 'ol/proj';
 import {
   useTranslation
 } from 'react-i18next';
@@ -16,6 +24,16 @@ export const BasicNominatimSearch: React.FC<Partial<NominatimSearchProps>> = ({
   const {
     t
   } = useTranslation();
+  const [viewBox, setViewBox] = useState<string>();
+
+  useEffect(() => {
+    const mapViewProjection = map?.getView().getProjection();
+    const extent: OlExtent = map?.getView()?.get('extent');
+    if (extent) {
+      const transformedExtent = transformExtent(extent, mapViewProjection, 'EPSG:4326');
+      setViewBox(transformedExtent.toString());
+    }
+  }, [map]);
 
   if (!map) {
     return <></>;
@@ -28,6 +46,7 @@ export const BasicNominatimSearch: React.FC<Partial<NominatimSearchProps>> = ({
       allowClear={true}
       nominatimBaseUrl={'https://nominatim.terrestris.de/search.php?'}
       placeholder={t('Nominatim.placeholder')}
+      viewBox={viewBox ? viewBox : ''}
       {...restProps}
     />
   );


### PR DESCRIPTION
This adds the `viewbox` param to `Nominatim` search query if the given mapView extent is set.
cf. https://nominatim.org/release-docs/develop/api/Search/#parameters

**Reason**: Avoid search results which are outside the defined mapView and can not be displayed on the map anyway.

@terrestris/devs please check.