### PR TITLE
breaking: remove client prop, get client from hook instead

### DIFF
--- a/src/components/PrintForm/index.tsx
+++ b/src/components/PrintForm/index.tsx
@@ -50,8 +50,8 @@ import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import {
   getBearerTokenHeader
 } from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
-import SHOGunAPIClient from '@terrestris/shogun-util/dist/service/SHOGunAPIClient';
 
+import useSHOGunAPIClient from '../../hooks/useSHOGunAPIClient';
 import SHOGunMapFishPrintV3TiledWMSSerializer from '../PrintForm/Serializer/SHOGunMapFishPrintV3TiledWMSSerializer';
 import SHOGunMapFishPrintV3WMSSerializer from '../PrintForm/Serializer/SHOGunMapFishPrintV3WMSSerializer';
 
@@ -73,7 +73,6 @@ export interface Layout {
 export interface PrintFormProps extends Omit<FormProps, 'form'> {
   active: boolean;
   map: OlMap;
-  client?: SHOGunAPIClient | null;
   customPrintScales?: number[];
   layouts?: Layout[];
   layerBlackList?: string[];
@@ -84,7 +83,6 @@ export const PrintForm: React.FC<PrintFormProps> = ({
   layerBlackList = [],
   map,
   active,
-  client,
   customPrintScales = [],
   outputFormats=['pdf', 'png'],
   ...restProps
@@ -94,6 +92,8 @@ export const PrintForm: React.FC<PrintFormProps> = ({
   const {
     t
   } = useTranslation();
+
+  const client = useSHOGunAPIClient();
 
   const [printManager, setPrintManager] = useState<MapFishPrintV3Manager | null>(null);
   const [loading, setLoading] = useState<boolean>(false);

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -93,8 +93,6 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
 
   const plugins = usePlugins();
 
-  const client = useSHOGunAPIClient();
-
   const dispatch = useAppDispatch();
   const availableTools = useAppSelector(state => state.toolMenu.availableTools);
   const activeKeys = useAppSelector(state => state.toolMenu.activeKeys);
@@ -271,7 +269,6 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
             <PrintForm
               active={activeKeys.includes('print')}
               map={map}
-              client={client}
               layerBlackList={[
                 'react-geo_measure',
                 'hoverVectorLayer'


### PR DESCRIPTION
Don't pass `client` as prop to `PrintForm`, use `useSHOGunAPIClient()` instead.

Please review @terrestris/devs 