### PR TITLE
feat: updating mapfish-print-manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.0",
         "@terrestris/base-util": "^1.0.1",
-        "@terrestris/mapfish-print-manager": "^8.0.0",
+        "@terrestris/mapfish-print-manager": "^8.0.1",
         "@terrestris/ol-util": "^10.1.3",
         "@terrestris/react-geo": "^22.1.0",
         "@terrestris/react-util": "^2.1.1",
@@ -5791,9 +5791,9 @@
       }
     },
     "node_modules/@terrestris/mapfish-print-manager": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/mapfish-print-manager/-/mapfish-print-manager-8.0.0.tgz",
-      "integrity": "sha512-KJRJKFx5A+SkCRb0NasTT6hMMX6SbD/M/gq43B38UBxLgRsLFBGvlxI9BdW8wxhu0Md/hPtlYyZNma7VjP6uuw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@terrestris/mapfish-print-manager/-/mapfish-print-manager-8.0.1.tgz",
+      "integrity": "sha512-PWQIayyvY6hf6Em4DazJiwUhYKdjJgiUdv60h3VQNTYZObZbOU2OXcxJ3kaNsYxeo4hjOG2lSCMevahzIwFzpQ==",
       "dependencies": {
         "@terrestris/eslint-config-typescript": "^3.1.0",
         "js-logger": "^1.6.1",
@@ -31427,9 +31427,9 @@
       }
     },
     "@terrestris/mapfish-print-manager": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/mapfish-print-manager/-/mapfish-print-manager-8.0.0.tgz",
-      "integrity": "sha512-KJRJKFx5A+SkCRb0NasTT6hMMX6SbD/M/gq43B38UBxLgRsLFBGvlxI9BdW8wxhu0Md/hPtlYyZNma7VjP6uuw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@terrestris/mapfish-print-manager/-/mapfish-print-manager-8.0.1.tgz",
+      "integrity": "sha512-PWQIayyvY6hf6Em4DazJiwUhYKdjJgiUdv60h3VQNTYZObZbOU2OXcxJ3kaNsYxeo4hjOG2lSCMevahzIwFzpQ==",
       "requires": {
         "@terrestris/eslint-config-typescript": "^3.1.0",
         "js-logger": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.0",
     "@terrestris/base-util": "^1.0.1",
-    "@terrestris/mapfish-print-manager": "^8.0.0",
+    "@terrestris/mapfish-print-manager": "^8.0.1",
     "@terrestris/ol-util": "^10.1.3",
     "@terrestris/react-geo": "^22.1.0",
     "@terrestris/react-util": "^2.1.1",


### PR DESCRIPTION
fyi, fixes issue when printing on devices with device-pixel-ratio != 1 (e.g. iPad)