### PR TITLE
Introduce multi search component

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -84,6 +84,9 @@ import {
   setLogoPath
 } from './store/logoPath';
 import {
+  setSearchEngines
+} from './store/searchEngines';
+import {
   createReducer,
   store
 } from './store/store';
@@ -210,15 +213,20 @@ const setApplicationToStore = async (application?: Application) => {
     store.dispatch(setLogoPath(application.clientConfig.theme.logoPath));
   }
 
+  // nominatim search is active by default
+  store.dispatch(setSearchEngines(['nominatim']));
+
   if (application.toolConfig && application.toolConfig.length > 0) {
     const availableTools: string[] = [];
     application.toolConfig
       .map((tool: DefaultApplicationToolConfig) => {
-        if (tool.config.visible) {
+        if (tool.config.visible && tool.name !== 'search') {
           availableTools.push(tool.name);
         }
+        if (tool.name === 'search' && tool.config.engines.length > 0) {
+          store.dispatch(setSearchEngines(tool.config.engines));
+        }
       });
-
     store.dispatch(setAvailableTools(availableTools));
   }
 };

--- a/src/components/Header/index.less
+++ b/src/components/Header/index.less
@@ -39,10 +39,6 @@
       flex: 1;
       display: flex;
       justify-content: center;
-
-      .react-geo-nominatimsearch.ant-select-auto-complete {
-        width: 60%;
-      }
     }
 
     &.right-items {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -11,8 +11,7 @@ import {
   HeaderPlacementOrientation,
   isHeaderIntegration
 } from '../../plugin';
-
-import BasicNominatimSearch from '../BasicNominatimSearch';
+import SearchField from '../SearchField';
 
 import UserMenu from '../UserMenu';
 
@@ -67,7 +66,7 @@ export const Header: React.FC<HeaderProps> = ({
 
   const getCenterItems = () => {
     const items = [
-      <BasicNominatimSearch
+      <SearchField
         key="search"
       />
     ];

--- a/src/components/MultiSearch/index.less
+++ b/src/components/MultiSearch/index.less
@@ -1,0 +1,58 @@
+.search {
+
+  position: relative;
+
+  span.ant-input-group-addon {
+    background-color: var(--secondaryColor);
+
+    span.anticon {
+      color: var(--primaryColor);
+    }
+  }
+
+  >div {
+    .search-result-div {
+      box-shadow: var(--componentShadow);
+      margin-top: 2px;
+      top: unset;
+      width: 100%;
+
+      .ant-collapse {
+
+        overflow-y: unset;
+
+        .ant-collapse-header {
+          line-height: unset;
+          border-bottom: solid 1px var(--secondaryColor);
+          background-color: color-mix(in srgb, var(--secondaryColor) 15%, white);
+        }
+
+        .ant-collapse-content {
+          max-height: 25vh;
+          overflow-y: auto;
+
+          .ant-list-item {
+            justify-content: flex-start;
+
+            .result-prefix:not(:empty) {
+              width: 130px;
+
+              .ant-tag {
+                width: 100%;
+                text-align: center;
+              }
+            }
+          }
+        }
+
+      }
+
+    }
+
+    .no-search-result-div {
+      background-color: white;
+      position: absolute;
+      width: 100%;
+    }
+  }
+}

--- a/src/components/MultiSearch/index.spec.tsx
+++ b/src/components/MultiSearch/index.spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import {
+  render
+} from '@testing-library/react';
+
+import { createReduxWrapper } from '../../utils/testUtils';
+
+import MultiSearch from './index';
+
+describe('<MultiSearch />', () => {
+
+  it('is defined', () => {
+    expect(MultiSearch).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(
+      <MultiSearch
+        useNominatim={true}
+      />, {
+        wrapper: createReduxWrapper()
+      }
+    );
+    expect(container).toBeVisible();
+  });
+
+});

--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -1,0 +1,440 @@
+import React, {
+  useCallback,
+  useEffect, useMemo, useRef, useState
+} from 'react';
+
+import {
+  SearchOutlined,
+  SettingOutlined,
+  LoadingOutlined
+} from '@ant-design/icons';
+import {
+  Checkbox,
+  Dropdown,
+  Empty,
+  Input,
+  InputProps,
+  Tag
+} from 'antd';
+
+import _debounce from 'lodash/debounce';
+import _groupBy from 'lodash/groupBy';
+import _isArray from 'lodash/isArray';
+
+import {
+  Extent as OlExtent
+} from 'ol/extent';
+import OlFeature from 'ol/Feature';
+import OlFormatGeoJSON from 'ol/format/GeoJSON';
+import OlFormatWKT from 'ol/format/WKT';
+import OlGeometry from 'ol/geom/Geometry';
+import { transformExtent } from 'ol/proj';
+import OlStyleCircle from 'ol/style/Circle';
+import OlStyleFill from 'ol/style/Fill';
+import OlStyleStroke from 'ol/style/Stroke';
+import OlStyle from 'ol/style/Style';
+
+import {
+  useTranslation
+} from 'react-i18next';
+
+import logger from '@terrestris/base-util/dist/Logger';
+
+import { NominatimPlace } from '@terrestris/react-geo/dist/Field/NominatimSearch/NominatimSearch';
+import useMap from '@terrestris/react-geo/dist/Hook/useMap';
+import SearchResultsPanel, {
+  Category as ResultCategory
+} from '@terrestris/react-geo/dist/Panel/SearchResultsPanel/SearchResultsPanel';
+
+import './index.less';
+
+interface MultiSearchProps extends InputProps {
+  useNominatim: boolean;
+  delay?: number;
+  minChars?: number;
+  solrSearchBasePath?: string;
+};
+
+export type DataSearchResult = {
+  [key: string]: string | string[] | number[];
+};
+
+export const MultiSearch: React.FC<MultiSearchProps> = ({
+  useNominatim,
+  delay = 1000,
+  minChars = 3,
+  solrSearchBasePath = '/search/query'
+}): JSX.Element => {
+
+  const map = useMap();
+  const {
+    t
+  } = useTranslation();
+  const clickAwayRef = useRef<HTMLDivElement>(null);
+
+  const [searchNominatim, setSearchNominatim] = useState<boolean>(useNominatim);
+  const [searchData, setSearchData] = useState<boolean>(true);
+  const [useViewBox, setUseViewBox] = useState<boolean>(true);
+  const [searchValue, setSearchValue] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(false);
+  const [resultsVisible, setResultsVisible] = useState<boolean>(false);
+  const [settingsVisible, setSettingsVisible] = useState<boolean>(false);
+  const [dataSearchResults, setDataSearchResults] = useState<DataSearchResult[]>([]);
+  const [nominatimResults, setNominatimResults] = useState<NominatimPlace[]>([]);
+  const [searchResults, setSearchResults] = useState<ResultCategory[]>([]);
+
+  useEffect(() => {
+    window.addEventListener('mousedown', handleClickAway);
+
+    return () => {
+      window.removeEventListener('mousedown', handleClickAway);
+    };
+  }, []);
+
+  const handleClickAway = (e: Event) => {
+    const parents = [];
+    let target = e.target;
+    while (target) {
+      parents.unshift(target);
+      target = (target as Node).parentNode;
+    }
+
+    if ((clickAwayRef.current && ((clickAwayRef.current as Element).contains(e.target as Node)))) {
+      return;
+    }
+
+    setResultsVisible(false);
+  };
+
+  const settingsMenu = useMemo(() => {
+    return {
+      items: [{
+        label: (
+          <Checkbox
+            checked={useViewBox}
+            onChange={e => setUseViewBox(e.target.checked)}
+          >
+            {t('MultiSearch.searchInViewBox')}
+          </Checkbox>
+        ),
+        key: 'viewbox'
+      }, {
+        label: (
+          <Checkbox
+            checked={searchData}
+            onChange={e => setSearchData(e.target.checked)}
+          >
+            {t('MultiSearch.searchData')}
+          </Checkbox>
+        ),
+        key: 'data'
+      }, {
+        label: (
+          <Checkbox
+            checked={searchNominatim}
+            onChange={e => setSearchNominatim(e.target.checked)}
+          >
+            {t('MultiSearch.searchNominatim')}
+          </Checkbox>
+        ),
+        key: 'nominatim'
+      }]
+    };
+  }, [searchData, searchNominatim, useViewBox, t]);
+
+  const performSearch = useCallback(async () => {
+
+    if (searchValue.length < minChars) {
+      resetSearch();
+      return;
+    }
+
+    if (!searchData && !searchNominatim) {
+      return;
+    }
+
+    setLoading(true);
+    setNominatimResults([]);
+    setDataSearchResults([]);
+
+    let response;
+    let viewBox: OlExtent | null = null;
+
+    if (useViewBox) {
+      const mapViewProjection = map?.getView().getProjection();
+      const extent = map?.getView()?.calculateExtent();
+      if (extent) {
+        viewBox = transformExtent(extent, mapViewProjection, 'EPSG:4326');
+      }
+    }
+
+    if (searchData) {
+      try {
+        let parts = searchValue.trim()
+          .replaceAll(/[()\\\-_./\/]/g, ' ').split(' ')
+          .filter(s => s.trim() !== '');
+
+        const partsQuery = parts.map(
+          (part: string) => `(search:${part.trim()}*^3 OR search:*${part.trim()}*^2 OR search:${part.trim()}~1)`
+        );
+        const searchUrl = new URL(`${window.location.origin}${solrSearchBasePath}`);
+
+        const query = `search:\"${searchValue.trim()}\" OR (${partsQuery.join(' AND ')})`;
+
+        if (useViewBox && viewBox) {
+          const bboxFilter = `geometry:[${viewBox[1]},${viewBox[0]} TO ${viewBox[3]},${viewBox[2]}]`;
+          searchUrl.searchParams.set('fq', bboxFilter);
+        }
+
+        searchUrl.searchParams.set('q', query);
+        response = await fetch(searchUrl.href);
+
+        const dataJson = await response.json();
+        setDataSearchResults(dataJson?.response?.docs);
+      } catch (error) {
+        setDataSearchResults([]);
+        logger.error('Error while fetching the layer search results: ', error);
+      } finally {
+        if (!searchNominatim) {
+          setLoading(false);
+        }
+      }
+    }
+
+    if (searchNominatim) {
+      try {
+        const nominatimUrl = new URL('https://nominatim.terrestris.de/search');
+        nominatimUrl.searchParams.set('q', searchValue);
+        nominatimUrl.searchParams.set('format', 'json');
+        nominatimUrl.searchParams.set('polygon_geojson', '1');
+
+        if (useViewBox && viewBox) {
+          nominatimUrl.searchParams.set('viewbox', viewBox.toString());
+          nominatimUrl.searchParams.set('bounded', '1');
+        }
+        response = await fetch(nominatimUrl.href);
+        setNominatimResults(await response.json());
+      }
+      catch (error) {
+        setNominatimResults([]);
+        logger.error('Error while fetching the nominatim results: ', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+  }, [searchValue, minChars, useViewBox, searchData, searchNominatim, map, solrSearchBasePath]);
+
+  const getFeatureTitle = useCallback((dsResult: DataSearchResult): string => {
+
+    const blacklistedAttributes = [
+      'id',
+      'search',
+      'geometry',
+      'category'
+    ];
+
+    let title: string = '';
+
+    // for now, we will use the first attribute that matches the search term.
+    // perspectively we will switch to the search configuration config which will
+    // provide a display template for the feature title among other things
+    Object.keys(dsResult)
+      .filter(key => !blacklistedAttributes.includes(key))
+      .forEach(propKey => {
+        let propValue = dsResult[propKey]?.toString();
+        if (!title && propValue.toLowerCase().indexOf(searchValue?.toLowerCase()) > -1) {
+          // show matched value followed by the attribute name in square brackets (e.g. '53111 Bonn [city]')
+          title = `${propValue} [${propKey}]`;
+        }
+      });
+
+    if (!title) {
+      // fallback -> should never happen after adding of the valid layer search config
+      title = dsResult.id as string;
+    }
+
+    return title;
+
+  }, [searchValue]);
+
+  useEffect(() => {
+
+    if (!map) {
+      return;
+    }
+
+    let updatedResults: ResultCategory[] = [];
+
+    if (nominatimResults.length > 0) {
+
+      const geoJsonFormat = new OlFormatGeoJSON();
+      const nFeats = nominatimResults.map(f => {
+        const olFeat = geoJsonFormat.readFeature(f.geojson, {
+          dataProjection: 'EPSG:4326',
+          featureProjection: map.getView().getProjection()
+        });
+        olFeat.set('title', f.display_name);
+        return olFeat;
+      });
+
+      const nResults: ResultCategory = {
+        title: t('MultiSearch.nominatimTitle'),
+        features: nFeats
+      };
+      updatedResults.push(nResults);
+    }
+
+    if (dataSearchResults.length > 0) {
+
+      const wktFormat = new OlFormatWKT();
+      // 1. group by category
+      const categories = _groupBy(dataSearchResults, res => res.category[0]);
+      // 2. build features
+      Object.keys(categories).forEach(category => {
+        const features = categories[category].map(dsResult => {
+          if (!dsResult.geometry?.[0]) {
+            return;
+          }
+          const id = dsResult.id as string;
+          const geometry = wktFormat.readGeometry(dsResult.geometry[0], {
+            dataProjection: 'EPSG:4326',
+            featureProjection: map.getView().getProjection()
+          });
+          const olFeat = new OlFeature({
+            geometry
+          });
+          olFeat.set('title', getFeatureTitle(dsResult));
+          olFeat.set('ftName', id.substring(0, id.lastIndexOf('_')));
+          return olFeat;
+        }).filter(f => f) as OlFeature<OlGeometry>[];
+        const resultCategory: ResultCategory = {
+          title: category,
+          features
+        };
+        updatedResults.push(resultCategory);
+      });
+
+    }
+
+    setResultsVisible(true);
+    setSearchResults(updatedResults);
+
+  }, [dataSearchResults, getFeatureTitle, map, nominatimResults, t]);
+
+  useEffect(() => {
+
+    const timeout = setTimeout(() => {
+      performSearch();
+    }, delay);
+
+    return () => clearTimeout(timeout);
+
+  }, [performSearch, delay]);
+
+  const resetSearch = () => {
+    setDataSearchResults([]);
+    setNominatimResults([]);
+  };
+
+  const listPrefixRenderer = (item: any) => {
+    const {
+      feature
+    } = item;
+
+    const ftName = feature.get('ftName');
+
+    if (!ftName) {
+      return <></>;
+    }
+
+    return <Tag>{ftName}</Tag>;
+  };
+
+  const resultRenderer = () => {
+
+    if (searchValue.length < 2 || !resultsVisible || loading) {
+      return null;
+    }
+
+    const numTotal = nominatimResults.length + dataSearchResults.length;
+
+    if (numTotal === 0) {
+      return (
+        <div
+          className='no-search-result-div'
+        >
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <SearchResultsPanel
+        searchResults={searchResults}
+        numTotal={numTotal}
+        accordion
+        searchTerms={searchValue.split(' ')}
+        listPrefixRenderer={listPrefixRenderer}
+        layerStyle={
+          new OlStyle({
+            stroke: new OlStyleStroke({
+              color: 'rgb(255,0,0)',
+              width: 2
+            }),
+            fill: new OlStyleFill({
+              color: 'rgba(255,255,255, 0.5)'
+            }),
+            image: new OlStyleCircle({
+              radius: 10,
+              fill: new OlStyleFill({
+                color: 'rgba(255,255,255, 0.5)'
+              }),
+              stroke: new OlStyleStroke({
+                color: 'rgb(255,0,0)',
+                width: 3
+              })
+            })
+          })
+        }
+      />
+    );
+  };
+
+  if (!map) {
+    return <></>;
+  }
+
+  return (
+    <div ref={clickAwayRef}>
+      <Input
+        value={searchValue}
+        disabled={!searchData && !searchNominatim}
+        onChange={event => {
+          setLoading(event.target.value !== '');
+          setSearchValue(event.target.value);
+        }}
+        allowClear
+        addonAfter={
+          <Dropdown
+            placement="bottomRight"
+            menu={settingsMenu}
+            trigger={['click']}
+            onOpenChange={setSettingsVisible}
+            open={settingsVisible}
+          >
+            <SettingOutlined />
+          </Dropdown >
+        }
+        onFocus={() => setResultsVisible(true)}
+        placeholder={t('MultiSearch.searchPlaceholder')}
+        prefix={<SearchOutlined />}
+        suffix={loading ? <LoadingOutlined /> : null}
+      />
+      {resultRenderer()}
+    </div>
+  );
+};
+
+export default MultiSearch;

--- a/src/components/SearchField/index.less
+++ b/src/components/SearchField/index.less
@@ -1,0 +1,3 @@
+.search {
+  width: 60%;
+}

--- a/src/components/SearchField/index.spec.tsx
+++ b/src/components/SearchField/index.spec.tsx
@@ -1,0 +1,9 @@
+import SearchField from './index';
+
+describe('<SearchField />', () => {
+
+  it('is defined', () => {
+    expect(SearchField).not.toBeUndefined();
+  });
+
+});

--- a/src/components/SearchField/index.tsx
+++ b/src/components/SearchField/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import {
+  InputProps
+} from 'antd/lib/input';
+
+import logger from '@terrestris/base-util/dist/Logger';
+
+import useAppSelector from '../../hooks/useAppSelector';
+import BasicNominatimSearch from '../BasicNominatimSearch';
+import MultiSearch from '../MultiSearch';
+
+import './index.less';
+
+interface SearchFieldProps extends InputProps { };
+
+export const SearchField: React.FC<SearchFieldProps> = (): JSX.Element => {
+
+  const useNominatim = useAppSelector((state) => state.searchEngines.includes('nominatim'));
+  const useSolr = useAppSelector((state) => state.searchEngines.includes('solr'));
+
+  if (!useNominatim && !useSolr) {
+    logger.warn('Neither nominatim nor solr search is configured.');
+    return <></>;
+  }
+
+  return (
+    <div className="search">
+      {
+        useSolr ?
+          <MultiSearch
+            useNominatim={useNominatim}
+          /> :
+          <BasicNominatimSearch />
+      }
+    </div>
+  );
+};
+
+export default SearchField;

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -137,6 +137,13 @@ export default {
           supportedFormats: 'Der Dateityp ist nicht unterstützt ({{supportedFormats}})',
           zipContent: 'Mehrere Geodatensätze innerhalb eines Archivs sind nicht unterstützt'
         }
+      },
+      MultiSearch: {
+        searchInViewBox: 'Im aktuellen Kartenausschnitt suchen',
+        searchData: 'Layerdaten durchsuchen',
+        searchNominatim: 'Ortssuche (Nominatim)',
+        nominatimTitle: 'Ortssuche',
+        searchPlaceholder: 'Orts- und Datensuche…'
       }
     }
   },
@@ -277,6 +284,13 @@ export default {
           supportedFormats: 'The given file type does not match the supported ones ({{supportedFormats}})',
           zipContent: 'Multiple geodatasets within one archive are not supported'
         }
+      },
+      MultiSearch: {
+        searchInViewBox: 'Search in current extent',
+        searchData: 'Search layer data',
+        searchNominatim: 'Search nominatim',
+        nominatimTitle: 'Nominatim',
+        searchPlaceholder: 'Address and data search…'
       }
     }
   }

--- a/src/store/searchEngines/index.ts
+++ b/src/store/searchEngines/index.ts
@@ -1,0 +1,22 @@
+import {
+  createSlice,
+  PayloadAction
+} from '@reduxjs/toolkit';
+
+const initialState: string[] = ['nominatim'];
+
+export const slice = createSlice({
+  name: 'searchEngines',
+  initialState,
+  reducers: {
+    setSearchEngines: (state, action: PayloadAction<string[]>) => {
+      return action.payload;
+    }
+  }
+});
+
+export const {
+  setSearchEngines
+} = slice.actions;
+
+export default slice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -10,6 +10,7 @@ import description from './description';
 import legal from './legal';
 import logoPath from './logoPath';
 import print from './print';
+import searchEngines from './searchEngines';
 import selectedFeatures from './selectedFeatures';
 import title from './title';
 import toolMenu from './toolMenu';
@@ -32,6 +33,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     title,
     toolMenu,
     uploadDataModal,
+    searchEngines,
     user,
     ...asyncReducers
   });


### PR DESCRIPTION
Add possibility to search the layer data via custom search engines (currently only Apache Solr is supported).

This search can be combined with already implemented nonimatim search - the configured engines can be (de)activated on demand via the settings menu in client. Additionally, the search query can be restricted by the visible map extent.

![image](https://github.com/terrestris/shogun-gis-client/assets/3939355/b7e0f80f-cfc8-43bb-a5d3-82371222f290)

To get the things work, the search engines should be configured for the certain application via `toolConfig` as follows:
```
toolConfig: [
  {...},
  {
    "name": "search",
    "config": {
      "engines": [
        "nominatim",
        "solr"
      ]
    }
  },
  {...}
]
```

If no engines are configured, the `nominatim` search will be available by default to keep the existing client behaviour unchanged.

Using of the `solr` assumes that the search engine is available and the data index is prepared.

At the moment, there is no possibility to configure, which layers and which attributes of these layers should be scanned while searching. This feature will be added in the followups.

Please review @terrestris/devs 