### PR TITLE
Use custom print scale from map scales

### DIFF
--- a/src/components/PrintForm/index.tsx
+++ b/src/components/PrintForm/index.tsx
@@ -130,8 +130,9 @@ export const PrintForm: React.FC<PrintFormProps> = ({
         ?.getView()
         ?.getResolutions()
         ?.map((d: number | undefined) => {
+          const units = map?.getView()?.getProjection()?.getUnits();
           if (typeof d !== 'undefined') {
-            const scale = MapUtil.getScaleForResolution(d, 'm');
+            const scale = MapUtil.getScaleForResolution(d, units);
             if (typeof scale !== 'undefined') {
               return MapUtil.roundScale(scale);
             }

--- a/src/components/PrintForm/index.tsx
+++ b/src/components/PrintForm/index.tsx
@@ -126,6 +126,20 @@ export const PrintForm: React.FC<PrintFormProps> = ({
     let pManagerOpts: MapFishPrintV3ManagerOpts = {
       url: ClientConfiguration.print?.url || '/print',
       map,
+      customPrintScales: map
+        ?.getView()
+        ?.getResolutions()
+        ?.map((d: number | undefined) => {
+          if (typeof d !== 'undefined') {
+            const scale = MapUtil.getScaleForResolution(d, 'm');
+            if (typeof scale !== 'undefined') {
+              return MapUtil.roundScale(scale);
+            }
+          }
+          return undefined;
+        })
+        .filter((scale: number | undefined) => typeof scale !== 'undefined')
+        ?.reverse() as number[] | undefined,
       timeout: 60000,
       layerFilter,
       headers: {


### PR DESCRIPTION
This PR uses `customPrintScales` from the defined map scales to keep the print scales and map scales in sync.

@terrestris/devs please review