### PR TITLE
Consider app projection while parsing layers

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -312,7 +312,7 @@ const setupSHOGunMap = async (application: Application) => {
 
   view.setConstrainResolution(true);
 
-  const layers = await parser.parseLayerTree(application);
+  const layers = await parser.parseLayerTree(application, projection);
 
   return new OlMap({
     view,

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -67,7 +67,7 @@ export const Footer: React.FC<FooterProps> = ({
     map.addControl(
       new OlControlMousePosition({
         coordinateFormat: createStringXY(2),
-        projection: 'EPSG:25832',
+        projection: map.getView().getProjection(),
         target: 'mouse-position'
       })
     );


### PR DESCRIPTION
* Pass projection string to layer tree parser, otherwise the [default](https://github.com/terrestris/shogun-util/blob/main/src/parser/SHOGunApplicationUtil.ts#L260) `EPSG:3857` CRS will always be assumed for all layers, what is obviously wrong for applications based on any projection beside Pseudo-Mercator
* Show coordinates of mouse position in configured map CRS (previously hardcoded to EPSG:25832)

Please review @terrestris/devs 