### PR TITLE
Disable the `BackgroundLayerChooser`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,6 @@ import React, {
   useEffect
 } from 'react';
 
-import {
-  BackgroundLayerChooser,
-  useMap
-} from '@terrestris/react-geo';
-
 import AddLayerModal from './components/AddLayerModal/index';
 import BasicMapComponent from './components/BasicMapComponent';
 import Footer from './components/Footer';
@@ -29,19 +24,12 @@ export const App: React.FC<AppProps> = ({
     }
   }, []);
 
-  const map = useMap();
-  let layers: any[] = [];
-  if (map) {
-    layers = map.getLayers().getArray();
-  }
-
   return (
     <div
       className="App"
       {...restProps}
     >
       <Header />
-      <BackgroundLayerChooser layers={layers as any} />
       <BasicMapComponent />
       <ToolMenu />
       <Footer />


### PR DESCRIPTION
This suggest to disable the `BackgroundLayerChooser` as it seems to be broken right now (see #485) and:

- There is no way to define the required property `isBackgroundLayer` in shogun nor the shogun-admin.
- There seems to be a conflict by setting it to a layer that is also visible in the tree (the layer _must_ be visible in the tree to be catched up by the chooser).
- There seems to be a request loop once a layer is activated in it.

Please review @terrestris/devs.