### PR TITLE
Fix a conflict between measurement tools and the export (print) panel

### DIFF
--- a/src/components/ToolMenu/Measure/index.tsx
+++ b/src/components/ToolMenu/Measure/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   faDrawPolygon,
@@ -19,6 +19,11 @@ import {
   useMap
 } from '@terrestris/react-geo/dist/Hook/useMap';
 
+import useAppDispatch from '../../../hooks/useAppDispatch';
+import useAppSelector from '../../../hooks/useAppSelector';
+
+import { setActiveKeys } from '../../../store/toolMenu';
+
 import './index.less';
 
 interface DefaultMeasureProps {
@@ -37,13 +42,19 @@ export const Measure: React.FC<MeasureProps> = ({
   } = useTranslation();
 
   const map = useMap();
+  const activeKeys = useAppSelector(state => state.toolMenu.activeKeys);
+  const dispatch = useAppDispatch();
+  const [activeMeasureToolName, setActiveMeasureToolName] =
+    useState<string>('');
 
   if (!map) {
     return <></>;
   }
 
   return (
-    <ToggleGroup>
+    <ToggleGroup
+      selectedName={activeKeys.includes('print') ? '' : activeMeasureToolName}
+    >
       {showMeasureDistance ? (
         <MeasureButton
           geodesic
@@ -52,6 +63,16 @@ export const Measure: React.FC<MeasureProps> = ({
           measureType="line"
           type="link"
           continueLineMsg={t('Measure.clicktodrawline')}
+          onToggle={(pressed: boolean) => {
+            if (pressed) {
+              if (activeKeys.includes('print')) {
+                dispatch(
+                  setActiveKeys(activeKeys.filter(keys => keys !== 'print'))
+                );
+                setActiveMeasureToolName('line');
+              }
+            }
+          }}
         >
           <FontAwesomeIcon icon={faPenRuler} />
           <span className="measure-text">{t('Measure.line')}</span>
@@ -66,6 +87,16 @@ export const Measure: React.FC<MeasureProps> = ({
           measureType="polygon"
           type="link"
           continuePolygonMsg={t('Measure.clicktodrawarea')}
+          onToggle={(pressed: boolean) => {
+            if (pressed) {
+              if (activeKeys.includes('print')) {
+                dispatch(
+                  setActiveKeys(activeKeys.filter(keys => keys !== 'print'))
+                );
+                setActiveMeasureToolName('poly');
+              }
+            }
+          }}
         >
           <FontAwesomeIcon icon={faDrawPolygon} />
           <span className="measure-text">{t('Measure.area')}</span>

--- a/src/components/ToolMenu/Measure/index.tsx
+++ b/src/components/ToolMenu/Measure/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import {
   faDrawPolygon,
@@ -19,11 +19,6 @@ import {
   useMap
 } from '@terrestris/react-geo/dist/Hook/useMap';
 
-import useAppDispatch from '../../../hooks/useAppDispatch';
-import useAppSelector from '../../../hooks/useAppSelector';
-
-import { setActiveKeys } from '../../../store/toolMenu';
-
 import './index.less';
 
 interface DefaultMeasureProps {
@@ -42,19 +37,13 @@ export const Measure: React.FC<MeasureProps> = ({
   } = useTranslation();
 
   const map = useMap();
-  const activeKeys = useAppSelector(state => state.toolMenu.activeKeys);
-  const dispatch = useAppDispatch();
-  const [activeMeasureToolName, setActiveMeasureToolName] =
-    useState<string>('');
 
   if (!map) {
     return <></>;
   }
 
   return (
-    <ToggleGroup
-      selectedName={activeKeys.includes('print') ? '' : activeMeasureToolName}
-    >
+    <ToggleGroup>
       {showMeasureDistance ? (
         <MeasureButton
           geodesic
@@ -63,16 +52,6 @@ export const Measure: React.FC<MeasureProps> = ({
           measureType="line"
           type="link"
           continueLineMsg={t('Measure.clicktodrawline')}
-          onToggle={(pressed: boolean) => {
-            if (pressed) {
-              if (activeKeys.includes('print')) {
-                dispatch(
-                  setActiveKeys(activeKeys.filter(keys => keys !== 'print'))
-                );
-                setActiveMeasureToolName('line');
-              }
-            }
-          }}
         >
           <FontAwesomeIcon icon={faPenRuler} />
           <span className="measure-text">{t('Measure.line')}</span>
@@ -87,16 +66,6 @@ export const Measure: React.FC<MeasureProps> = ({
           measureType="polygon"
           type="link"
           continuePolygonMsg={t('Measure.clicktodrawarea')}
-          onToggle={(pressed: boolean) => {
-            if (pressed) {
-              if (activeKeys.includes('print')) {
-                dispatch(
-                  setActiveKeys(activeKeys.filter(keys => keys !== 'print'))
-                );
-                setActiveMeasureToolName('poly');
-              }
-            }
-          }}
         >
           <FontAwesomeIcon icon={faDrawPolygon} />
           <span className="measure-text">{t('Measure.area')}</span>

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -35,8 +35,6 @@ import _toArray from 'lodash/toArray';
 
 const { Panel } = Collapse;
 
-import OlInteractionDraw from 'ol/interaction/Draw';
-import Interaction from 'ol/interaction/Interaction';
 import {
   useTranslation
 } from 'react-i18next';
@@ -133,6 +131,21 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
       }
     }
   }, [menuTools, availableTools]);
+
+  useEffect(() => {
+    if (
+      activeKeys.includes('print') &&
+      activeKeys.includes('measure_tools')
+    ) {
+      if (activeKeys.indexOf('print') < activeKeys.indexOf('measure_tools')) {
+        dispatch(setActiveKeys(activeKeys.filter(keys => keys !== 'print')));
+      } else {
+        dispatch(
+          setActiveKeys(activeKeys.filter(keys => keys !== 'measure_tools'))
+        );
+      }
+    }
+  }, [activeKeys, dispatch]);
 
   const getToolPanels = (): JSX.Element[] => {
 
@@ -309,17 +322,6 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
         onChange={(keys: string[] | string) => {
           setCollapsed(false);
           dispatch(setActiveKeys(_toArray(keys)));
-
-          if (_toArray(keys).includes('print') && map) {
-            const interactions = map
-              .getInteractions()
-              .getArray()
-              .filter(item => item instanceof OlInteractionDraw);
-
-            interactions.forEach((interaction: Interaction) => {
-              interaction.setActive(false);
-            });
-          }
         }}
         {...restProps}
       >

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -35,6 +35,8 @@ import _toArray from 'lodash/toArray';
 
 const { Panel } = Collapse;
 
+import OlInteractionDraw from 'ol/interaction/Draw';
+import Interaction from 'ol/interaction/Interaction';
 import {
   useTranslation
 } from 'react-i18next';
@@ -307,6 +309,17 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
         onChange={(keys: string[] | string) => {
           setCollapsed(false);
           dispatch(setActiveKeys(_toArray(keys)));
+
+          if (_toArray(keys).includes('print') && map) {
+            const interactions = map
+              .getInteractions()
+              .getArray()
+              .filter(item => item instanceof OlInteractionDraw);
+
+            interactions.forEach((interaction: Interaction) => {
+              interaction.setActive(false);
+            });
+          }
         }}
         {...restProps}
       >


### PR DESCRIPTION
This PR fixes a conflict between the measurement tools and the export (print) panel where the measuring tools remain active when opening the print tool and thus led to a conflict when selecting the print frame and vice versa

@terrestris/devs please review