### PR TITLE
add unit tests for print components and footer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/* eslint-disable quote-props */
 module.exports = {
   extends: [
     '@terrestris/eslint-config-typescript',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,8 +25,8 @@ module.exports = {
     }],
     'object-property-newline': 'warn',
     'object-curly-newline': ['warn', {
-      'multiline': true,
-      'minProperties': 1
+      'consistent': true,
+      'minProperties': 2
     }],
     'space-before-function-paren': ['warn', {
       'anonymous': 'always',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   globals: {
+    PROJECT_VERSION: '42.0.0',
     KEYCLOAK_HOST: 'localhost',
     KEYCLOAK_REALM: 'SHOGun',
     KEYCLOAK_CLIENT_ID: 'shogun-client'
@@ -23,7 +24,7 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/jest/fileMock.js',
     '^.+\\.(css|less)$': '<rootDir>/jest/cssTransform.js',
-    'clientConfig': '<rootDir>/resources/config/gis-client-config.js'
+    clientConfig: '<rootDir>/resources/config/gis-client-config.js'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
   reporters: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@terrestris/eslint-config-typescript-react": "^2.0.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
+        "@testing-library/user-event": "^14.4.3",
         "@types/color": "^3.0.3",
         "@types/jest": "^29.2.1",
         "@types/js-md5": "^0.4.3",
@@ -5956,6 +5957,19 @@
       "dev": true,
       "dependencies": {
         "@types/react": "^17"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -31225,6 +31239,13 @@
           }
         }
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@terrestris/eslint-config-typescript-react": "^2.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
+    "@testing-library/user-event": "^14.4.3",
     "@types/color": "^3.0.3",
     "@types/jest": "^29.2.1",
     "@types/js-md5": "^0.4.3",

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -4,33 +4,15 @@ import {
   render
 } from '@testing-library/react';
 
-import {
-  Provider
-} from 'react-redux';
-
 import App from './App';
-
-import {
-  store
-} from './store/store';
-
-const createWrapper = () => {
-  // eslint-disable-next-line react/display-name
-  return ({
-    children
-  }: any) => (
-    <Provider store={store}>
-      {children}
-    </Provider>
-  );
-};
+import { createReduxWrapper } from './utils/testUtils';
 
 describe('App', () => {
   it('can be rendered', () => {
     const {
       container
     } = render(<App />, {
-      wrapper: createWrapper()
+      wrapper: createReduxWrapper()
     });
 
     expect(container).toBeVisible();

--- a/src/components/AddLayerModal/index.spec.tsx
+++ b/src/components/AddLayerModal/index.spec.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 
 import {
-  getByRole,
   render,
   screen,
   fireEvent
 } from '@testing-library/react';
-
-import {
-  Provider
-} from 'react-redux';
 
 import {
   show,
@@ -20,18 +15,9 @@ import {
   store
 } from '../../store/store';
 
-import AddLayerModal from './index';
+import { createReduxWrapper } from '../../utils/testUtils';
 
-const createWrapper = () => {
-  // eslint-disable-next-line react/display-name
-  return ({
-    children
-  }: any) => (
-    <Provider store={store}>
-      {children}
-    </Provider>
-  );
-};
+import AddLayerModal from './index';
 
 describe('<AddLayerModal />', () => {
 
@@ -51,7 +37,7 @@ describe('<AddLayerModal />', () => {
     const {
       container
     } = render(<AddLayerModal />, {
-      wrapper: createWrapper()
+      wrapper: createReduxWrapper()
     });
 
     expect(container).toBeVisible();
@@ -59,7 +45,7 @@ describe('<AddLayerModal />', () => {
 
   it('can toggle its visibility', () => {
     render(<AddLayerModal />, {
-      wrapper: createWrapper()
+      wrapper: createReduxWrapper()
     });
 
     const modal = screen.getByRole('dialog');

--- a/src/components/ApplicationInfo/index.spec.tsx
+++ b/src/components/ApplicationInfo/index.spec.tsx
@@ -1,9 +1,26 @@
+import React from 'react';
+
+import {
+  render
+} from '@testing-library/react';
+
+import { createReduxWrapper } from '../../utils/testUtils';
+
 import ApplicationInfo from './index';
 
 describe('<ApplicationInfo />', () => {
 
   it('is defined', () => {
     expect(ApplicationInfo).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(<ApplicationInfo />, {
+      wrapper: createReduxWrapper()
+    });
+    expect(container).toBeVisible();
   });
 
 });

--- a/src/components/Footer/index.spec.tsx
+++ b/src/components/Footer/index.spec.tsx
@@ -2,10 +2,8 @@
 import React from 'react';
 
 import {
-  getByRole,
   render,
-  screen,
-  fireEvent
+  screen
 } from '@testing-library/react';
 
 import OlMap from 'ol/Map';

--- a/src/components/Footer/index.spec.tsx
+++ b/src/components/Footer/index.spec.tsx
@@ -1,9 +1,82 @@
+
+import React from 'react';
+
+import {
+  getByRole,
+  render,
+  screen,
+  fireEvent
+} from '@testing-library/react';
+
+import OlMap from 'ol/Map';
+import OlView from 'ol/View';
+
+import {
+  renderInMapContext
+} from '@terrestris/react-geo/dist/Util/rtlTestUtils';
+
 import Footer from './index';
 
 describe('<Footer />', () => {
 
+  const center = [829729, 6708850];
+  let map: OlMap;
+
+  beforeEach(() => {
+    map = new OlMap({
+      view: new OlView({
+        center,
+        zoom: 10
+      }),
+      controls: [],
+      layers: []
+    });
+  });
+
   it('is defined', () => {
     expect(Footer).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(<Footer />);
+    expect(container).toBeVisible();
+  });
+
+  it('contact is rendered', () => {
+    renderInMapContext(map, <Footer />);
+    const contact = screen.getByText('Footer.contact');
+    expect(contact).toBeVisible();
+  });
+
+  it('imprint is rendered', () => {
+    renderInMapContext(map, <Footer />);
+    const imprint = screen.getByText('Footer.imprint');
+    expect(imprint).toBeVisible();
+  });
+
+  it('privacy is rendered', () => {
+    renderInMapContext(map, <Footer />);
+    const privacy = screen.getByText('Footer.privacypolicy');
+    expect(privacy).toBeVisible();
+  });
+
+  it('mouseposition controls is rendered', () => {
+    const {
+      container
+    } = renderInMapContext(map, <Footer />);
+    const mousePosition = container.querySelector('div.ol-mouse-position');
+    expect(mousePosition).toBeVisible();
+  });
+
+  it('scalebar control is rendered', () => {
+    const {
+      container
+    } = renderInMapContext(map, <Footer />);
+
+    const scalebar = container.querySelector('div.ol-scale-line');
+    expect(scalebar).toBeVisible();
   });
 
 });

--- a/src/components/Header/index.spec.tsx
+++ b/src/components/Header/index.spec.tsx
@@ -1,9 +1,26 @@
+import React from 'react';
+
+import {
+  render
+} from '@testing-library/react';
+
+import { createReduxWrapper } from '../../utils/testUtils';
+
 import Header from './index';
 
 describe('<Header />', () => {
 
   it('is defined', () => {
     expect(Header).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(<Header />, {
+      wrapper: createReduxWrapper()
+    });
+    expect(container).toBeVisible();
   });
 
 });

--- a/src/components/PrintForm/CustomFieldInput/index.spec.tsx
+++ b/src/components/PrintForm/CustomFieldInput/index.spec.tsx
@@ -1,3 +1,16 @@
+import React from 'react';
+
+import {
+  render
+} from '@testing-library/react';
+
+import OlMap from 'ol/Map';
+import OlView from 'ol/View';
+
+import {
+  MapFishPrintV3Manager
+} from '@terrestris/mapfish-print-manager';
+
 import CustomFieldInput from './index';
 
 describe('<CustomFieldInput />', () => {

--- a/src/components/PrintForm/LayoutSelect/index.spec.tsx
+++ b/src/components/PrintForm/LayoutSelect/index.spec.tsx
@@ -1,9 +1,32 @@
+import React from 'react';
+
+import {
+  render
+} from '@testing-library/react';
+
+import {
+  MapFishPrintV3Manager
+} from '@terrestris/mapfish-print-manager';
+
 import LayoutSelect from './index';
 
 describe('<LayoutSelect />', () => {
 
+  let printManager: MapFishPrintV3Manager;
+
+  beforeEach(() => {
+    printManager = new MapFishPrintV3Manager({});
+  });
+
   it('is defined', () => {
     expect(LayoutSelect).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(<LayoutSelect printManager={printManager} />);
+    expect(container).toBeVisible();
   });
 
 });

--- a/src/components/PrintForm/OutputFormatSelect/index.spec.tsx
+++ b/src/components/PrintForm/OutputFormatSelect/index.spec.tsx
@@ -1,9 +1,61 @@
+import React from 'react';
+
+import {
+  render,
+  screen
+} from '@testing-library/react';
+
+import userEvent from '@testing-library/user-event';
+
+import {
+  MapFishPrintV3Manager
+} from '@terrestris/mapfish-print-manager';
+
+import {
+  findAntdDropdownOptionByText
+} from '@terrestris/react-geo/dist/Util/antdTestQueries';
+
 import OutputFormatSelect from './index';
 
 describe('<OutputFormatSelect />', () => {
 
+  let printManager: MapFishPrintV3Manager;
+
+  beforeEach(() => {
+    printManager = new MapFishPrintV3Manager({});
+  });
+
   it('is defined', () => {
     expect(OutputFormatSelect).not.toBeUndefined();
+  });
+
+  it('can be rendered', async () => {
+    const {
+      container
+    } = render(
+      <OutputFormatSelect
+        printManager={printManager}
+        outputFormats={['PDF', 'PNG']}
+      />
+    );
+    expect(container).toBeVisible();
+  });
+
+  it('output format options are rendered', async () => {
+    render(
+      <OutputFormatSelect
+        printManager={printManager}
+        outputFormats={['PDF', 'PNG']}
+      />
+    );
+    const combobox = screen.getByRole('combobox');
+    userEvent.click(combobox);
+
+    const optionPng = await findAntdDropdownOptionByText('PNG');
+    const optionPdf = await findAntdDropdownOptionByText('PDF');
+    // would be nicer to test for `toBeVisible`, but antd seems to be in the way
+    expect(optionPng).toBeInTheDocument();
+    expect(optionPdf).toBeInTheDocument();
   });
 
 });

--- a/src/components/PrintForm/ResolutionSelect/index.spec.tsx
+++ b/src/components/PrintForm/ResolutionSelect/index.spec.tsx
@@ -1,9 +1,35 @@
+import React from 'react';
+
+import {
+  render
+} from '@testing-library/react';
+
+import OlMap from 'ol/Map';
+import OlView from 'ol/View';
+
+import {
+  MapFishPrintV3Manager
+} from '@terrestris/mapfish-print-manager';
+
 import ResolutionSelect from './index';
 
 describe('<ResolutionSelect />', () => {
 
+  let printManager: MapFishPrintV3Manager;
+
+  beforeEach(() => {
+    printManager = new MapFishPrintV3Manager({});
+  });
+
   it('is defined', () => {
     expect(ResolutionSelect).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(<ResolutionSelect printManager={printManager} />);
+    expect(container).toBeVisible();
   });
 
 });

--- a/src/components/PrintForm/index.spec.tsx
+++ b/src/components/PrintForm/index.spec.tsx
@@ -1,9 +1,50 @@
+import React from 'react';
+
+import {
+  render
+} from '@testing-library/react';
+
+import OlMap from 'ol/Map';
+import OlView from 'ol/View';
+
+import {
+  MapFishPrintV3Manager
+} from '@terrestris/mapfish-print-manager';
+
 import PrintForm from './index';
 
 describe('<PrintForm />', () => {
 
+  const center = [829729, 6708850];
+  let map: OlMap;
+  let printManager: MapFishPrintV3Manager;
+
+  beforeEach(() => {
+    map = new OlMap({
+      view: new OlView({
+        center,
+        zoom: 10
+      })
+    });
+    printManager = new MapFishPrintV3Manager({
+      map
+    });
+  });
+
   it('is defined', () => {
     expect(PrintForm).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(
+      <PrintForm
+        map={map}
+        printManager={printManager}
+      />
+    );
+    expect(container).toBeVisible();
   });
 
 });

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -125,7 +125,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
   // inside of PrintForm component itself, but this is not possible due to the
   // dubious antd menu implementaion: https://ant.design/components/menu/#FAQ
   // According to this, all menu children will be rendered twice, what leads to
-  // dublicated instantiation of mapfish manager 🤦‍♂️
+  // duplicated instantiation of mapfish manager 🤦‍♂️
   const [printManager, setPrintManager] = useState<MapFishPrintV3Manager | null>(null);
 
   const layerFilter = useCallback((l: OlLayer<OlSource>) => {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -30,6 +30,10 @@ declare module 'clientConfig' {
   export default config;
 };
 
+// todo: remove when react-geo test util types are exported properly
+declare module '@terrestris/react-geo/dist/Util/rtlTestUtils';
+declare module '@terrestris/react-geo/dist/Util/antdTestQueries';
+
 type Scope = unknown;
 type Factory = () => any;
 // eslint-disable-next-line @typescript-eslint/naming-convention, camelcase, no-underscore-dangle

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import {
+  Provider
+} from 'react-redux';
+
+import {
+  store
+} from '../store/store';
+
+export const createReduxWrapper = () => {
+  // eslint-disable-next-line react/display-name
+  return ({
+    children
+  }: any) => (
+    <Provider store={store}>
+      {children}
+    </Provider>
+  );
+};

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -85,7 +85,7 @@ module.exports = {
       name: 'SHOGunGISClient',
       shared: {
         ...require('./package.json').dependencies,
-        'react': {
+        react: {
           singleton: true
         },
         'react-dom': {


### PR DESCRIPTION
- adds some unit tests (Footer, PrintForm and related components)
- adds user-event and updates some dependencies
- adds util `createReduxWrapper`
- fixes linting problems
- changes eslint rule `object-curly-newline` to `consistent` with `minProperties: 2`. See https://eslint.org/docs/latest/rules/object-curly-newline

@terrestris/devs Please review