### PR TITLE
Several fixes for external layers in permalinks

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -293,15 +293,6 @@ const setupSHOGunMap = async (application: Application) => {
 
   view.setConstrainResolution(true);
 
-  const externalWmsLayerGroup = new OlLayerGroup({
-    layers: []
-  });
-  externalWmsLayerGroup.set('name', i18n.t('AddLayerModal.externalWmsFolder'));
-
-  externalWmsLayerGroup.set('hideInLayerTree', externalWmsLayerGroup.getLayers().getLength() < 1);
-
-  layers?.getLayers().extend([externalWmsLayerGroup]);
-
   return new OlMap({
     view,
     layers,
@@ -333,14 +324,6 @@ const setupDefaultMap = () => {
     hoverable: true
   });
 
-  const externalLayerGroup = new OlLayerGroup({
-    layers: []
-  });
-  externalLayerGroup.set('name', i18n.t('AddLayerModal.externalWmsFolder'));
-  externalLayerGroup.set('isGroupForImportedLayers', true);
-
-  externalLayerGroup.set('hideInLayerTree', externalLayerGroup.getLayers().getLength() < 1);
-
   const eoLayerGroup = new OlLayerGroup({
     layers: [temperatureLayer]
   });
@@ -358,7 +341,7 @@ const setupDefaultMap = () => {
       center: center,
       zoom: 0
     }),
-    layers: [backgroundLayerGroup, eoLayerGroup, externalLayerGroup],
+    layers: [backgroundLayerGroup, eoLayerGroup],
     controls: OlControlDefaults({
       zoom: false
     })

--- a/src/components/AddLayerModal/index.tsx
+++ b/src/components/AddLayerModal/index.tsx
@@ -105,7 +105,9 @@ export const AddLayerModal: React.FC<AddLayerModalProps> = ({
     let targetGroup = MapUtil.getLayerByName(map, targetFolderName) as OlLayerGroup;
 
     if (!targetGroup) {
-      targetGroup = new OlLayerGroup();
+      targetGroup = new OlLayerGroup({
+        layers: []
+      });
       targetGroup.set('name', targetFolderName);
       const existingGroups = map.getLayerGroup().getLayers();
       existingGroups.insertAt(existingGroups?.getLength() || 0, targetGroup);
@@ -139,8 +141,6 @@ export const AddLayerModal: React.FC<AddLayerModalProps> = ({
         targetGroup.getLayers().push(layerToAdd);
       }
     });
-
-    targetGroup.set('hideInLayerTree', targetGroup.getLayers().getLength() < 1);
 
     closeModal();
   };

--- a/src/components/AddLayerModal/index.tsx
+++ b/src/components/AddLayerModal/index.tsx
@@ -153,18 +153,18 @@ export const AddLayerModal: React.FC<AddLayerModalProps> = ({
       onCancel={closeModal}
       footer={[
         <Button
-          key="add-selected"
-          disabled={selectedRowKeys?.length < 1}
-          onClick={onAddSelected}
-        >
-          {t('AddLayerModal.addSelectedLayers')}
-        </Button>,
-        <Button
           key="add-all"
           disabled={layers?.length < 1}
           onClick={onAddAll}
         >
           {t('AddLayerModal.addAllLayers')}
+        </Button>,
+        <Button
+          key="add-selected"
+          disabled={selectedRowKeys?.length < 1}
+          onClick={onAddSelected}
+        >
+          {t('AddLayerModal.addSelectedLayers')}
         </Button>
       ]}
       {...restProps}

--- a/src/components/AddLayerModal/index.tsx
+++ b/src/components/AddLayerModal/index.tsx
@@ -103,6 +103,7 @@ export const AddLayerModal: React.FC<AddLayerModalProps> = ({
 
     const targetFolderName = t('AddLayerModal.externalWmsFolder');
     let targetGroup = MapUtil.getLayerByName(map, targetFolderName) as OlLayerGroup;
+
     if (!targetGroup) {
       targetGroup = new OlLayerGroup();
       targetGroup.set('name', targetFolderName);
@@ -113,7 +114,6 @@ export const AddLayerModal: React.FC<AddLayerModalProps> = ({
     layersToAdd.forEach(layerToAdd => {
       if (!targetGroup.getLayers().getArray().includes(layerToAdd)) {
         layerToAdd.set('isExternalLayer', true);
-        layerToAdd.set('isImported', true);
 
         let layerUrl: string | undefined;
         if (layerToAdd instanceof ImageLayer) {

--- a/src/components/Permalink/index.tsx
+++ b/src/components/Permalink/index.tsx
@@ -93,7 +93,7 @@ export const Permalink: React.FC<PermalinkProps> = () => {
 
     const updateLayerConfig = () => {
       const externalLayers = map.getAllLayers().filter(l => l.get('isExternalLayer'));
-      externalLayers.forEach((externalLayer) => {
+      externalLayers.forEach(externalLayer => {
         const layerConfig = externalLayer.get('layerConfig') as Layer;
         if (layerConfig) {
           if (layerConfig.clientConfig) {
@@ -123,14 +123,6 @@ export const Permalink: React.FC<PermalinkProps> = () => {
         }
       }
     };
-
-    const layerGroups = map.getLayers().getArray().filter((l) => l.get('isGroupForImportedLayers'));
-    layerGroups.forEach((layerGroup) => {
-      // @ts-ignore
-      eventKeys.push(layerGroup.getLayers().on('add', updateLayersInPermalink));
-      // @ts-ignore
-      eventKeys.push(layerGroup.getLayers().on('remove', updateLayersInPermalink));
-    });
 
     const listenerKeyCenter = map.getView().on('change:center', updatePermalink);
     const listenerKeyResolution = map.getView().on('change:resolution', updatePermalink);

--- a/src/components/ToolMenu/Draw/StylingDrawer/StylingComponent/index.tsx
+++ b/src/components/ToolMenu/Draw/StylingDrawer/StylingComponent/index.tsx
@@ -104,7 +104,6 @@ export const StylingComponent: React.FC<StylingComponentProps> = ({
     }]
   };
 
-  // @ts-ignore - TS-Error due to old Geostyler-Style version.
   const [style, setStyle] = useState<GsStyle>(defaultStyle);
 
   const map = useMap();
@@ -130,7 +129,6 @@ export const StylingComponent: React.FC<StylingComponentProps> = ({
           rules: [rule]
         };
 
-        // @ts-ignore - TS-Error due to old Geostyler-Style version.
         const olStyle = await olParser.writeStyle(newStyle);
 
         if (!olStyle.output) {

--- a/src/components/ToolMenu/Draw/StylingDrawer/StylingComponent/index.tsx
+++ b/src/components/ToolMenu/Draw/StylingDrawer/StylingComponent/index.tsx
@@ -40,14 +40,13 @@ export const StylingComponent: React.FC<StylingComponentProps> = ({
   ...passThroughProps
 }): JSX.Element => {
 
-  const defaultStyle = {
+  const defaultStyle: GsStyle = {
     name: 'Default Style',
     rules: [{
       name: 'Area',
       symbolizers: [{
         kind: 'Fill',
         color: '#00b72b',
-        strokeColor: '#00b72b',
         outlineOpacity: 0.8,
         opacity: 0.5,
         fillOpacity: 0.8,
@@ -69,7 +68,7 @@ export const StylingComponent: React.FC<StylingComponentProps> = ({
         wellKnownName: 'circle',
         color: '#00b72b',
         strokeColor: '#00b72b',
-        outlineOpacity: 0.8,
+        strokeOpacity: 0.8,
         opacity: 0.5,
         radius: 7
       }],

--- a/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
+++ b/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
@@ -198,7 +198,7 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
     });
   }
 
-  if (layer.get('isImported')) {
+  if (layer.get('isExternalLayer')) {
     dropdownMenuItems.push({
       label: t('LayerTreeContextMenu.removeLayer'),
       key: 'removeExternal'

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -13,6 +13,7 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceImageWMS from 'ol/source/ImageWMS';
 import OlSource from 'ol/source/Source';
 import OlSourceTileWMS from 'ol/source/TileWMS';
+import OlSourceVector from 'ol/source/Vector';
 
 import {
   useTranslation
@@ -51,13 +52,11 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
 
   const treeFilterFunction = (layer: OlLayer<OlSource> | OlLayerGroup) => {
 
-    // @ts-ignore
-    if (layer.getLayers) {
+    if ((layer as OlLayerGroup).getLayers) {
       return !layer.get('hideInLayerTree');
     }
 
-    // @ts-ignore
-    if (layer.getSource && layer.getSource().forEachFeature) {
+    if ((layer as OlLayer).getSource && ((layer as OlLayer).getSource() as OlSourceVector)?.forEachFeature) {
       return false;
     }
     return true;

--- a/src/index.less
+++ b/src/index.less
@@ -26,8 +26,8 @@ body,
   overflow: hidden;
 }
 
-.ant-notification-notice {
-  margin-top: var(--headerHeight);
+.ant-notification-topRight {
+  top: calc(var(--headerHeight) + 25px) !important;
 }
 
 .error-boundary {

--- a/src/index.less
+++ b/src/index.less
@@ -26,6 +26,7 @@ body,
   overflow: hidden;
 }
 
+// adds margin to make login button clickable when notifications are shown
 .ant-notification-topRight {
   top: calc(var(--headerHeight) + 25px) !important;
 }


### PR DESCRIPTION
This fixes several issues while using external layers in the permalink:

- Fix removal of external links
  - the external layer folder will be removed if no external layer is available anymore
  - layers can be removed from whatever folder they have been dragged to
- Flip the add all and add selected buttons in the add external layers modal
- Set the layer visibility as given in the permalink

Please review @terrestris/devs.