### PR TITLE
Bump mapfish-print-manager from 8.0.1 to 8.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.0",
         "@terrestris/base-util": "^1.0.1",
-        "@terrestris/mapfish-print-manager": "^8.0.1",
+        "@terrestris/mapfish-print-manager": "^8.0.2",
         "@terrestris/ol-util": "^10.1.3",
         "@terrestris/react-geo": "^22.1.0",
         "@terrestris/react-util": "^2.1.1",
@@ -5794,9 +5794,9 @@
       }
     },
     "node_modules/@terrestris/mapfish-print-manager": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/mapfish-print-manager/-/mapfish-print-manager-8.0.1.tgz",
-      "integrity": "sha512-PWQIayyvY6hf6Em4DazJiwUhYKdjJgiUdv60h3VQNTYZObZbOU2OXcxJ3kaNsYxeo4hjOG2lSCMevahzIwFzpQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@terrestris/mapfish-print-manager/-/mapfish-print-manager-8.0.2.tgz",
+      "integrity": "sha512-75ucrwpX2XHPuFa8Vyje/zpRDJ5Kvcj/8ObkGLw4QN1EyZL/JnkGdLm/nAQfNpNZxQY167BzT0BENNuqH38Npw==",
       "dependencies": {
         "@terrestris/eslint-config-typescript": "^3.1.0",
         "js-logger": "^1.6.1",
@@ -32149,9 +32149,9 @@
       }
     },
     "@terrestris/mapfish-print-manager": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/mapfish-print-manager/-/mapfish-print-manager-8.0.1.tgz",
-      "integrity": "sha512-PWQIayyvY6hf6Em4DazJiwUhYKdjJgiUdv60h3VQNTYZObZbOU2OXcxJ3kaNsYxeo4hjOG2lSCMevahzIwFzpQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@terrestris/mapfish-print-manager/-/mapfish-print-manager-8.0.2.tgz",
+      "integrity": "sha512-75ucrwpX2XHPuFa8Vyje/zpRDJ5Kvcj/8ObkGLw4QN1EyZL/JnkGdLm/nAQfNpNZxQY167BzT0BENNuqH38Npw==",
       "requires": {
         "@terrestris/eslint-config-typescript": "^3.1.0",
         "js-logger": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.0",
     "@terrestris/base-util": "^1.0.1",
-    "@terrestris/mapfish-print-manager": "^8.0.1",
+    "@terrestris/mapfish-print-manager": "^8.0.2",
     "@terrestris/ol-util": "^10.1.3",
     "@terrestris/react-geo": "^22.1.0",
     "@terrestris/react-util": "^2.1.1",


### PR DESCRIPTION
This PR updates the mapfish-print-manager to version 8.0.2

@terrestris/devs please review