### PR TITLE
Several layout enhancements for footer and feature info grid components

### DIFF
--- a/src/components/Footer/index.less
+++ b/src/components/Footer/index.less
@@ -22,6 +22,9 @@
       justify-content: flex-start;
       flex: 1;
       column-gap: .5rem;
+      >div {
+        white-space: nowrap;
+      }
 
       #scale-line-container {
         width: 8rem;

--- a/src/components/Footer/index.less
+++ b/src/components/Footer/index.less
@@ -52,6 +52,9 @@
         display: flex;
         flex-direction: row;
         align-items: center;
+        .react-geo-scalecombo {
+          min-width: 110px;
+        }
       }
       @media screen and (max-width: 800px) {
         .scale-combo {

--- a/src/components/ToolMenu/FeatureInfo/FeaturePropertyGrid/index.less
+++ b/src/components/ToolMenu/FeatureInfo/FeaturePropertyGrid/index.less
@@ -14,6 +14,13 @@
           .ant-table-title {
             display: flex;
             align-items: center;
+
+            .copy {
+              display: flex;
+              button {
+                margin-left: 5px;
+              }
+            }
           }
 
           .ant-table-body {

--- a/src/components/ToolMenu/FeatureInfo/FeaturePropertyGrid/index.less
+++ b/src/components/ToolMenu/FeatureInfo/FeaturePropertyGrid/index.less
@@ -25,6 +25,11 @@
 
           .ant-table-body {
             overflow: auto !important;
+
+            td {
+              word-break: break-word;
+              white-space: pre-line;
+            }
           }
 
           .ant-table-container {

--- a/src/components/ToolMenu/FeatureInfo/FeaturePropertyGrid/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/FeaturePropertyGrid/index.tsx
@@ -153,10 +153,20 @@ export const FeatureInfoPropertyGrid: React.FC<FeatureInfoPropertyGridProps> = (
     return <></>;
   }
 
+  const attributeFilter = selectedFeature.getKeys()
+    .filter((prop: string | number | boolean) => {
+      return ![
+        'geom',
+        'the_geom',
+        'geometry'
+      ].includes((prop as string).toLocaleLowerCase());
+    });
+
   return (
     <PropertyGrid
       className="property-grid"
       feature={selectedFeature}
+      attributeFilter={attributeFilter}
       size="small"
       sticky={true}
       title={() => {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -204,6 +204,12 @@ export default {
       },
       EditFeatureButton: {
         title: 'Objekt bearbeiten'
+      },
+      FeaturePropertyGrid: {
+        copyAsGeoJson: 'Als GeoJSON kopieren (inkl. Geometrie)',
+        copyAsObject: 'Als Objekt kopieren (nur angezeigte Werte)',
+        key: 'Name',
+        value: 'Wert'
       }
     }
   },
@@ -411,6 +417,12 @@ export default {
       },
       EditFeatureButton: {
         title: 'Edit feature'
+      },
+      FeaturePropertyGrid: {
+        copyAsGeoJson: 'Copy as GeoJSON (incl. geometry)',
+        copyAsObject: 'Copy as object (displayed values only)',
+        key: 'Name',
+        value: 'Value'
       }
     }
   }


### PR DESCRIPTION
* Set min width on scale combo to prevent cropped values for small scales (long numbers)
* Prevent ugly breaking of footer labels on middle/small devices
* Several feature grid enhancements
  * Try to detect a geom field by some common names like `the_geom` or `geometry` and remove them from grid 
  * Introduce further copy button (similar to "copy as GeoJson") which allows to copy shown feature attribute as KVP without geometry.
  * Add line breaks to prevent cropped labels on log attributes
  * Add some missing translations

Please review @terrestris/devs 