### PR TITLE
Use legal links config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@terrestris/ol-util": "^10.1.3",
         "@terrestris/react-geo": "^22.1.0",
         "@terrestris/react-util": "^2.1.1",
-        "@terrestris/shogun-util": "^5.0.0",
+        "@terrestris/shogun-util": "^5.1.0",
         "antd": "^4.24.4",
         "color": "^4.2.3",
         "geostyler": "^11.1.0",
@@ -5919,16 +5919,16 @@
       }
     },
     "node_modules/@terrestris/shogun-util": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-5.0.0.tgz",
-      "integrity": "sha512-125RF7Ejkh5oOGm4YYwL0Gb0fHGgcaRyk4GFniOLIatOH75tsCh4wWbBsc6vlfEp1SyuWnQge0XTgMqVp2vTOA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-5.1.0.tgz",
+      "integrity": "sha512-I69sCyeUR5OAtU2/6RassHBgUbqb0IDTb/zHrTYSbPjMR7EnkaafwUwUEMr/J0R5quFOOeqQ8SHcaAT9/9P8Eg==",
       "dependencies": {
         "@terrestris/base-util": "^1.0.1",
         "@terrestris/ol-util": "^10.1.3",
         "geojson": "^0.5.0",
-        "keycloak-js": "^20.0.2",
+        "keycloak-js": "^20.0.3",
         "lodash": "^4.17.21",
-        "ol": "^7.1.0"
+        "ol": "^7.2.2"
       },
       "engines": {
         "node": ">=10.13",
@@ -32245,16 +32245,16 @@
       }
     },
     "@terrestris/shogun-util": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-5.0.0.tgz",
-      "integrity": "sha512-125RF7Ejkh5oOGm4YYwL0Gb0fHGgcaRyk4GFniOLIatOH75tsCh4wWbBsc6vlfEp1SyuWnQge0XTgMqVp2vTOA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-5.1.0.tgz",
+      "integrity": "sha512-I69sCyeUR5OAtU2/6RassHBgUbqb0IDTb/zHrTYSbPjMR7EnkaafwUwUEMr/J0R5quFOOeqQ8SHcaAT9/9P8Eg==",
       "requires": {
         "@terrestris/base-util": "^1.0.1",
         "@terrestris/ol-util": "^10.1.3",
         "geojson": "^0.5.0",
-        "keycloak-js": "^20.0.2",
+        "keycloak-js": "^20.0.3",
         "lodash": "^4.17.21",
-        "ol": "^7.1.0"
+        "ol": "^7.2.2"
       }
     },
     "@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@terrestris/ol-util": "^10.1.3",
     "@terrestris/react-geo": "^22.1.0",
     "@terrestris/react-util": "^2.1.1",
-    "@terrestris/shogun-util": "^5.0.0",
+    "@terrestris/shogun-util": "^5.1.0",
     "antd": "^4.24.4",
     "color": "^4.2.3",
     "geostyler": "^11.1.0",

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -91,6 +91,7 @@ import {
 } from './store/user';
 
 import './index.less';
+import { setLegal } from './store/legal';
 
 // TODO: extend antd properties too
 export interface ThemeProperties extends React.CSSProperties {
@@ -193,6 +194,10 @@ const setApplicationToStore = async (application?: Application) => {
 
   if (application.clientConfig?.description) {
     store.dispatch(setDescription(application.clientConfig?.description));
+  }
+
+  if (application.clientConfig?.legal) {
+    store.dispatch(setLegal(application.clientConfig.legal));
   }
 
   if (application?.clientConfig?.theme?.logoPath) {

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -74,6 +74,9 @@ import {
   setDescription
 } from './store/description';
 import {
+  setLegal
+} from './store/legal';
+import {
   setLogoPath
 } from './store/logoPath';
 import {
@@ -91,7 +94,6 @@ import {
 } from './store/user';
 
 import './index.less';
-import { setLegal } from './store/legal';
 
 // TODO: extend antd properties too
 export interface ThemeProperties extends React.CSSProperties {

--- a/src/components/Footer/index.spec.tsx
+++ b/src/components/Footer/index.spec.tsx
@@ -1,22 +1,21 @@
-
 import React from 'react';
 
 import {
-  render,
-  screen
+  render, screen
 } from '@testing-library/react';
 
 import OlMap from 'ol/Map';
 import OlView from 'ol/View';
 
-import {
-  renderInMapContext
-} from '@terrestris/react-geo/dist/Util/rtlTestUtils';
+import { Provider } from 'react-redux';
+
+import { renderInMapContext } from '@terrestris/react-geo/dist/Util/rtlTestUtils';
+
+import { store } from '../../store/store';
 
 import Footer from './index';
 
 describe('<Footer />', () => {
-
   const center = [829729, 6708850];
   let map: OlMap;
 
@@ -36,45 +35,67 @@ describe('<Footer />', () => {
   });
 
   it('can be rendered', () => {
-    const {
-      container
-    } = render(<Footer />);
+    const { container } = render(
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    );
     expect(container).toBeVisible();
   });
 
   it('contact is rendered', () => {
-    renderInMapContext(map, <Footer />);
+    renderInMapContext(
+      map,
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    );
     const contact = screen.getByText('Footer.contact');
     expect(contact).toBeVisible();
   });
 
   it('imprint is rendered', () => {
-    renderInMapContext(map, <Footer />);
+    renderInMapContext(
+      map,
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    );
     const imprint = screen.getByText('Footer.imprint');
     expect(imprint).toBeVisible();
   });
 
   it('privacy is rendered', () => {
-    renderInMapContext(map, <Footer />);
+    renderInMapContext(
+      map,
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    );
     const privacy = screen.getByText('Footer.privacypolicy');
     expect(privacy).toBeVisible();
   });
 
   it('mouseposition controls is rendered', () => {
-    const {
-      container
-    } = renderInMapContext(map, <Footer />);
+    const { container } = renderInMapContext(
+      map,
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    );
     const mousePosition = container.querySelector('div.ol-mouse-position');
     expect(mousePosition).toBeVisible();
   });
 
   it('scalebar control is rendered', () => {
-    const {
-      container
-    } = renderInMapContext(map, <Footer />);
+    const { container } = renderInMapContext(
+      map,
+      <Provider store={store}>
+        <Footer />
+      </Provider>
+    );
 
     const scalebar = container.querySelector('div.ol-scale-line');
     expect(scalebar).toBeVisible();
   });
-
 });

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,21 +1,14 @@
-import React, {
-  useEffect
-} from 'react';
+import React, { useEffect } from 'react';
 
 import {
-  Button,
-  Divider
+  Button, Divider
 } from 'antd';
 
 import OlControlMousePosition from 'ol/control/MousePosition';
 import OlControlScaleLine from 'ol/control/ScaleLine';
-import {
-  createStringXY
-} from 'ol/coordinate';
+import { createStringXY } from 'ol/coordinate';
 
-import {
-  useTranslation
-} from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import ScaleCombo from '@terrestris/react-geo/dist/Field/ScaleCombo/ScaleCombo';
 import useMap from '@terrestris/react-geo/dist/Hook/useMap';
@@ -24,14 +17,12 @@ import './index.less';
 import useAppSelector from '../../hooks/useAppSelector';
 import { Legal } from '../../store/legal';
 
-export interface FooterProps extends React.ComponentProps<'div'> { }
+export interface FooterProps extends React.ComponentProps<'div'> {}
 
 export const Footer: React.FC<FooterProps> = ({
   ...restProps
 }): JSX.Element => {
-  const {
-    t
-  } = useTranslation();
+  const { t } = useTranslation();
 
   const legalInformation: Legal = useAppSelector(state => state.legal);
   const map = useMap();
@@ -41,7 +32,9 @@ export const Footer: React.FC<FooterProps> = ({
       return;
     }
 
-    const existingControl = map.getControls().getArray()
+    const existingControl = map
+      .getControls()
+      .getArray()
       .find(control => control instanceof OlControlScaleLine);
 
     if (existingControl) {
@@ -60,7 +53,9 @@ export const Footer: React.FC<FooterProps> = ({
       return;
     }
 
-    const existingControl = map.getControls().getArray()
+    const existingControl = map
+      .getControls()
+      .getArray()
       .find(control => control instanceof OlControlMousePosition);
 
     if (existingControl) {
@@ -107,37 +102,19 @@ export const Footer: React.FC<FooterProps> = ({
       className="footer"
       {...restProps}
     >
-      <div
-        className="item-container left-items"
-      >
-        <div
-          id="scale-line-container"
-        />
-        <Divider
-          type="vertical"
-        />
-        <div
-          className="scale-combo"
-        >
+      <div className="item-container left-items">
+        <div id="scale-line-container" />
+        <Divider type="vertical" />
+        <div className="scale-combo">
           {t('Footer.scale')}:&nbsp;
-          <ScaleCombo
-            map={map}
-          />
-          <Divider
-            type="vertical"
-          />
+          <ScaleCombo map={map} />
+          <Divider type="vertical" />
         </div>
-        <div
-          className="reference-system"
-        >
+        <div className="reference-system">
           {t('Footer.refSystem')}: {map.getView().getProjection().getCode()}
-          <Divider
-            type="vertical"
-          />
+          <Divider type="vertical" />
         </div>
-        <div
-          className="mouse-position-wrapper"
-        >
+        <div className="mouse-position-wrapper">
           {t('Footer.mousePosition')}:&nbsp;
           <div
             id="mouse-position"

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -21,6 +21,8 @@ import ScaleCombo from '@terrestris/react-geo/dist/Field/ScaleCombo/ScaleCombo';
 import useMap from '@terrestris/react-geo/dist/Hook/useMap';
 
 import './index.less';
+import useAppSelector from '../../hooks/useAppSelector';
+import { Legal } from '../../store/legal';
 
 export interface FooterProps extends React.ComponentProps<'div'> { }
 
@@ -31,6 +33,7 @@ export const Footer: React.FC<FooterProps> = ({
     t
   } = useTranslation();
 
+  const legalInformation: Legal = useAppSelector(state => state.legal);
   const map = useMap();
 
   useEffect(() => {
@@ -74,15 +77,25 @@ export const Footer: React.FC<FooterProps> = ({
   }, [map]);
 
   const openContactModal = (): void => {
-    window.open('https://www.terrestris.de/de/kontakt/', '_blank');
+    window.open(
+      legalInformation.contact || 'https://www.terrestris.de/de/kontakt/',
+      '_blank'
+    );
   };
 
   const openImprintModal = (): void => {
-    window.open('https://www.terrestris.de/de/impressum/', '_blank');
+    window.open(
+      legalInformation.imprint || 'https://www.terrestris.de/de/impressum/',
+      '_blank'
+    );
   };
 
   const openPrivacyModal = (): void => {
-    window.open('https://www.terrestris.de/de/datenschutzerklaerung/', '_blank');
+    window.open(
+      legalInformation.privacy ||
+        'https://www.terrestris.de/de/datenschutzerklaerung/',
+      '_blank'
+    );
   };
 
   if (!map) {

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -72,25 +72,15 @@ export const Footer: React.FC<FooterProps> = ({
   }, [map]);
 
   const openContactModal = (): void => {
-    window.open(
-      legalInformation.contact || 'https://www.terrestris.de/de/kontakt/',
-      '_blank'
-    );
+    window.open(legalInformation.contact, '_blank');
   };
 
   const openImprintModal = (): void => {
-    window.open(
-      legalInformation.imprint || 'https://www.terrestris.de/de/impressum/',
-      '_blank'
-    );
+    window.open(legalInformation.imprint, '_blank');
   };
 
   const openPrivacyModal = (): void => {
-    window.open(
-      legalInformation.privacy ||
-        'https://www.terrestris.de/de/datenschutzerklaerung/',
-      '_blank'
-    );
+    window.open(legalInformation.privacy, '_blank');
   };
 
   if (!map) {

--- a/src/components/ToolMenu/Draw/StylingDrawer/StylingComponent/index.tsx
+++ b/src/components/ToolMenu/Draw/StylingDrawer/StylingComponent/index.tsx
@@ -5,15 +5,15 @@ import {
   useState
 } from 'react';
 
+import CardStyle, {
+  CardStyleProps
+} from 'geostyler/dist/Component/CardStyle/CardStyle';
+
 import OlParser from 'geostyler-openlayers-parser';
 
 import {
   Style as GsStyle
 } from 'geostyler-style';
-
-import CardStyle, {
-  CardStyleProps
-} from 'geostyler/dist/Component/CardStyle/CardStyle';
 
 import OlFeature from 'ol/Feature';
 

--- a/src/store/legal/index.ts
+++ b/src/store/legal/index.ts
@@ -1,0 +1,25 @@
+import {
+  createSlice, PayloadAction
+} from '@reduxjs/toolkit';
+
+export type Legal = {
+  contact?: string;
+  imprint?: string;
+  privacy?: string;
+};
+
+const initialState: Legal = {};
+
+export const slice = createSlice({
+  name: 'legal',
+  initialState,
+  reducers: {
+    setLegal: (state, action: PayloadAction<Legal>) => {
+      return action.payload;
+    }
+  }
+});
+
+export const { setLegal } = slice.actions;
+
+export default slice.reducer;

--- a/src/store/legal/index.ts
+++ b/src/store/legal/index.ts
@@ -8,14 +8,22 @@ export type Legal = {
   privacy?: string;
 };
 
-const initialState: Legal = {};
+const initialState: Legal = {
+  contact: 'https://www.terrestris.de/de/kontakt/',
+  imprint: 'https://www.terrestris.de/de/impressum/',
+  privacy: 'https://www.terrestris.de/de/datenschutzerklaerung/'
+};
 
 export const slice = createSlice({
   name: 'legal',
   initialState,
   reducers: {
     setLegal: (state, action: PayloadAction<Legal>) => {
-      return action.payload;
+      return {
+        contact: action.payload.contact || initialState.contact,
+        imprint: action.payload.imprint || initialState.imprint,
+        privacy: action.payload.privacy || initialState.privacy
+      };
     }
   }
 });

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -7,6 +7,7 @@ import {
 import addLayerModal from './addLayerModal';
 import appInfo from './appInfo';
 import description from './description';
+import legal from './legal';
 import logoPath from './logoPath';
 import selectedFeatures from './selectedFeatures';
 import title from './title';
@@ -22,6 +23,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     appInfo,
     title,
     description,
+    legal,
     logoPath,
     toolMenu,
     addLayerModal,


### PR DESCRIPTION
This PR lets the map client use the configuration of the legal links for the footer, when available. If this setting is not specified for a client, the already existing defined links are used as default.  
Needs https://github.com/terrestris/shogun/pull/642 and https://github.com/terrestris/shogun-util/pull/254 first be merged.

Also included is some code styling by eslint.

@terrestris/devs please review