### PR TITLE
Pin semantic version to compatible one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        with:
+          semantic_version: 19
 
       - name: Login to Nexus ⌨️
         uses: docker/login-action@v1


### PR DESCRIPTION
This fixes the failing `release` pipeline, see [here](https://github.com/cycjimmy/semantic-release-action/issues/143) for details.

Please review @terrestris/devs.