### PR TITLE
Fix i18n initialization

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -13,6 +13,8 @@ import ClientConfiguration from 'clientConfig';
 
 import Color from 'color';
 
+import LanguageDetector from 'i18next-browser-languagedetector';
+
 import Keycloak from 'keycloak-js';
 
 import {
@@ -61,7 +63,9 @@ import {
   SHOGunAPIClientProvider
 } from './context/SHOGunAPIClientContext';
 
-import i18n from './i18n';
+import i18n, {
+  initOpts
+} from './i18n';
 
 import {
   ClientPluginInternal
@@ -522,9 +526,14 @@ const renderApp = async () => {
     const appConfig = await getApplicationConfiguration();
 
     const defaultLanguage = appConfig?.clientConfig?.defaultLanguage;
-    const storedLanguage = localStorage.getItem('i18nextLng');
-    // Only apply default language if no stored language is found.
-    if (!storedLanguage && defaultLanguage) {
+
+    if (!defaultLanguage) {
+      i18n.use(LanguageDetector);
+    }
+
+    await i18n.init(initOpts);
+
+    if (defaultLanguage) {
       i18n.changeLanguage(defaultLanguage);
     }
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -14,7 +14,6 @@ export const initOpts: InitOptions = {
   interpolation: {
     escapeValue: false
   },
-  // supportedLngs: ['de', 'en'],
   returnNull: false
 };
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,24 +1,27 @@
-import i18n from 'i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
+import i18n, {
+  InitOptions
+} from 'i18next';
 import {
   initReactI18next
 } from 'react-i18next';
 
 import resources from './translations';
 
+export const initOpts: InitOptions = {
+  resources,
+  fallbackLng: 'en',
+  debug: false,
+  interpolation: {
+    escapeValue: false
+  },
+  // supportedLngs: ['de', 'en'],
+  returnNull: false
+};
+
 // eslint-disable-next-line import/no-named-as-default-member
 i18n
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
-    resources,
-    fallbackLng: 'en',
-    debug: false,
-    interpolation: {
-      escapeValue: false
-    },
-    supportedLngs: ['de', 'en'],
-    returnNull: false
-  });
+  .use(initReactI18next);
+
+i18n.options = initOpts;
 
 export default i18n;


### PR DESCRIPTION
Follow-up fix of #813 :  
If `defaultLanguage` is set, no LanguageDetector should be use.  
Then the initialization of i18n must be done **after** `LanguageDetector` plugin has been added.  

Big Thanks to @dnlkoch 

@terrestris/devs 