### PR TITLE
feat: add layer loading indicator to tree

### DIFF
--- a/src/components/ToolMenu/LayerTree/index.less
+++ b/src/components/ToolMenu/LayerTree/index.less
@@ -19,11 +19,16 @@
       .tree-node-header {
         display: flex;
 
-        :first-child {
+        .loading-indicator {
           flex: 1;
         }
 
+        span {
+          flex: 10;
+        }
+
         .ant-dropdown-trigger {
+          flex: 1;
           align-self: center;
           // creates clickable area around svg
           padding-left: 5px;
@@ -35,7 +40,7 @@
 
       .ant-slider {
         flex: 1;
-        padding-left: 5px;
+        margin-left: 8px;
       }
 
       .layer-transparency {
@@ -44,5 +49,4 @@
       }
     }
   }
-
 }

--- a/src/components/ToolMenu/LayerTree/index.less
+++ b/src/components/ToolMenu/LayerTree/index.less
@@ -21,10 +21,17 @@
 
         .loading-indicator {
           flex: 1;
+          opacity: 0.75;
+          transition: opacity 2s;
+        }
+
+        .loading-indicator.ant-progress-status-success {
+          opacity: 0;
+          transition: opacity 2s;
         }
 
         span {
-          flex: 10;
+          flex: 16;
         }
 
         .ant-dropdown-trigger {
@@ -40,7 +47,7 @@
 
       .ant-slider {
         flex: 1;
-        margin-left: 8px;
+        margin-left: 27px;
       }
 
       .layer-transparency {

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -153,10 +153,6 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
               format={() => ''}
               width={16}
               strokeWidth={20}
-              strokeColor={{
-                '0%': '#108ee9',
-                '100%': '#87d068'
-              }}
             />
             <span>{layer.get('name')}</span>
             {


### PR DESCRIPTION
This adds a loading indicator to layers to give a better user experience.

![Peek 2023-01-04 15-52](https://user-images.githubusercontent.com/1381363/210582120-3261e89f-33c2-477e-8e1b-d154b38c8ed9.gif)

Some layer sources, like OSM, may have a flickering effect as their loading state cannot always be determined completely.

@terrestris/devs please review