### PR TITLE
fix: remove unnecessary layer visibility check for GFI tool

### DIFF
--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -79,7 +79,7 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
 
   const queryLayers = MapUtil.getAllLayers(map)
     .filter((layer) => {
-      if (!layer.get('hoverable') || !layer.getVisible()) {
+      if (!layer.get('hoverable')) {
         return false;
       }
 


### PR DESCRIPTION
Remove unnecessary check for layer visibility which actually breaks GFI tool functionality for the following use case:

- start client
- request some visible queryable layer -> GFI grid is shown
- turn some another queryable layer visible via checkbox in layer tree
- request this layer -> infos are not shown / GFI request is missing

Please review @terrestris/devs 