### PR TITLE
Fix FeatureInfo for plugins

### DIFF
--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -12,6 +12,7 @@ import OlLayerImage from 'ol/layer/Image';
 import OlLayerTile from 'ol/layer/Tile';
 import OlSourceImageWMS from 'ol/source/ImageWMS';
 import OlSourceTileWMS from 'ol/source/TileWMS';
+import OlSourceWMTS from 'ol/source/WMTS';
 
 import {
   Tab
@@ -112,10 +113,14 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
 
       const mapLayer = map.getAllLayers().find(l => {
         if (l instanceof OlLayerImage || l instanceof OlLayerTile) {
-          const unqualifiedMapLayerName = getUnqualifiedLayerName(l.getSource().getParams().LAYERS);
-          const unqualifiedLayerName = getUnqualifiedLayerName(layerName);
-
-          return unqualifiedLayerName === unqualifiedMapLayerName;
+          const source = l.getSource();
+          if (source instanceof OlSourceWMTS) {
+            return false;
+          } else {
+            const unqualifiedMapLayerName = getUnqualifiedLayerName(l.getSource().getParams().LAYERS);
+            const unqualifiedLayerName = getUnqualifiedLayerName(layerName);
+            return unqualifiedLayerName === unqualifiedMapLayerName;
+          }
         }
         return false;
       });

--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -79,7 +79,7 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
 
   const queryLayers = MapUtil.getAllLayers(map)
     .filter((layer) => {
-      if (!layer.get('hoverable')) {
+      if (!layer.get('hoverable') || !layer.getVisible()) {
         return false;
       }
 


### PR DESCRIPTION
Pass `client` as property instead of getting it from context via hook.

This is needed for the case if the `FeatureInfo` component is used with some plugin, where the client context is not  directly accessible.

Also enhance logic to estimate query layers:
- exclude invisible layer candidates
- exclude WMTS layers

Please review @terrestris/devs 