### PR TITLE
feat: allow shape and geotiff upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Several global settings for the client can be configured via the [`gis-client-co
 | keycloak.clientId | The Keycloak client that should be used for authentication, e.g. `shogun-client` | null |
 | keycloak.onLoadAction | See [here](https://www.keycloak.org/docs/latest/securing_apps/#_javascript_adapter) for details | 'check-sso' |
 | print.url | The url of the MapFish Print servlet | '/print' |
+| plugins | The list of plugins to be loaded | [] |
+| plugin.name | The name of the plugin | undefined |
+| plugin.exposedPaths | The list of exposed paths | undefined |
+| plugin.resourcePath | The resource path | undefined |
+| geoserver.base | The base url of the GeoServer | '/geoserver' |
+| geoserver.upload.workspace | The workspace the uploads should be placed in | 'SHOGUN' |
+| geoserver.upload.limit | The upload size limit in bytes (note: this is the client evaluation only!) | 200000000 (= 200MB) |
+| geoserver.upload.authorizedRoles | The list of role names the upload should be allowed/visible to (note: this is the client evaluation only!) | ['admin'] |
 
 The configuration file is not bundled and will be loaded before application start from `./gis-client-config.js`. Typically you want to override the file in a production environment and you can pass a custom file by mounting the desired one directly into the nginx container of the client. For example:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-i18next": "^12.0.0",
-        "react-redux": "^8.0.5"
+        "react-redux": "^8.0.5",
+        "shapefile.js": "^1.1.3"
       },
       "devDependencies": {
         "@babel/cli": "^7.19.3",
@@ -25903,6 +25904,14 @@
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
+    "node_modules/shapefile.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/shapefile.js/-/shapefile.js-1.1.3.tgz",
+      "integrity": "sha512-mKcCpHGXgVeZWDcVi1Mmz2X0bfw1V9PE+aAY7cmO8+RLjFK5q/G8Fg/grc55mNJ5GDBlxkTlIluRHNsCOSMwrg==",
+      "dependencies": {
+        "jszip": "^3.7.1"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -47787,6 +47796,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
+    "shapefile.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/shapefile.js/-/shapefile.js-1.1.3.tgz",
+      "integrity": "sha512-mKcCpHGXgVeZWDcVi1Mmz2X0bfw1V9PE+aAY7cmO8+RLjFK5q/G8Fg/grc55mNJ5GDBlxkTlIluRHNsCOSMwrg==",
+      "requires": {
+        "jszip": "^3.7.1"
+      }
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^12.0.0",
-    "react-redux": "^8.0.5"
+    "react-redux": "^8.0.5",
+    "shapefile.js": "^1.1.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/resources/config/gis-client-config.js
+++ b/resources/config/gis-client-config.js
@@ -10,5 +10,15 @@ var clientConfig = {
   print: {
     url: '/print'
   },
-  plugins: []
+  plugins: [],
+  geoserver: {
+    base: '/geoserver',
+    upload: {
+      workspace: 'SHOGUN-UPLOADS',
+      limit: 200000000, // ~200MB
+      authorizedRoles: [
+        'admin'
+      ]
+    }
+  }
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import BasicMapComponent from './components/BasicMapComponent';
 import Footer from './components/Footer';
 import Header from './components/Header';
 import ToolMenu from './components/ToolMenu';
+import UploadDataModal from './components/UploadDataModal';
 
 import './App.less';
 
@@ -34,6 +35,7 @@ export const App: React.FC<AppProps> = ({
       <ToolMenu />
       <Footer />
       <AddLayerModal />
+      <UploadDataModal />
     </div>
   );
 };

--- a/src/components/BasicMapComponent/index.tsx
+++ b/src/components/BasicMapComponent/index.tsx
@@ -85,13 +85,21 @@ export const BasicMapComponent: React.FC<Partial<MapComponentProps>> = ({
         if (!_isEmpty(cfg?.layerConfig)) {
           const layerConfig: Layer = cfg.layerConfig;
           const olLayer = await parser.parseLayer(layerConfig);
-          olLayer.set('isExternalLayer', cfg.isExternalLayer);
+
+          if (cfg.isExternalLayer) {
+            olLayer.set('isExternalLayer', cfg.isExternalLayer);
+          }
+
+          if (cfg.isUploadedLayer) {
+            olLayer.set('isUploadedLayer', cfg.isUploadedLayer);
+          }
+
           olLayer.set('groupName', cfg.groupName);
           olLayer.set('layerConfig', cfg.layerConfig);
 
           olLayer.setVisible(!!permaLinkLayers?.split(';').some(l => l === layerConfig.name));
 
-          if (!olLayer.get('isExternalLayer')) {
+          if (!(olLayer.get('isExternalLayer') || olLayer.get('isUploadedLayer'))) {
             continue;
           }
 

--- a/src/components/Permalink/index.tsx
+++ b/src/components/Permalink/index.tsx
@@ -42,7 +42,12 @@ export interface PermalinkProps extends Partial<DefaultPermalinkProps> { }
 
 export const Permalink: React.FC<PermalinkProps> = () => {
   const map = useMap();
-  const layerAttributes = useMemo(() => ['layerConfig', 'isExternalLayer', 'groupName'], []);
+  const layerAttributes = useMemo(() => [
+    'layerConfig',
+    'isExternalLayer',
+    'isUploadedLayer',
+    'groupName'
+  ], []);
   const {
     t
   } = useTranslation();
@@ -78,21 +83,8 @@ export const Permalink: React.FC<PermalinkProps> = () => {
       ));
     };
 
-    const filterFunctionForLayers = (l: BaseLayer) => (l instanceof TileLayer || l instanceof ImageLayer);
-    const updateLayersInPermalink = () => {
-      setPermalink(
-        PermalinkUtil.getLink(
-          map,
-          ';',
-          identifierFunction,
-          filterFunctionForLayers,
-          layerAttributes
-        )
-      );
-    };
-
     const updateLayerConfig = () => {
-      const externalLayers = map.getAllLayers().filter(l => l.get('isExternalLayer'));
+      const externalLayers = map.getAllLayers().filter(l => l.get('isExternalLayer') || l.get('isUploadedLayer'));
       externalLayers.forEach(externalLayer => {
         const layerConfig = externalLayer.get('layerConfig') as Layer;
         if (layerConfig) {

--- a/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
+++ b/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
@@ -175,9 +175,14 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
     removeLayer(layer);
 
     const externalLayerGroup = MapUtil.getLayerByName(map, t('AddLayerModal.externalWmsFolder')) as OlLayerGroup;
+    const uploadedLayerGroup = MapUtil.getLayerByName(map, t('UploadDataModal.uploadedDataFolder')) as OlLayerGroup;
 
     if (externalLayerGroup && externalLayerGroup.getLayers().getLength() === 0) {
       removeLayer(externalLayerGroup);
+    }
+
+    if (uploadedLayerGroup && uploadedLayerGroup.getLayers().getLength() === 0) {
+      removeLayer(uploadedLayerGroup);
     }
   };
 
@@ -225,7 +230,7 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
     });
   }
 
-  if (layer.get('isExternalLayer')) {
+  if (layer.get('isExternalLayer') || layer.get('isUploadedLayer')) {
     dropdownMenuItems.push({
       label: t('LayerTreeContextMenu.removeLayer'),
       key: 'removeExternal'

--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -30,7 +30,6 @@
   }
 
   .react-geo-togglegroup.vertical-toggle-group {
-
     button {
       display: flex;
       width: 100%;
@@ -47,7 +46,6 @@
   }
 
   &.collapsed {
-
     min-width: unset;
     width: 40px;
 
@@ -78,7 +76,6 @@
     overflow-y: auto;
 
     .ant-collapse-item {
-
       .ant-collapse-header {
         background-color: #fff;
         padding: 6px 40px 6px 16px;
@@ -106,6 +103,9 @@
           flex-direction: column;
           background-color: white;
 
+          .upload-data-button {
+            margin-top: 5px;
+          }
         }
       }
 

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -17,7 +17,8 @@ import {
   faPlus,
   faRuler,
   faShareNodes,
-  faStream
+  faStream,
+  faUpload
 } from '@fortawesome/free-solid-svg-icons';
 
 import {
@@ -30,6 +31,8 @@ import {
   CollapsePanelProps,
   Tooltip
 } from 'antd';
+
+import ClientConfiguration from 'clientConfig';
 
 import _toArray from 'lodash/toArray';
 
@@ -58,6 +61,9 @@ import {
 import {
   setActiveKeys
 } from '../../store/toolMenu';
+import {
+  show as showUpload
+} from '../../store/uploadDataModal';
 
 import LanguageSelect from '../LanguageSelector';
 import Permalink from '../Permalink';
@@ -96,6 +102,9 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
   const dispatch = useAppDispatch();
   const availableTools = useAppSelector(state => state.toolMenu.availableTools);
   const activeKeys = useAppSelector(state => state.toolMenu.activeKeys);
+
+  const client = useSHOGunAPIClient();
+  const keycloak = client?.getKeycloak();
 
   const [collapsed, setCollapsed] = useState<boolean>(false);
   const [menuTools, setMenuTools] = useState<string[]>([]);
@@ -290,6 +299,18 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
               >
                 {t('ToolMenu.addWms')}
               </Button>
+              {
+                keycloak && ClientConfiguration.geoserver?.upload?.authorizedRoles?.some(
+                  role => keycloak.hasResourceRole(role, keycloak.clientId)) && (
+                  <Button
+                    className='upload-data-button tool-menu-button'
+                    icon={<FontAwesomeIcon icon={faUpload} />}
+                    onClick={() => dispatch(showUpload())}
+                  >
+                    {t('ToolMenu.uploadData')}
+                  </Button>
+                )
+              }
             </div>
           )
         };

--- a/src/components/UploadDataModal/index.less
+++ b/src/components/UploadDataModal/index.less
@@ -1,0 +1,5 @@
+.upload-data-modal {
+  .ant-alert {
+    margin-bottom: 15px;
+  }
+}

--- a/src/components/UploadDataModal/index.spec.tsx
+++ b/src/components/UploadDataModal/index.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import {
+  render,
+  screen,
+  fireEvent
+} from '@testing-library/react';
+
+import {
+  store
+} from '../../store/store';
+import {
+  show,
+  hide
+} from '../../store/uploadDataModal';
+
+import {
+  createReduxWrapper
+} from '../../utils/testUtils';
+
+import UploadDataModal from './index';
+
+describe('<UploadDataModal />', () => {
+
+  beforeEach(() => {
+    store.dispatch(show());
+  });
+
+  afterEach(() => {
+    store.dispatch(hide());
+  });
+
+  it('is defined', () => {
+    expect(UploadDataModal).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(<UploadDataModal />, {
+      wrapper: createReduxWrapper()
+    });
+
+    expect(container).toBeVisible();
+  });
+
+  it('can toggle its visibility', () => {
+    render(<UploadDataModal />, {
+      wrapper: createReduxWrapper()
+    });
+
+    const modal = screen.getByRole('dialog');
+
+    expect(modal).toBeVisible();
+
+    const closeButton = screen.getByLabelText('Close');
+
+    fireEvent.click(closeButton);
+
+    expect(modal).not.toBeVisible();
+  });
+});

--- a/src/components/UploadDataModal/index.tsx
+++ b/src/components/UploadDataModal/index.tsx
@@ -1,0 +1,537 @@
+import React, {
+  useState
+} from 'react';
+
+import {
+  faUpload
+} from '@fortawesome/free-solid-svg-icons';
+import {
+  FontAwesomeIcon
+} from '@fortawesome/react-fontawesome';
+
+import {
+  Alert,
+  Modal,
+  ModalProps,
+  Spin,
+  Upload
+} from 'antd';
+
+const { Dragger } = Upload;
+
+import {
+  RcFile,
+  UploadChangeParam,
+  UploadFile
+} from 'antd/lib/upload/interface';
+
+import ClientConfiguration from 'clientConfig';
+
+import OlLayerGroup from 'ol/layer/Group';
+import TileLayer from 'ol/layer/Tile';
+import TileWMSSource from 'ol/source/TileWMS';
+
+import {
+  UploadRequestOption
+} from 'rc-upload/lib/interface';
+
+import {
+  useTranslation
+} from 'react-i18next';
+
+import {
+  Shapefile
+} from 'shapefile.js';
+
+import Logger from '@terrestris/base-util/dist/Logger';
+
+import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+
+import {
+  useMap
+} from '@terrestris/react-geo/dist/Hook/useMap';
+
+import Layer from '@terrestris/shogun-util/dist/model/Layer';
+import SHOGunApplicationUtil from '@terrestris/shogun-util/dist/parser/SHOGunApplicationUtil';
+import {
+  getBearerTokenHeader
+} from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
+
+import useAppDispatch from '../../hooks/useAppDispatch';
+import useAppSelector from '../../hooks/useAppSelector';
+import useSHOGunAPIClient from '../../hooks/useSHOGunAPIClient';
+import {
+  hide
+} from '../../store/uploadDataModal';
+
+import './index.less';
+
+type FeatureTypeAttribute = {
+  name: string;
+  minOccurs: number;
+  maxOccurs: number;
+  nillable: boolean;
+  binding?: string | null;
+  length?: number;
+};
+
+type FeatureTypeAttributes = {
+  attribute: FeatureTypeAttribute[];
+};
+
+export type LayerUploadOptions = {
+  baseUrl: string;
+  workspace: string;
+  storeName: string;
+  layerName: string;
+  file: RcFile;
+};
+
+export type LayerUploadResponse = {
+  layerName: string;
+  workspace: string;
+  baseUrl: string;
+};
+
+export type UploadDataModalProps = {} & Partial<ModalProps>;
+
+export const UploadDataModal: React.FC<UploadDataModalProps> = ({
+  ...restProps
+}): JSX.Element => {
+  const [uploadError, setUploadError] = useState('');
+  const [uploadSuccess, setUploadSuccess] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
+
+  const isModalVisible = useAppSelector(state => state.uploadDataModal.visible);
+  const user = useAppSelector((state) => state.user);
+
+  const dispatch = useAppDispatch();
+
+  const map = useMap();
+  const client = useSHOGunAPIClient();
+
+  const {
+    t
+  } = useTranslation();
+
+  const closeModal = () => {
+    setUploadError('');
+    setUploadSuccess('');
+    dispatch(hide());
+  };
+
+  const addLayer = (layer: TileLayer<TileWMSSource>) => {
+    if (!map) {
+      return;
+    }
+
+    const targetFolderName = t('UploadDataModal.uploadedDataFolder');
+    let targetGroup = MapUtil.getLayerByName(map, targetFolderName) as OlLayerGroup;
+
+    if (!targetGroup) {
+      targetGroup = new OlLayerGroup({
+        layers: [],
+        properties: {
+          name: targetFolderName
+        }
+      });
+      const existingGroups = map.getLayerGroup().getLayers();
+      existingGroups.insertAt(existingGroups?.getLength() || 0, targetGroup);
+    }
+
+    if (!targetGroup.getLayers().getArray().includes(layer)) {
+      targetGroup.getLayers().push(layer);
+    }
+  };
+
+  const onBeforeFileUpload = (file: RcFile) => {
+    const maxSize = ClientConfiguration.geoserver?.upload?.limit || 200000000;
+    const fileType = file.type;
+    const fileSize = file.size;
+
+    setUploadError('');
+    setUploadSuccess('');
+
+    if (fileSize > maxSize) {
+      setUploadError(t('UploadDataModal.error.maxSize', {
+        maxSize: maxSize / 1000000
+      }));
+
+      return false;
+    }
+
+    const supportedFormats = ['application/zip', 'image/tiff'];
+    if (!supportedFormats.includes(fileType)) {
+      setUploadError(t('UploadDataModal.error.supportedFormats', {
+        supportedFormats: supportedFormats.join(', ')
+      }));
+
+      return false;
+    }
+
+    return true;
+  };
+
+  const uploadGeoTiff = async (options: LayerUploadOptions): Promise<void> => {
+    const {
+      baseUrl,
+      workspace,
+      storeName,
+      layerName,
+      file
+    } = options;
+
+    const coverageStoreUrl = `${baseUrl}/rest/workspaces/${workspace}/coveragestores/` +
+      `${storeName}/file.geotiff?configure=none`;
+
+    const coverageStoreResponse = await fetch(coverageStoreUrl, {
+      method: 'PUT',
+      headers: {
+        ...getBearerTokenHeader(client?.getKeycloak()),
+        'Content-Type': 'image/tiff'
+      },
+      body: file
+    });
+
+    if (!coverageStoreResponse.ok) {
+      throw new Error(t('UploadDataModal.error.general', {
+        fileName: file.name
+      }));
+    }
+
+    const coverageUrl = `${baseUrl}/rest/workspaces/${workspace}/coveragestores/${storeName}/coverages`;
+
+    const coverageResponse = await fetch(coverageUrl, {
+      method: 'POST',
+      headers: {
+        ...getBearerTokenHeader(client?.getKeycloak()),
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        coverage: {
+          enabled: true,
+          name: layerName,
+          nativeName: layerName,
+          title: layerName,
+          keywords: {
+            // eslint-disable-next-line quote-props
+            'string': [
+              'User upload',
+              `Uploaded by ${user.providerDetails?.username}`
+            ]
+          }
+        }
+      })
+    });
+
+    if (!coverageResponse.ok) {
+      throw new Error(t('UploadDataModal.error.general', {
+        fileName: file.name
+      }));
+    }
+  };
+
+  const uploadShapeZip = async (options: LayerUploadOptions): Promise<void> => {
+    const {
+      baseUrl,
+      workspace,
+      storeName,
+      layerName,
+      file
+    } = options;
+
+    const shp = await Shapefile.load(file);
+
+    let featureTypeName = '';
+    let featureTypeAttributes: FeatureTypeAttributes = {
+      attribute: []
+    };
+
+    if (Object.entries(shp).length !== 1) {
+      throw new Error(t('UploadDataModal.error.zipContent'));
+    }
+
+    Object.entries(shp).forEach(([k, v]) => {
+      featureTypeName = k;
+
+      const dbfContent = v.parse('dbf', {
+        properties: false
+      });
+
+      featureTypeAttributes.attribute = dbfContent.fields.map(field => ({
+        name: field.name,
+        minOccurs: 0,
+        maxOccurs: 1,
+        nillable: true,
+        binding: getAttributeType(field.type),
+        length: field.length
+      }));
+
+      const shxContent = v.parse('shx');
+
+      featureTypeAttributes.attribute.push({
+        name: 'the_geom',
+        minOccurs: 0,
+        maxOccurs: 1,
+        nillable: true,
+        binding: getGeometryType(shxContent.header.type)
+      });
+    });
+
+    const url = `${baseUrl}/rest/workspaces/${workspace}/datastores/` +
+      `${storeName}/file.shp?configure=none`;
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        ...getBearerTokenHeader(client?.getKeycloak()),
+        'Content-Type': 'application/zip'
+      },
+      body: file
+    });
+
+    if (!response.ok) {
+      throw new Error(t('UploadDataModal.error.general', {
+        fileName: file.name
+      }));
+    }
+
+    const featureTypeUrl = `${baseUrl}/rest/workspaces/${workspace}/datastores/${storeName}/featuretypes`;
+
+    const featureTypeResponse = await fetch(featureTypeUrl, {
+      method: 'POST',
+      headers: {
+        ...getBearerTokenHeader(client?.getKeycloak()),
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        featureType: {
+          enabled: true,
+          name: layerName,
+          nativeName: featureTypeName,
+          title: layerName,
+          attributes: featureTypeAttributes,
+          keywords: {
+            // eslint-disable-next-line quote-props
+            'string': [
+              'User upload',
+              `Uploaded by ${user.providerDetails?.username}`
+            ]
+          }
+        }
+      })
+    });
+
+    if (!featureTypeResponse.ok) {
+      throw new Error(t('UploadDataModal.error.general', {
+        fileName: file.name
+      }));
+    }
+  };
+
+  const onFileUploadAction = async (options: UploadRequestOption<LayerUploadResponse>) => {
+    const {
+      onError,
+      onSuccess,
+      file
+    } = options;
+
+    const splittedFileName = (file as RcFile).name.split('.');
+    const fileType = (file as RcFile).type;
+    const geoServerBaseUrl = ClientConfiguration.geoserver?.base || '/geoserver';
+    const workspace = ClientConfiguration.geoserver?.upload?.workspace || 'SHOGUN';
+    const layerName = `${splittedFileName[0]}_${Date.now()}`.toUpperCase();
+
+    const uploadData = {
+      file: file as RcFile,
+      baseUrl: geoServerBaseUrl,
+      workspace: workspace,
+      storeName: layerName,
+      layerName: layerName
+    };
+
+    try {
+      if (fileType === 'image/tiff') {
+        await uploadGeoTiff(uploadData);
+      }
+
+      if (fileType === 'application/zip') {
+        await uploadShapeZip(uploadData);
+      }
+
+      if (onSuccess) {
+        onSuccess({
+          baseUrl: geoServerBaseUrl,
+          workspace: workspace,
+          layerName: layerName
+        });
+      }
+    } catch (error) {
+      if (onError) {
+        onError({
+          name: 'UploadError',
+          message: (error instanceof Error) ? error.message : t('UploadDataModal.error.general', {
+            fileName: (file as RcFile).name
+          })
+        });
+      }
+    }
+  };
+
+  const onFileUploadChange = async (info: UploadChangeParam<UploadFile<LayerUploadResponse>>) => {
+    const file = info.file;
+
+    if (file.status === 'uploading') {
+      setIsUploading(true);
+    }
+
+    if (file.status === 'done') {
+      if (!client || !file.response) {
+        return;
+      }
+
+      const layerConfig: Layer = {
+        name: file.response.layerName,
+        type: 'TILEWMS',
+        clientConfig: {
+          hoverable: true
+        },
+        sourceConfig: {
+          url: `${file.response.baseUrl}/ows?`,
+          layerNames: `${file.response.workspace}:${file.response.layerName}`,
+          useBearerToken: true
+        }
+      };
+
+      const parser = new SHOGunApplicationUtil({
+        client
+      });
+
+      const olLayer = parser.parseTileLayer(layerConfig);
+      olLayer.set('layerConfig', layerConfig);
+      olLayer.set('isUploadedLayer', true);
+      olLayer.set('groupName', t('UploadDataModal.uploadedDataFolder'));
+      addLayer(olLayer);
+
+      setUploadSuccess(t('UploadDataModal.success', {
+        fileName: file.name,
+        layerName: file.response.layerName
+      }));
+
+      setIsUploading(false);
+    } else if (file.status === 'error') {
+      setIsUploading(false);
+
+      Logger.error(file.error);
+
+      if (file.error && file.error.message) {
+        setUploadError(file.error.message);
+      } else {
+        setUploadError(t('UploadDataModal.error.general', {
+          fileName: file.name
+        }));
+      }
+    }
+  };
+
+  const getGeometryType = (type: number) => {
+    const types: {
+      [key: number]: string | null;
+    } = {
+      0: null, // Null
+      1: 'org.locationtech.jts.geom.Point', // Point
+      3: 'org.locationtech.jts.geom.LineString', // Polyline
+      5: 'org.locationtech.jts.geom.Polygon', // Polygon
+      8: 'org.locationtech.jts.geom.MultiPoint', // MultiPoint
+      11: 'org.locationtech.jts.geom.Point', // PointZ
+      13: 'org.locationtech.jts.geom.LineString', // PolylineZ
+      15: 'org.locationtech.jts.geom.Polygon', // PolygonZ
+      18: 'org.locationtech.jts.geom.MultiPoint', // MultiPointZ
+      21: 'org.locationtech.jts.geom.Point', // PointM
+      23: 'org.locationtech.jts.geom.LineString', // PolylineM
+      25: 'org.locationtech.jts.geom.Polygon', // PolygonM
+      28: 'org.locationtech.jts.geom.MultiPoint', // MultiPointM
+      31: null // MultiPatch
+    };
+
+    return types[type];
+  };
+
+  const getAttributeType = (dbfFieldType: string) => {
+    switch (dbfFieldType) {
+      case 'C': // Character
+        return 'java.lang.String';
+      case 'D': // Date
+        return 'java.util.Date';
+      case 'N': // Numeric
+        return 'java.lang.Long';
+      case 'F': // Floating point
+        return 'java.lang.Double';
+      case 'L': // Logical
+        return 'java.lang.Boolean';
+      case 'M': // Memo
+        return null;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Modal
+      className="upload-data-modal"
+      title={t('UploadDataModal.title')}
+      open={isModalVisible}
+      onCancel={closeModal}
+      width={600}
+      footer={false}
+      {...restProps}
+    >
+      {
+        uploadSuccess && (
+          <Alert
+            message={uploadSuccess}
+            closable={true}
+            type="success"
+          />
+        )
+      }
+
+      {
+        uploadError && (
+          <Alert
+            message={uploadError}
+            closable={true}
+            type="error"
+          />
+        )
+      }
+
+      <Spin
+        spinning={isUploading}
+      >
+        <Dragger
+          customRequest={onFileUploadAction}
+          accept='image/tiff,application/zip'
+          maxCount={1}
+          showUploadList={false}
+          beforeUpload={onBeforeFileUpload}
+          onChange={onFileUploadChange}
+        >
+          <p className="ant-upload-drag-icon">
+            <FontAwesomeIcon
+              icon={faUpload}
+            />
+          </p>
+          <p className="ant-upload-text">
+            {t('UploadDataModal.description')}
+          </p>
+          <p className="ant-upload-hint">
+            {t('UploadDataModal.hint')}
+          </p>
+        </Dragger>
+      </Spin>
+    </Modal>
+  );
+};
+
+export default UploadDataModal;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -7,9 +7,9 @@ declare const KEYCLOAK_CLIENT_ID: string;
 
 declare module 'clientConfig' {
   type PluginConfiguration = {
-    name: string;
-    resourcePath: string;
-    exposedPaths: string[];
+    name?: string;
+    resourcePath?: string;
+    exposedPaths?: string[];
   };
   type ClientConfiguration = {
     shogunBase?: string;
@@ -23,7 +23,15 @@ declare module 'clientConfig' {
     print?: {
       url?: string;
     };
-    plugins: PluginConfiguration[];
+    plugins?: PluginConfiguration[];
+    geoserver?: {
+      base?: string;
+      upload?: {
+        workspace?: string;
+        limit?: number;
+        authorizedRoles?: string[];
+      };
+    };
   };
   const config: ClientConfiguration;
 

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -128,7 +128,7 @@ export default {
       UploadDataModal: {
         title: 'Daten hochladen',
         uploadedDataFolder: 'Hochgeladene Daten',
-        description: 'Klicken oder ziehen Sie die Datei zum Hochladen in diesen Bereich',
+        description: 'Klicken Sie oder ziehen Sie die Datei zum Hochladen in diesen Bereich',
         hint: 'Unterstützte Dateiformate sind Shapefile (gebündelt als *.zip) und GeoTIFF',
         success: 'Datei {{fileName}} wurde erfolgreich geladen und der Layer {{layerName}} erstellt',
         error: {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -74,6 +74,7 @@ export default {
         draw: 'Zeichnen',
         featureInfo: 'Karteninhalte abfragen',
         addWms: 'WMS hinzufügen',
+        uploadData: 'Daten hochladen',
         print: 'Export',
         layertree: 'Karten',
         languageSelect: 'Sprachauswahl'
@@ -123,6 +124,19 @@ export default {
       WmsTimeSlider: {
         title: 'Zeitlicher Bezug',
         default: 'Keine Daten gefunden'
+      },
+      UploadDataModal: {
+        title: 'Daten hochladen',
+        uploadedDataFolder: 'Hochgeladene Daten',
+        description: 'Klicken oder ziehen Sie die Datei zum Hochladen in diesen Bereich',
+        hint: 'Unterstützte Dateiformate sind Shapefile (gebündelt als *.zip) und GeoTIFF',
+        success: 'Datei {{fileName}} wurde erfolgreich geladen und der Layer {{layerName}} erstellt',
+        error: {
+          general: 'Fehler beim Hochladen der Datei {{fileName}}',
+          maxSize: 'Der Upload überschreitet das Limit von {{maxSize}} MB',
+          supportedFormats: 'Der Dateityp ist nicht unterstützt ({{supportedFormats}})',
+          zipContent: 'Mehrere Geodatensätze innerhalb eines Archivs sind nicht unterstützt'
+        }
       }
     }
   },
@@ -201,6 +215,7 @@ export default {
         draw: 'Draw',
         featureInfo: 'Query map features',
         addWms: 'Add WMS',
+        uploadData: 'Upload data',
         print: 'Export',
         layertree: 'Maps',
         languageSelect: 'Language selector'
@@ -249,6 +264,19 @@ export default {
       WmsTimeSlider: {
         title: 'Time reference',
         default: 'No data found'
+      },
+      UploadDataModal: {
+        title: 'Upload data',
+        uploadedDataFolder: 'Uploaded data',
+        description: 'Click or drag file to this area to upload',
+        hint: 'Supported file formats are Shapefile (bundled as *.zip) and GeoTIFF',
+        success: 'Successfully uploaded file {{fileName}} and created layer {{layerName}}',
+        error: {
+          general: 'Error while uploading file {{fileName}}',
+          maxSize: 'The file exceeds the upload limit of {{maxSize}} MB',
+          supportedFormats: 'The given file type does not match the supported ones ({{supportedFormats}})',
+          zipContent: 'Multiple geodatasets within one archive are not supported'
+        }
       }
     }
   }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -12,6 +12,7 @@ import logoPath from './logoPath';
 import selectedFeatures from './selectedFeatures';
 import title from './title';
 import toolMenu from './toolMenu';
+import uploadDataModal from './uploadDataModal';
 import user from './user';
 
 type AsyncReducer = {
@@ -29,6 +30,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     addLayerModal,
     user,
     selectedFeatures,
+    uploadDataModal,
     ...asyncReducers
   });
 };

--- a/src/store/uploadDataModal/index.ts
+++ b/src/store/uploadDataModal/index.ts
@@ -1,0 +1,35 @@
+import {
+  createSlice
+} from '@reduxjs/toolkit';
+
+export interface UploadDataModalState {
+  visible: boolean;
+}
+
+const initialState: UploadDataModalState = {
+  visible: false
+};
+
+const uploadDataModalSlice = createSlice({
+  name: 'uploadDataModal',
+  initialState,
+  reducers: {
+    show(state) {
+      state.visible = true;
+    },
+    hide(state) {
+      state.visible = false;
+    },
+    toggle(state) {
+      state.visible = !state.visible;
+    }
+  }
+});
+
+export const {
+  show,
+  hide,
+  toggle
+} = uploadDataModalSlice.actions;
+
+export default uploadDataModalSlice.reducer;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -50,7 +50,10 @@ module.exports = {
       '.tsx',
       '.ts',
       '.js'
-    ]
+    ],
+    fallback: {
+      buffer: require.resolve('buffer/')
+    }
   },
   output: {
     path: path.resolve(__dirname, 'build'),
@@ -86,6 +89,12 @@ module.exports = {
       KEYCLOAK_HOST: JSON.stringify(process.env.KEYCLOAK_HOST),
       KEYCLOAK_REALM: JSON.stringify(process.env.KEYCLOAK_REALM),
       KEYCLOAK_CLIENT_ID: JSON.stringify(process.env.KEYCLOAK_CLIENT_ID)
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: [
+        'buffer',
+        'Buffer'
+      ]
     }),
     new ModuleFederationPlugin({
       name: 'SHOGunGISClient',


### PR DESCRIPTION
This adds a modal for uploading shape- and geotiff files to the specified GeoServer.

![Peek 2023-04-17 13-43](https://user-images.githubusercontent.com/1137620/232474796-1ff4289a-81f8-4214-8315-d38b0b0fe7e6.gif)

Per default the upload is available for admin users only. If you want to allow upload for other user roles, note the given configuration `authorizedRoles` and ensure the [rest interfaces in GeoServer](https://docs.geoserver.org/stable/en/user/security/rest.html) are accessible for the users. An example `rest.properties` allowing the upload for users with the `ROLE_USER` could look like the following:

```properties
/rest/workspaces/shogun/datastores/*/file.shp;PUT=ROLE_USER,ROLE_ADMINISTRATOR
/rest/workspaces/shogun/datastores/*/featuretypes;POST=ROLE_USER,ROLE_ADMINISTRATOR
/rest/workspaces/shogun/coveragestores/*/file.geotiff;PUT=ROLE_USER,ROLE_ADMINISTRATOR
/rest/workspaces/shogun/coveragestores/*/coverages;POST=ROLE_USER,ROLE_ADMINISTRATOR
/**;GET=ROLE_ADMINISTRATOR
/**;POST,DELETE,PUT=ROLE_ADMINISTRATOR
```

Please review @terrestris/devs.