### PR TITLE
feat: use print app of current language code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ We recommend to install the client via the prebuilt Docker image `docker-public.
 Even if the client can be used without any backend providing a context configuration, it is designed to run on top of a [SHOGun backend](https://github.com/terrestris/shogun) while reading the configuration from the [`/applications`](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/terrestris/shogun/gh-pages/api/swagger.json#/application-controller)  REST interface. To specify a configuration the query parameter `applicationId` must be set (e.g. `https://localhost/client/?applicationId=18` to get the configuration for the application with the ID 18).
 If no ID is given (e.g. because no backend is available) or the requested application is not accessible, the client will load a fallback configuration.
 
+### Print
+To use print apps for different languages just name them after the language code (`ISO_639-1`). The print app that has the name of the currently selected language will be used.
+
 ## Configuration 🎨
 
 Several global settings for the client can be configured via the [`gis-client-config.js`](https://github.com/terrestris/shogun-gis-client/blob/main/resources/config/gis-client-config.js) file:

--- a/src/components/PrintForm/index.tsx
+++ b/src/components/PrintForm/index.tsx
@@ -165,7 +165,7 @@ export const PrintForm: React.FC<PrintFormProps> = ({
       const apps = await pManager.getPrintApps();
 
       if (apps && currentLanguageCode && apps.includes(currentLanguageCode)) {
-        pManager.setPrintApp(currentLanguageCode);
+        await pManager.setPrintApp(currentLanguageCode);
       }
 
       pManager.setOutputFormat(pManager.getOutputFormats()[0]);

--- a/src/components/PrintForm/index.tsx
+++ b/src/components/PrintForm/index.tsx
@@ -177,7 +177,7 @@ export const PrintForm: React.FC<PrintFormProps> = ({
       setErrorMsg(() => t('PrintForm.managerErrorMessage'));
       Logger.error('Could not initialize print manager: ', error);
     }
-  }, [customParams, customMapParams, client, layerFilter, legendFilter, map, t, customPrintScales]);
+  }, [customParams, customMapParams, client, layerFilter, legendFilter, map, t, customPrintScales, currentLanguageCode]);
 
   useEffect(() => {
     if (active) {

--- a/src/components/PrintForm/index.tsx
+++ b/src/components/PrintForm/index.tsx
@@ -68,10 +68,13 @@ export const PrintForm: React.FC<PrintFormProps> = ({
 
   const [form] = Form.useForm();
   const {
-    t
+    t,
+    i18n
   } = useTranslation();
 
   const map = useMap();
+
+  const currentLanguageCode = i18n.language;
 
   const client = useSHOGunAPIClient();
 
@@ -156,6 +159,14 @@ export const PrintForm: React.FC<PrintFormProps> = ({
 
     try {
       await pManager.init();
+
+      // Use locale print app if available.
+      // Implies that a print app with the language code exists.
+      const apps = await pManager.getPrintApps();
+
+      if (apps && currentLanguageCode && apps.includes(currentLanguageCode)) {
+        pManager.setPrintApp(currentLanguageCode);
+      }
 
       pManager.setOutputFormat(pManager.getOutputFormats()[0]);
       pManager.setDpi(pManager.getDpis()[0]);


### PR DESCRIPTION
### Use Case
One or more print apps of specific language where `print app name === languageCode`.

### Solution
When initializing the print manager, check if print apps has an app that has the same name as the current language code and set it as active print app.

@terrestris/devs what do you think?

