### PR TITLE
Disable checking login status in iframe

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -277,7 +277,8 @@ const initKeycloak = async () => {
   };
 
   await keycloak.init({
-    onLoad: keycloakOnLoad
+    onLoad: keycloakOnLoad,
+    checkLoginIframe: false
   });
 
   return keycloak;


### PR DESCRIPTION
This fixes the reloading loop in some browsers (e.g. Firefox) by disabling checking the login status in an iframe.

See [here](https://www.keycloak.org/docs/latest/securing_apps/index.html#session-status-iframe) for further details.

Please review @terrestris/devs.