### PR TITLE
Introduce layer details modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import AddLayerModal from './components/AddLayerModal/index';
 import BasicMapComponent from './components/BasicMapComponent';
 import Footer from './components/Footer';
 import Header from './components/Header';
+import LayerDetailsModal from './components/LayerDetailsModal';
 import ToolMenu from './components/ToolMenu';
 import UploadDataModal from './components/UploadDataModal';
 
@@ -36,6 +37,7 @@ export const App: React.FC<AppProps> = ({
       <Footer />
       <AddLayerModal />
       <UploadDataModal />
+      <LayerDetailsModal />
     </div>
   );
 };

--- a/src/components/LayerDetailsModal/LayerConfiguration/index.less
+++ b/src/components/LayerDetailsModal/LayerConfiguration/index.less
@@ -1,0 +1,4 @@
+.layer-configuration {
+  max-height: calc(100vh - 256px);
+  overflow: auto;
+}

--- a/src/components/LayerDetailsModal/LayerConfiguration/index.spec.tsx
+++ b/src/components/LayerDetailsModal/LayerConfiguration/index.spec.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import {
+  render
+} from '@testing-library/react';
+
+import LayerConfiguration from './index';
+
+describe('<LayerConfiguration />', () => {
+
+  it('is defined', () => {
+    expect(LayerConfiguration).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(<LayerConfiguration />);
+
+    expect(container).toBeVisible();
+  });
+
+});

--- a/src/components/LayerDetailsModal/LayerConfiguration/index.tsx
+++ b/src/components/LayerDetailsModal/LayerConfiguration/index.tsx
@@ -1,0 +1,96 @@
+import React, {
+  useState,
+  useEffect,
+  useCallback
+} from 'react';
+
+import {
+  Alert,
+  Spin
+} from 'antd';
+
+import OlLayer from 'ol/layer/Layer';
+
+import {
+  useTranslation
+} from 'react-i18next';
+
+import Logger from '@terrestris/base-util/dist/Logger';
+
+import Layer from '@terrestris/shogun-util/dist/model/Layer';
+
+import useSHOGunAPIClient from '../../../hooks/useSHOGunAPIClient';
+
+import './index.less';
+
+export type LayerConfigurationProps = React.ComponentProps<'pre'> & {
+  layer?: OlLayer;
+};
+
+export const LayerConfiguration: React.FC<LayerConfigurationProps> = ({
+  layer,
+  ...restProps
+}): JSX.Element => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const [layerConfiguration, setLayerConfiguration] = useState<Layer>();
+
+  const client = useSHOGunAPIClient();
+
+  const {
+    t
+  } = useTranslation();
+
+  const getLayerConfiguration = useCallback(async () => {
+    try {
+      setLoading(true);
+      setErrorMessage('');
+
+      if (!layer || !layer.get('shogunId')) {
+        throw new Error('No layer provided or the layer has no shogunId set');
+      }
+
+      const conf = await client?.layer().findOne(layer.get('shogunId'));
+
+      setLayerConfiguration(conf);
+    } catch (error) {
+      Logger.error(error);
+      setErrorMessage(t('LayerConfiguration.errorMessage'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t, client, layer]);
+
+  useEffect(() => {
+    getLayerConfiguration();
+  }, [getLayerConfiguration]);
+
+  if (errorMessage) {
+    return (
+      <Alert
+        type="error"
+        closable={true}
+        message={errorMessage}
+      />
+    );
+  }
+
+  return (
+    <Spin
+      spinning={loading}
+    >
+      <pre
+        className="layer-configuration"
+        {...restProps}
+      >
+        <code>
+          {
+            JSON.stringify(layerConfiguration, null, '  ')
+          }
+        </code>
+      </pre>
+    </Spin>
+  );
+};
+
+export default LayerConfiguration;

--- a/src/components/LayerDetailsModal/LayerDetails/index.less
+++ b/src/components/LayerDetailsModal/LayerDetails/index.less
@@ -1,0 +1,4 @@
+.layer-details {
+  max-height: calc(100vh - 242px);
+  overflow: auto;
+}

--- a/src/components/LayerDetailsModal/LayerDetails/index.spec.tsx
+++ b/src/components/LayerDetailsModal/LayerDetails/index.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import {
+  render
+} from '@testing-library/react';
+
+import LayerDetails from './index';
+
+describe('<LayerDetails />', () => {
+
+  it('is defined', () => {
+    expect(LayerDetails).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(<LayerDetails />);
+
+    expect(container).toBeVisible();
+  });
+});

--- a/src/components/LayerDetailsModal/LayerDetails/index.tsx
+++ b/src/components/LayerDetailsModal/LayerDetails/index.tsx
@@ -1,0 +1,282 @@
+import React, {
+  useState,
+  useEffect,
+  useCallback
+} from 'react';
+
+import {
+  Alert,
+  Form,
+  FormProps,
+  Spin
+} from 'antd';
+
+import OlLayerImage from 'ol/layer/Image';
+import OlLayer from 'ol/layer/Layer';
+import OlLayerTile from 'ol/layer/Tile';
+import OlSourceImageWMS from 'ol/source/ImageWMS';
+import OlSourceTileWMS from 'ol/source/TileWMS';
+
+import {
+  useTranslation
+} from 'react-i18next';
+
+import Logger from '@terrestris/base-util/dist/Logger';
+import UrlUtil from '@terrestris/base-util/dist/UrlUtil/UrlUtil';
+
+import CapabilitiesUtil from '@terrestris/ol-util/dist/CapabilitiesUtil/CapabilitiesUtil';
+
+import {
+  isWmsLayer
+} from '@terrestris/react-geo/dist/Util/typeUtils';
+
+import {
+  getBearerTokenHeader
+} from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
+
+import useSHOGunAPIClient from '../../../hooks/useSHOGunAPIClient';
+
+import './index.less';
+
+export type LayerDetailsProps = Partial<FormProps> & {
+  layer?: OlLayer;
+};
+
+export const LayerDetails: React.FC<LayerDetailsProps> = ({
+  layer,
+  ...restProps
+}): JSX.Element => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [capabilities, setCapabilities] = useState<any>();
+  const [errorMessage, setErrorMessage] = useState<string>();
+
+  const client = useSHOGunAPIClient();
+
+  const {
+    t
+  } = useTranslation();
+
+  const getCapabilities = useCallback(async () => {
+    if (!layer || !isWmsLayer(layer)) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setErrorMessage('');
+
+      const capa = await CapabilitiesUtil.getWmsCapabilitiesByLayer(
+        (layer as OlLayerImage<OlSourceImageWMS> | OlLayerTile<OlSourceTileWMS>), {
+          headers: {
+            ...layer.get('useBearerToken') ? {
+              ...getBearerTokenHeader(client?.getKeycloak())
+            } : undefined
+          }
+        });
+
+      setCapabilities(capa);
+    } catch (error) {
+      Logger.error(error);
+      setErrorMessage(t('LayerDetails.errorMessage'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t, client, layer]);
+
+  useEffect(() => {
+    getCapabilities();
+  }, [getCapabilities]);
+
+  const getLayerName = () => {
+    if (!layer) {
+      return;
+    }
+
+    if (isWmsLayer(layer)) {
+      return layer.getSource()?.getParams().LAYERS;
+    }
+  };
+
+  const getCapabilitiesUrl = () => {
+    if (!layer) {
+      return;
+    }
+
+    if (isWmsLayer(layer)) {
+      let layerUrl;
+      if (layer.getSource() instanceof OlSourceImageWMS) {
+        layerUrl = (layer.getSource() as OlSourceImageWMS).getUrl();
+      }
+      if (layer.getSource() instanceof OlSourceTileWMS) {
+        const urls = (layer.getSource() as OlSourceTileWMS).getUrls();
+        layerUrl = urls ? urls[0] : undefined;
+      }
+
+      if (layerUrl) {
+        return UrlUtil.createValidGetCapabilitiesRequest(layerUrl, 'WMS', '1.3.0');
+      }
+    }
+  };
+
+  const getCapabilitiesLayer = () => {
+    const layers: any[] = capabilities?.Capability?.Layer?.Layer;
+    const layerName = getLayerName();
+
+    const lay = layers?.find(l => l.Name === layerName);
+
+    return lay;
+  };
+
+  const getBBox = () => {
+    const lay = getCapabilitiesLayer();
+
+    if (!lay) {
+      return;
+    }
+
+    return lay.EX_GeographicBoundingBox?.join(', ');
+  };
+
+  const getMinScale = () => {
+    const lay = getCapabilitiesLayer();
+
+    if (!lay) {
+      return;
+    }
+
+    return lay.MinScaleDenominator;
+  };
+
+  const getMaxScale = () => {
+    const lay = getCapabilitiesLayer();
+
+    if (!lay) {
+      return;
+    }
+
+    return lay.MaxScaleDenominator;
+  };
+
+  const getAbstract = () => {
+    const lay = getCapabilitiesLayer();
+
+    if (!lay) {
+      return;
+    }
+
+    return lay.Abstract;
+  };
+
+  const getServiceAbstract = () => {
+    return capabilities?.Service?.Abstract;
+  };
+
+  const getContact = () => {
+    return capabilities?.Service?.ContactInformation?.ContactElectronicMailAddress;
+  };
+
+  const getLayerTitle = () => {
+    const lay = getCapabilitiesLayer();
+
+    if (!lay) {
+      return;
+    }
+
+    return lay.Title;
+  };
+
+  const getAccessConstraints = () => {
+    return capabilities?.Service?.AccessConstraints;
+  };
+
+  if (errorMessage) {
+    return (
+      <Alert
+        type="error"
+        closable={true}
+        message={errorMessage}
+      />
+    );
+  }
+
+  return (
+    <Spin
+      spinning={loading}
+    >
+      <Form
+        className="layer-details"
+        layout="horizontal"
+        size="small"
+        labelAlign="left"
+        labelWrap={true}
+        labelCol={{
+          flex: '150px'
+        }}
+        {...restProps}
+      >
+        <Form.Item
+          name="layerName"
+          label={t('LayerDetails.layerNameLabel')}
+        >
+          <span>{getLayerName() ? getLayerName() : t('LayerDetails.noDataPlaceholder')}</span>
+        </Form.Item>
+        <Form.Item
+          name="layerTitle"
+          label={t('LayerDetails.layerTitleLabel')}
+        >
+          <span>{getLayerTitle() ? getLayerTitle() : t('LayerDetails.noDataPlaceholder')}</span>
+        </Form.Item>
+        <Form.Item
+          name="service-abstract"
+          label={t('LayerDetails.serviceAbstractLabel')}
+        >
+          <span>{getServiceAbstract() ? getServiceAbstract() : t('LayerDetails.noDataPlaceholder')}</span>
+        </Form.Item>
+        <Form.Item
+          name="abstract"
+          label={t('LayerDetails.abstractLabel')}
+        >
+          <span>{getAbstract() ? getAbstract() : t('LayerDetails.noDataPlaceholder')}</span>
+        </Form.Item>
+        <Form.Item
+          name="accessConstraints"
+          label={t('LayerDetails.accessConstraintsLabel')}
+        >
+          <span>{getAccessConstraints() ? getAccessConstraints() : t('LayerDetails.noDataPlaceholder')}</span>
+        </Form.Item>
+        <Form.Item
+          name="CapabilitiesUrl"
+          label={t('LayerDetails.capabilitiesUrlLabel')}
+        >
+          <a href={getCapabilitiesUrl()}>{getCapabilitiesUrl()}</a>
+        </Form.Item>
+        <Form.Item
+          name="contact"
+          label={t('LayerDetails.contactLabel')}
+        >
+          {getContact() ? <a href={`mailto:${getContact()}`}>{getContact()}</a> : <span>{t('LayerDetails.noDataPlaceholder')}</span>}
+        </Form.Item>
+        <Form.Item
+          name="minScale"
+          label={t('LayerDetails.minScaleLabel')}
+        >
+          <span>{getMinScale() ? getMinScale() : t('LayerDetails.noDataPlaceholder')}</span>
+        </Form.Item>
+        <Form.Item
+          name="maxScale"
+          label={t('LayerDetails.maxScaleLabel')}
+        >
+          <span>{getMaxScale() ? getMaxScale() : t('LayerDetails.noDataPlaceholder')}</span>
+        </Form.Item>
+        <Form.Item
+          name="bbox"
+          label={t('LayerDetails.bboxLabel')}
+        >
+          <span>{getBBox() ? getBBox() : t('LayerDetails.noDataPlaceholder')}</span>
+        </Form.Item>
+      </Form>
+    </Spin>
+  );
+};
+
+export default LayerDetails;

--- a/src/components/LayerDetailsModal/index.less
+++ b/src/components/LayerDetailsModal/index.less
@@ -1,0 +1,33 @@
+.layer-details-modal {
+  top: var(--headerHeight);
+  padding: 24px 0;
+
+  .ant-modal-content {
+    .ant-modal-header {
+      .title-group {
+        .pressed {
+          color: white;
+          background-color: gray;
+        };
+
+        button {
+          position: absolute;
+          top: 0;
+          right: 55px;
+          height: 54px;
+          width: 54px;
+          color: rgba(0, 0, 0, .45);
+          border: 0;
+          outline: 0;
+          padding: 0;
+        }
+      }
+    }
+
+    .ant-modal-body {
+      .ant-alert {
+        margin-bottom: 15px;
+      }
+    }
+  }
+}

--- a/src/components/LayerDetailsModal/index.spec.tsx
+++ b/src/components/LayerDetailsModal/index.spec.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import {
+  render,
+  screen,
+  fireEvent
+} from '@testing-library/react';
+
+import {
+  show,
+  hide
+} from '../../store/layerDetailsModal';
+
+import {
+  store
+} from '../../store/store';
+
+import { createReduxWrapper } from '../../utils/testUtils';
+
+import LayerDetailsModal from './index';
+
+describe('<LayerDetailsModal />', () => {
+
+  beforeEach(() => {
+    store.dispatch(show());
+  });
+
+  afterEach(() => {
+    store.dispatch(hide());
+  });
+
+  it('is defined', () => {
+    expect(LayerDetailsModal).not.toBeUndefined();
+  });
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(<LayerDetailsModal />, {
+      wrapper: createReduxWrapper()
+    });
+
+    expect(container).toBeVisible();
+  });
+
+  it('can toggle its visibility', () => {
+    render(<LayerDetailsModal />, {
+      wrapper: createReduxWrapper()
+    });
+
+    const modal = screen.getByRole('dialog');
+
+    expect(modal).toBeVisible();
+
+    const closeButton = screen.getByLabelText('Close');
+
+    fireEvent.click(closeButton);
+
+    expect(modal).not.toBeVisible();
+  });
+});

--- a/src/components/LayerDetailsModal/index.tsx
+++ b/src/components/LayerDetailsModal/index.tsx
@@ -1,0 +1,141 @@
+import React, {
+  useState,
+  useEffect
+} from 'react';
+
+import {
+  FileTextOutlined
+} from '@ant-design/icons';
+
+import {
+  Button,
+  Modal,
+  ModalProps,
+  Tooltip
+} from 'antd';
+
+import OlLayer from 'ol/layer/Layer';
+
+import {
+  useTranslation
+} from 'react-i18next';
+
+import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+
+import {
+  useMap
+} from '@terrestris/react-geo/dist/Hook/useMap';
+
+import useAppDispatch from '../../hooks/useAppDispatch';
+import useAppSelector from '../../hooks/useAppSelector';
+
+import {
+  hide as hideLayerDetailsModal,
+  setLayer as setDetailsLayer
+} from '../../store/layerDetailsModal';
+
+import LayerConfiguration from './LayerConfiguration';
+import LayerDetails from './LayerDetails';
+
+import './index.less';
+
+export type LayerDetailsModalProps = {} & Partial<ModalProps>;
+
+export const LayerDetailsModal: React.FC<LayerDetailsModalProps> = ({
+  ...restProps
+}): JSX.Element => {
+  const [layer, setLayer] = useState<OlLayer>();
+  const [configurationVisible, setConfigurationVisible] = useState<boolean>(false);
+
+  const isModalVisible = useAppSelector(state => state.layerDetailsModal.visible);
+  const layerId = useAppSelector(state => state.layerDetailsModal.layerId);
+
+  const dispatch = useAppDispatch();
+
+  const map = useMap();
+
+  const {
+    t
+  } = useTranslation();
+
+  useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    if (!layerId) {
+      setLayer(undefined);
+      return;
+    }
+
+    const l = MapUtil.getLayerByOlUid(map, layerId);
+
+    if (!(l instanceof OlLayer)) {
+      return;
+    }
+
+    setLayer(l);
+  }, [map, layerId]);
+
+  const closeModal = () => {
+    dispatch(hideLayerDetailsModal());
+    dispatch(setDetailsLayer(undefined));
+  };
+
+  const onShowConfigurationClick = () => {
+    setConfigurationVisible(!configurationVisible);
+  };
+
+  return (
+    <Modal
+      className="layer-details-modal"
+      title={(
+        <div
+          className="title-group"
+        >
+          <span>{t('LayerDetailsModal.title', {
+            layerName: layer?.get('name')
+          })}
+          </span>
+          {
+            layer?.get('shogunId') && (
+              <Tooltip
+                title={configurationVisible ?
+                  t('LayerDetailsModal.internalConfigurationButtonTooltip') :
+                  t('LayerDetailsModal.internalConfigurationButtonTooltipPressed')
+                }
+              >
+                <Button
+                  type="link"
+                  className={configurationVisible ? 'pressed' : ''}
+                  icon={<FileTextOutlined />}
+                  onClick={onShowConfigurationClick}
+                />
+              </Tooltip>
+            )
+          }
+        </div>
+      )}
+      open={isModalVisible}
+      onCancel={closeModal}
+      width={800}
+      footer={false}
+      {...restProps}
+    >
+      <LayerDetails
+        layer={layer}
+        hidden={configurationVisible}
+      />
+      {
+        layer?.get('shogunId') && (
+          <LayerConfiguration
+            layer={layer}
+            hidden={!configurationVisible}
+          />
+        )
+      }
+    </Modal>
+  );
+};
+
+export default LayerDetailsModal;

--- a/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
+++ b/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
@@ -59,7 +59,13 @@ import {
   getBearerTokenHeader
 } from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
 
+import useAppDispatch from '../../../../hooks/useAppDispatch';
 import useSHOGunAPIClient from '../../../../hooks/useSHOGunAPIClient';
+
+import {
+  setLayer as setLayerDetailsLayer,
+  show as showLayerDetailsModal
+} from '../../../../store/layerDetailsModal';
 
 export type LayerTreeContextMenuProps = {
   layer: OlLayerTile<OlSourceTileWMS> | OlLayerImage<OlSourceImageWMS>;
@@ -77,6 +83,7 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
   const [settingsVisible, setSettingsVisible] = useState<boolean>(false);
   const [extentLoading, setExtentLoading] = useState<boolean>(false);
 
+  const dispatch = useAppDispatch();
   const client = useSHOGunAPIClient();
   const map = useMap();
   const {
@@ -106,6 +113,10 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
           newLegendIds.push(legendId);
         }
         setVisibleLegendsIds(newLegendIds);
+        break;
+      case 'layerDetails':
+        dispatch(setLayerDetailsLayer(getUid(layer)));
+        dispatch(showLayerDetailsModal());
         break;
       default:
         break;
@@ -222,8 +233,9 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
     });
   }
 
-  const legendVisible = visibleLegendsIds.includes(getUid(layer));
   if (isWmsLayer(layer) && layer.getVisible()) {
+    const legendVisible = visibleLegendsIds.includes(getUid(layer));
+
     dropdownMenuItems.push({
       label: legendVisible ? t('LayerTreeContextMenu.hideLegend') : t('LayerTreeContextMenu.showLegend'),
       key: 'toggleLegend'
@@ -248,6 +260,11 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
     });
     dropdownMenuItems.push(...downloadItems);
   }
+
+  dropdownMenuItems.push({
+    label: t('LayerTreeContextMenu.layerDetails'),
+    key: 'layerDetails'
+  });
 
   return (
     <Dropdown

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -65,7 +65,30 @@ export default {
         removeLayer: 'Layer entfernen',
         showLegend: 'Legende anzeigen',
         hideLegend: 'Legende ausblenden',
-        downloadLayer: 'Layer exportieren ({{formatName}})'
+        downloadLayer: 'Layer exportieren ({{formatName}})',
+        layerDetails: 'Eigenschaften'
+      },
+      LayerDetailsModal: {
+        title: 'Eigenschaften des Layers {{layerName}}',
+        internalConfigurationButtonTooltip: 'Interne Konfiguration anzeigen',
+        internalConfigurationButtonTooltipPressed: 'Interne Konfiguration verbergen'
+      },
+      LayerDetails: {
+        noDataPlaceholder: '-',
+        layerNameLabel: 'Name',
+        layerTitleLabel: 'Titel',
+        serviceAbstractLabel: 'Service Beschreibung',
+        abstractLabel: 'Beschreibung',
+        accessConstraintsLabel: 'Nutzungseinschränkungen',
+        capabilitiesUrlLabel: 'GetCapabilities URL',
+        contactLabel: 'Kontakt',
+        minScaleLabel: 'Min. Maßstab',
+        maxScaleLabel: 'Max. Maßstab',
+        bboxLabel: 'Bounding Box',
+        errorMessage: 'Fehler beim Laden der Layer Capabilities'
+      },
+      LayerConfiguration: {
+        errorMessage: 'Fehler beim Laden der internen Konfiguration'
       },
       ToolMenu: {
         expand: 'Menu ausklappen',
@@ -213,7 +236,30 @@ export default {
         removeLayer: 'Remove layer',
         showLegend: 'Show legend',
         hideLegend: 'Hide legend',
-        downloadLayer: 'Export layer as {{formatName}}'
+        downloadLayer: 'Export layer as {{formatName}}',
+        layerDetails: 'Properties'
+      },
+      LayerDetailsModal: {
+        title: 'Properties of layer {{layerName}}',
+        internalConfigurationButtonTooltip: 'Show internal configuration',
+        internalConfigurationButtonTooltipPressed: 'Hide internal configuration'
+      },
+      LayerDetails: {
+        noDataPlaceholder: '-',
+        layerNameLabel: 'Name',
+        layerTitleLabel: 'Title',
+        serviceAbstractLabel: 'Service abstract',
+        abstractLabel: 'Abstract',
+        accessConstraintsLabel: 'Access constraints',
+        capabilitiesUrlLabel: 'GetCapabilities URL',
+        contactLabel: 'Contact',
+        minScaleLabel: 'Min. scale',
+        maxScaleLabel: 'Max. scale',
+        bboxLabel: 'Bounding box',
+        errorMessage: 'Error while loading the layer capabilities'
+      },
+      LayerConfiguration: {
+        errorMessage: 'Error while loading the internal configuration'
       },
       ToolMenu: {
         expand: 'Expand',

--- a/src/store/layerDetailsModal/index.ts
+++ b/src/store/layerDetailsModal/index.ts
@@ -1,0 +1,41 @@
+import {
+  PayloadAction,
+  createSlice
+} from '@reduxjs/toolkit';
+
+export interface LayerDetailsModalState {
+  visible: boolean;
+  layerId?: string;
+}
+
+const initialState: LayerDetailsModalState = {
+  visible: false
+};
+
+const layerDetailsModalSlice = createSlice({
+  name: 'layerDetailsModal',
+  initialState,
+  reducers: {
+    setLayer(state, action: PayloadAction<string | undefined>) {
+      state.layerId = action.payload;
+    },
+    show(state) {
+      state.visible = true;
+    },
+    hide(state) {
+      state.visible = false;
+    },
+    toggle(state) {
+      state.visible = !state.visible;
+    }
+  }
+});
+
+export const {
+  setLayer,
+  show,
+  hide,
+  toggle
+} = layerDetailsModalSlice.actions;
+
+export default layerDetailsModalSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -7,6 +7,7 @@ import {
 import addLayerModal from './addLayerModal';
 import appInfo from './appInfo';
 import description from './description';
+import layerDetailsModal from './layerDetailsModal';
 import legal from './legal';
 import logoPath from './logoPath';
 import print from './print';
@@ -26,6 +27,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     addLayerModal,
     appInfo,
     description,
+    layerDetailsModal,
     legal,
     logoPath,
     print,


### PR DESCRIPTION
This introduces the `LayerDetailsModal` presenting asorted entries of the `Capabilities` document of the given layer as well as the internal SHOGun configuration object.

![image](https://github.com/terrestris/shogun-gis-client/assets/1137620/b0f9bf82-e0a5-43eb-b998-fd55e88bc31a)

![image](https://github.com/terrestris/shogun-gis-client/assets/1137620/46f2deaa-5907-4fb8-a390-4f56ca2d468b)

Please review @terrestris/devs.