### PR TITLE
fix(layout): fix menu icons and text positioning

### DIFF
--- a/src/components/ToolMenu/Draw/index.less
+++ b/src/components/ToolMenu/Draw/index.less
@@ -3,7 +3,6 @@
     border-radius: 0;
     border: none;
     text-align: left;
-    padding-left: 2rem;
 
     &.btn-pressed {
       background-color: white;

--- a/src/components/ToolMenu/Measure/index.less
+++ b/src/components/ToolMenu/Measure/index.less
@@ -3,7 +3,6 @@
     border-radius: 0;
     border: none;
     text-align: left;
-    padding-left: 2rem;
 
     &.btn-pressed {
       background-color: white;

--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -6,8 +6,40 @@
   max-height: calc(100% - var(--headerHeight) - var(--footerHeight));
   overflow: hidden;
   max-width: 600px;
+  min-width: 280px;
   box-shadow: var(--componentShadow);
   overflow-x: hidden;
+
+  .ant-collapse-header-text {
+    display: flex;
+      width: 100%;
+
+      svg {
+        padding-top: 4px;
+        flex: 2;
+      }
+
+      span {
+        flex: 10;
+      }
+  }
+
+  .react-geo-togglegroup.vertical-toggle-group {
+
+    button {
+      display: flex;
+      width: 100%;
+
+      svg {
+        padding-top: 4px;
+        flex: 2;
+      }
+
+      span {
+        flex: 10;
+      }
+    }
+  }
 
   &.collapsed {
 


### PR DESCRIPTION
This makes the icons and texts appear uniform.

Before:
![image](https://user-images.githubusercontent.com/1381363/210390230-fd6c8206-2003-4f37-838d-759191616bae.png)


After:
![image](https://user-images.githubusercontent.com/1381363/210389878-42e43dc3-1e5c-43b2-9218-a3405a26540f.png)

@mholthausen @hblitza please review