### PR TITLE
fix: fixing playwright workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,40 +66,6 @@ jobs:
         run: |
           docker push ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:${{ steps.semantic.outputs.new_release_version }}
 
-  release-e2e:
-    name: release-e2e
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout 🔰
-        uses: actions/checkout@v2
-
-      - name: Setup Node.js 🧮
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-
-      - name: Install dependencies ⏬
-        run: npm ci
-
-      - name: Build (dist) artifacts 🏗️
-        run: npm run build:dist
-
-      - name: Semantic Release 🚀
-        uses: cycjimmy/semantic-release-action@v2
-        id: semantic
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_API_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        with:
-          semantic_version: 19
-
-      - name: Login to Nexus ⌨️
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ secrets.NEXUS_USERNAME }}
-          password: ${{ secrets.NEXUS_PASSWORD }}
-
       - name: Build docker image (latest) 🏗️
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
merge two workflows so that the building process of the e2e image has access to all variables like `steps.semantic.outputs.new_release_published == 'true'`