### PR TITLE
generate search query based on search configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@terrestris/ol-util": "^10.1.3",
         "@terrestris/react-geo": "^22.1.0",
         "@terrestris/react-util": "^2.1.1",
-        "@terrestris/shogun-util": "^5.4.1",
+        "@terrestris/shogun-util": "^5.5.0",
         "antd": "^4.24.4",
         "color": "^4.2.3",
         "geostyler": "^12.0.0",
@@ -6346,9 +6346,9 @@
       }
     },
     "node_modules/@terrestris/shogun-util": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-5.4.1.tgz",
-      "integrity": "sha512-4mKk+SbOc3KXBe4gKx1O8zye9LG7Iwf2yA+9Njek3l+sotAXl+tB6iEyim9cBTsH5+Tu9KuP6EFHzXVTnh0aZQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-5.5.0.tgz",
+      "integrity": "sha512-wl4wwE7s0BbLPEkmjhX+NfzN2Yuy4OvGiqfqqAfSbM3J3TSFxMR55al96k/Lqopsz/aM2YXE/X8RC9tX8hE5Eg==",
       "dependencies": {
         "@terrestris/base-util": "^1.0.1",
         "@terrestris/ol-util": "^10.3.0",
@@ -33308,9 +33308,9 @@
       }
     },
     "@terrestris/shogun-util": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-5.4.1.tgz",
-      "integrity": "sha512-4mKk+SbOc3KXBe4gKx1O8zye9LG7Iwf2yA+9Njek3l+sotAXl+tB6iEyim9cBTsH5+Tu9KuP6EFHzXVTnh0aZQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-5.5.0.tgz",
+      "integrity": "sha512-wl4wwE7s0BbLPEkmjhX+NfzN2Yuy4OvGiqfqqAfSbM3J3TSFxMR55al96k/Lqopsz/aM2YXE/X8RC9tX8hE5Eg==",
       "requires": {
         "@terrestris/base-util": "^1.0.1",
         "@terrestris/ol-util": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@terrestris/ol-util": "^10.1.3",
     "@terrestris/react-geo": "^22.1.0",
     "@terrestris/react-util": "^2.1.1",
-    "@terrestris/shogun-util": "^5.4.1",
+    "@terrestris/shogun-util": "^5.5.0",
     "antd": "^4.24.4",
     "color": "^4.2.3",
     "geostyler": "^12.0.0",

--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -64,6 +64,8 @@ import {
   show as showEditFeatureDrawer
 } from '../../store/editFeatureDrawerOpen';
 
+import generateSolrQuery from '../../utils/generateSolrQuery';
+
 interface MultiSearchProps extends InputProps {
   useNominatim: boolean;
   delay?: number;
@@ -190,18 +192,13 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
       }
     }
 
-    if (searchData) {
+    if (searchData && map) {
       try {
-        let parts = searchValue.trim()
-          .replaceAll(/[()\\\-_./\/]/g, ' ').split(' ')
-          .filter(s => s.trim() !== '');
-
-        const partsQuery = parts.map(
-          (part: string) => `(search:${part.trim()}*^3 OR search:*${part.trim()}*^2 OR search:${part.trim()}~1)`
-        );
+        const query = generateSolrQuery({
+          searchValue,
+          map
+        });
         const searchUrl = new URL(`${window.location.origin}${solrSearchBasePath}`);
-
-        const query = `search:\"${searchValue.trim()}\" OR (${partsQuery.join(' AND ')})`;
 
         if (useViewBox && viewBox) {
           const bboxFilter = `geometry:[${viewBox[1]},${viewBox[0]} TO ${viewBox[3]},${viewBox[2]}]`;
@@ -244,7 +241,7 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
         setLoading(false);
       }
     }
-  }, [searchValue, minChars, useViewBox, searchData, searchNominatim, map, solrSearchBasePath]);
+  }, [searchValue, minChars, searchData, searchNominatim, useViewBox, map, solrSearchBasePath]);
 
   const getFeatureTitle = useCallback((dsResult: DataSearchResult): string => {
 

--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -51,10 +51,15 @@ import SearchResultsPanel, {
   Category as ResultCategory
 } from '@terrestris/react-geo/dist/Panel/SearchResultsPanel/SearchResultsPanel';
 
-import useAppDispatch from '../../hooks/useAppDispatch';
+import {
+  getBearerTokenHeader
+} from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
+
 import './index.less';
 
+import useAppDispatch from '../../hooks/useAppDispatch';
 import useAppSelector from '../../hooks/useAppSelector';
+import useSHOGunAPIClient from '../../hooks/useSHOGunAPIClient';
 
 import {
   setLayerId
@@ -84,6 +89,7 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
   solrSearchBasePath = '/search/query'
 }): JSX.Element => {
 
+  const client = useSHOGunAPIClient();
   const map = useMap();
   const {
     t
@@ -200,13 +206,30 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
         });
         const searchUrl = new URL(`${window.location.origin}${solrSearchBasePath}`);
 
+        const data: {
+          query: string;
+          filterQuery?: string;
+        } = {
+          query
+        };
+
         if (useViewBox && viewBox) {
           const bboxFilter = `geometry:[${viewBox[1]},${viewBox[0]} TO ${viewBox[3]},${viewBox[2]}]`;
-          searchUrl.searchParams.set('fq', bboxFilter);
+          data.filterQuery = bboxFilter;
         }
 
-        searchUrl.searchParams.set('q', query);
-        response = await fetch(searchUrl.href);
+        const defaultHeaders = {
+          'Content-Type': 'application/json'
+        };
+
+        response = await fetch(searchUrl.href, {
+          method: 'POST',
+          headers: {
+            ...defaultHeaders,
+            ...getBearerTokenHeader(client?.getKeycloak())
+          },
+          body: JSON.stringify(data)
+        });
 
         const dataJson = await response.json();
         setDataSearchResults(dataJson?.response?.docs);
@@ -241,7 +264,7 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
         setLoading(false);
       }
     }
-  }, [searchValue, minChars, searchData, searchNominatim, useViewBox, map, solrSearchBasePath]);
+  }, [searchValue, minChars, searchData, searchNominatim, useViewBox, map, solrSearchBasePath, client]);
 
   const getFeatureTitle = useCallback((dsResult: DataSearchResult): string => {
 
@@ -304,7 +327,7 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
       updatedResults.push(nResults);
     }
 
-    if (dataSearchResults.length > 0) {
+    if (dataSearchResults?.length > 0) {
 
       const wktFormat = new OlFormatWKT();
       // 1. group by category
@@ -419,7 +442,7 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
 
   const resultRenderer = () => {
 
-    if (searchValue.length < 2 || !resultsVisible || loading) {
+    if (searchValue.length < 2 || !resultsVisible || loading || !dataSearchResults) {
       return null;
     }
 

--- a/src/utils/generateSolrQuery.spec.ts
+++ b/src/utils/generateSolrQuery.spec.ts
@@ -1,21 +1,16 @@
 import OlLayerTile from 'ol/layer/Tile';
 import OlMap from 'ol/Map';
 import OlSourceTileWMS from 'ol/source/TileWMS';
-import OlView from 'ol/View';
 
 import generateSolrQuery from './generateSolrQuery';
 
 describe('<generateSolrQuery />', () => {
-  const center = [829729, 6708850];
   let map: OlMap;
 
   beforeEach(() => {
     const layer1 = new OlLayerTile({
-      opacity: 0.5,
-      visible: true,
       source: new OlSourceTileWMS({
         url: 'https://example.com/wms1',
-        projection: 'EPSG:3857',
         params: {
           LAYERS: 'SHOGUN:foo'
         }
@@ -29,11 +24,8 @@ describe('<generateSolrQuery />', () => {
     });
 
     const layer2 = new OlLayerTile({
-      opacity: 0.5,
-      visible: true,
       source: new OlSourceTileWMS({
         url: 'https://example.com/wms2',
-        projection: 'EPSG:3857',
         params: {
           LAYERS: 'SHOGUN:bar'
         }
@@ -47,10 +39,6 @@ describe('<generateSolrQuery />', () => {
     });
 
     map = new OlMap({
-      view: new OlView({
-        center,
-        zoom: 10
-      }),
       controls: [],
       layers: [layer1, layer2]
     });
@@ -62,11 +50,8 @@ describe('<generateSolrQuery />', () => {
 
   it('returns the correct solr query (single term, no attributes specified)', () => {
     const layerWithoutAttributeConfig = new OlLayerTile({
-      opacity: 0.5,
-      visible: true,
       source: new OlSourceTileWMS({
         url: 'https://example.com/wms2',
-        projection: 'EPSG:3857',
         params: {
           LAYERS: 'SHOGUN:bar'
         }

--- a/src/utils/generateSolrQuery.spec.ts
+++ b/src/utils/generateSolrQuery.spec.ts
@@ -1,0 +1,116 @@
+import OlLayerTile from 'ol/layer/Tile';
+import OlMap from 'ol/Map';
+import OlSourceTileWMS from 'ol/source/TileWMS';
+import OlView from 'ol/View';
+
+import generateSolrQuery from './generateSolrQuery';
+
+describe('<generateSolrQuery />', () => {
+  const center = [829729, 6708850];
+  let map: OlMap;
+
+  beforeEach(() => {
+    const layer1 = new OlLayerTile({
+      opacity: 0.5,
+      visible: true,
+      source: new OlSourceTileWMS({
+        url: 'https://example.com/wms1',
+        projection: 'EPSG:3857',
+        params: {
+          LAYERS: 'SHOGUN:foo'
+        }
+      })
+    });
+    layer1.setProperties({
+      searchConfig: {
+        attributes: ['attr1', 'attr2']
+      },
+      searchable: true
+    });
+
+    const layer2 = new OlLayerTile({
+      opacity: 0.5,
+      visible: true,
+      source: new OlSourceTileWMS({
+        url: 'https://example.com/wms2',
+        projection: 'EPSG:3857',
+        params: {
+          LAYERS: 'SHOGUN:bar'
+        }
+      })
+    });
+    layer2.setProperties({
+      searchConfig: {
+        attributes: ['attr3', 'attr4']
+      },
+      searchable: true
+    });
+
+    map = new OlMap({
+      view: new OlView({
+        center,
+        zoom: 10
+      }),
+      controls: [],
+      layers: [layer1, layer2]
+    });
+  });
+
+  it('is defined', () => {
+    expect(generateSolrQuery).not.toBeUndefined();
+  });
+
+  it('returns the correct solr query (single term, no attributes specified)', () => {
+    const layerWithoutAttributeConfig = new OlLayerTile({
+      opacity: 0.5,
+      visible: true,
+      source: new OlSourceTileWMS({
+        url: 'https://example.com/wms2',
+        projection: 'EPSG:3857',
+        params: {
+          LAYERS: 'SHOGUN:bar'
+        }
+      })
+    });
+
+    layerWithoutAttributeConfig.setProperties({
+      searchable: true
+    });
+
+    map.setLayers([layerWithoutAttributeConfig]);
+
+    let generatedQuery = generateSolrQuery({
+      searchValue: 'foo',
+      map
+    });
+
+    const expectedSolrQuery = '(layerName:"SHOGUN:bar" AND ((search:"foo") OR ((search:foo*^3 OR search:*foo*^2 OR search:foo~1))))';
+
+    expect(generatedQuery).toEqual(expectedSolrQuery);
+  });
+
+  it('returns the correct solr query (single term, two attributes specified)', () => {
+    let generatedQuery = generateSolrQuery({
+      searchValue: 'lorem',
+      map
+    });
+
+    // eslint-disable-next-line max-len
+    const expectedSolrQuery = '(layerName:"SHOGUN:foo" AND ((attr1:"lorem" OR attr2:"lorem") OR ((attr1:lorem*^3 OR attr1:*lorem*^2 OR attr1:lorem~1) AND (attr2:lorem*^3 OR attr2:*lorem*^2 OR attr2:lorem~1)))) OR (layerName:"SHOGUN:bar" AND ((attr3:"lorem" OR attr4:"lorem") OR ((attr3:lorem*^3 OR attr3:*lorem*^2 OR attr3:lorem~1) AND (attr4:lorem*^3 OR attr4:*lorem*^2 OR attr4:lorem~1))))';
+
+    expect(generatedQuery).toEqual(expectedSolrQuery);
+  });
+
+  it('returns the correct solr query (search phrase, two attributes specified)', () => {
+    let generatedQuery = generateSolrQuery({
+      searchValue: 'lorem ipsum',
+      map
+    });
+
+    // eslint-disable-next-line max-len
+    const expectedSolrQuery = '(layerName:"SHOGUN:foo" AND ((attr1:"lorem ipsum" OR attr2:"lorem ipsum") OR ((attr1:lorem*^3 OR attr1:*lorem*^2 OR attr1:lorem~1 OR attr1:ipsum*^3 OR attr1:*ipsum*^2 OR attr1:ipsum~1) AND (attr2:lorem*^3 OR attr2:*lorem*^2 OR attr2:lorem~1 OR attr2:ipsum*^3 OR attr2:*ipsum*^2 OR attr2:ipsum~1)))) OR (layerName:"SHOGUN:bar" AND ((attr3:"lorem ipsum" OR attr4:"lorem ipsum") OR ((attr3:lorem*^3 OR attr3:*lorem*^2 OR attr3:lorem~1 OR attr3:ipsum*^3 OR attr3:*ipsum*^2 OR attr3:ipsum~1) AND (attr4:lorem*^3 OR attr4:*lorem*^2 OR attr4:lorem~1 OR attr4:ipsum*^3 OR attr4:*ipsum*^2 OR attr4:ipsum~1))))';
+
+    expect(generatedQuery).toEqual(expectedSolrQuery);
+  });
+
+});

--- a/src/utils/generateSolrQuery.ts
+++ b/src/utils/generateSolrQuery.ts
@@ -1,0 +1,75 @@
+import Map from 'ol/Map';
+
+import { isWmsLayer } from '@terrestris/react-geo/dist/Util/typeUtils';
+
+import {
+  SearchConfig
+} from '@terrestris/shogun-util/dist/model/Layer';
+
+export interface SolrQueryProps {
+  searchValue: string;
+  map: Map;
+}
+
+/**
+ * Generates a solr search query based on the `searchConfiguration` and `searchable` properties of each layer. This
+ * currently considers all layers which are part of the layer tree / map.
+ */
+export const generateSolrQuery = ({
+  searchValue,
+  map
+}: SolrQueryProps): string => {
+  // parse searchValue into an array of search terms,
+  // removing special characters and white spaces
+  let parts = searchValue.trim()
+    .replaceAll(/[()\\\-_./\/]/g, ' ')
+    .split(' ')
+    .map(s => s.trim())
+    .filter(s => s !== '');
+
+  const subQueriesPerLayer: string[] = [];
+  const layers = map.getAllLayers();
+  layers.forEach(layer => {
+    if (layer.get('searchable') && isWmsLayer(layer)) {
+      const searchConfig = layer.get('searchConfig') as SearchConfig;
+      const fullLayerName = layer.getSource()?.getParams().LAYERS;
+      if (searchConfig?.attributes) {
+        // search only configured attributes
+        subQueriesPerLayer.push(`(layerName:"${fullLayerName}" AND (${generateFuzzySearchQuery(parts, searchConfig.attributes)}))`);
+      } else {
+        // search all attributes of this layer
+        subQueriesPerLayer.push(`(layerName:"${fullLayerName}" AND (${generateFuzzySearchQuery(parts, ['search'])}))`);
+      }
+    }
+  });
+  return subQueriesPerLayer.join(' OR ');
+};
+
+/**
+ * Generates a solr (sub)query for multiple search terms which searches over a list of specified search attributes.
+ * @param searchParts The search input which may consist of multiple search terms, e.g. ["foo", "bar"]
+ * @param searchAttributes The search attributes, e.g. ["name", "street"]
+ */
+const generateFuzzySearchQuery = (
+  searchParts: string[],
+  searchAttributes: string[]
+): string => {
+
+  let exactPart = searchAttributes
+    .map(a => `${a}:\"${searchParts.join(' ')}\"`)
+    .join(' OR ');
+
+  const allPartsQuery = searchAttributes.map(a => {
+    const innerPartsQuery = searchParts.map(
+      (part: string) => `${a}:${part.trim()}*^3 OR ${a}:*${part.trim()}*^2 OR ${a}:${part.trim()}~1`
+    );
+    return `(${innerPartsQuery.join(' OR ')})`;
+  });
+
+  const fuzzyPart = allPartsQuery.join(' AND ');
+
+  return `(${exactPart}) OR (${fuzzyPart})`;
+
+};
+
+export default generateSolrQuery;


### PR DESCRIPTION
Instead of always searching through all the indexed solr data, this dynamically creates a solr search query based on the following layer attributes:

- `searchable` - only layers where this is `true` will be considered in the search
- `searchConfig`
   - `attributes` - only layer attributes specified in this array will be included in the search query
   - if `attributes` is not specified, all attributes will be included

Related PRs:
- https://github.com/terrestris/shogun/pull/703
- https://github.com/terrestris/shogun-util/pull/363

@terrestris/devs Please review