### PR TITLE
fix: avoid scrollbar on collapsed menu

### DIFF
--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -13,12 +13,12 @@
 
     width: 40px;
 
-    .ant-collapse-item {
+    >.ant-collapse .ant-collapse-item {
+      overflow: hidden;
 
       .ant-collapse-header {
-        padding-right: 0;
-        padding-left: 0;
         justify-content: center;
+        padding: 6px 0px;
 
         .ant-collapse-header-text {
           display: flex;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3939355/206425314-99690cc2-7596-406f-965e-81e7863a5721.png)

After:
![image](https://user-images.githubusercontent.com/3939355/206425391-392f9b97-c4fa-4afa-91bf-2d7f2e0f6250.png)

Please review @terrestris/devs 
