### PR TITLE
fix(issue): disable measure tools when panel collapses, highlight active tool

### DIFF
--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -84,4 +84,9 @@
     border: none;
     border-radius: 0;
   }
+
+  .react-geo-togglebutton.btn-pressed {
+    font-size: 1.2em;
+    text-shadow: 0.5px 0.5px 0.5px grey;
+  }
 }

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -303,6 +303,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
       <Collapse
         expandIconPosition='end'
         activeKey={activeKeys}
+        destroyInactivePanel={true}
         onChange={(keys: string[] | string) => {
           setCollapsed(false);
           dispatch(setActiveKeys(_toArray(keys)));


### PR DESCRIPTION
If one closes the measure tools panel, its interactions will be disabled.

Besides, active measure and draw tools are highlighted a bit with a bigger font size.

![image](https://user-images.githubusercontent.com/1381363/210382030-5ffc2c52-200b-4215-abf7-68f444fbd08c.png)
