### PR TITLE
Prevent layer duplication from permalink on language change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import LayerDetailsModal from './components/LayerDetailsModal';
 import ToolMenu from './components/ToolMenu';
 import UploadDataModal from './components/UploadDataModal';
 
+import useRestoreTransientLayers from './hooks/useRestoreTransientLayers';
+
 import './App.less';
 
 export interface AppProps extends React.ComponentProps<'div'> { };
@@ -18,6 +20,8 @@ export interface AppProps extends React.ComponentProps<'div'> { };
 export const App: React.FC<AppProps> = ({
   ...restProps
 }): JSX.Element => {
+
+  useRestoreTransientLayers();
 
   useEffect(() => {
     const loadingMask = document.querySelectorAll('.loadmask')[0];

--- a/src/components/BasicMapComponent/index.tsx
+++ b/src/components/BasicMapComponent/index.tsx
@@ -59,6 +59,7 @@ export const BasicMapComponent: React.FC<Partial<MapComponentProps>> = ({
     }
 
     const addLayerGroup = (name: string) => {
+      console.log('adding layer group: ', name);
       const layerGroup = new OlLayerGroup({
         layers: []
       });
@@ -110,21 +111,28 @@ export const BasicMapComponent: React.FC<Partial<MapComponentProps>> = ({
           let targetGroup: OlLayerGroup;
 
           if (olLayer.get('groupName')) {
+            const groupByProperty = MapUtil.getLayersByProperty(map, 'isExternalLayer', true);
+
+            console.log('groupByProperty', groupByProperty);
             targetGroup = MapUtil.getLayerByName(map, olLayer.get('groupName')) as OlLayerGroup;
+            console.log('targetGroup', targetGroup);
 
             if (!targetGroup) {
               targetGroup = addLayerGroup(olLayer.get('groupName'));
+              // targetGroup.set('isExternalLayerGroup', true);
             }
           } else {
-            targetGroup = MapUtil.getLayerByName(map,
-              t('AddLayerModal.externalWmsFolder')) as OlLayerGroup;
-
+            targetGroup = MapUtil.getLayersByProperty(map, 'isExternalLayerGroup', true)[0] as OlLayerGroup;
             if (!targetGroup) {
               targetGroup = addLayerGroup(t('AddLayerModal.externalWmsFolder'));
+              targetGroup.set('isExternalLayerGroup', true);
             }
           }
 
-          targetGroup.getLayers().push(olLayer);
+          targetGroup.set('name', t('AddLayerModal.externalWmsFolder'));
+          if (!MapUtil.getLayerByName(map, olLayer.get('name'))) {
+            targetGroup.getLayers().push(olLayer);
+          }
         }
       }
     } catch (error) {
@@ -136,7 +144,9 @@ export const BasicMapComponent: React.FC<Partial<MapComponentProps>> = ({
     if (map) {
       const identifier = (l: BaseLayer) => l.get('name');
       const filter = (l: BaseLayer) => (l instanceof OlLayerTile || l instanceof OlLayerImage);
+      console.log('applying permalink!');
       const configString = PermalinkUtil.applyLink(map, ';', identifier, filter);
+      console.log('configString', configString);
 
       if (!configString) {
         return;

--- a/src/hooks/useRestoreTransientLayers.ts
+++ b/src/hooks/useRestoreTransientLayers.ts
@@ -1,0 +1,127 @@
+import _isEmpty from 'lodash/isEmpty';
+
+import BaseLayer from 'ol/layer/Base';
+import OlLayerGroup from 'ol/layer/Group';
+
+import OlLayerImage from 'ol/layer/Image';
+import OlLayerTile from 'ol/layer/Tile';
+
+import {
+  useTranslation
+} from 'react-i18next';
+
+import Logger from '@terrestris/base-util/dist/Logger';
+
+import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+import PermalinkUtil from '@terrestris/ol-util/dist/PermalinkUtil/PermalinkUtil';
+
+import {
+  useMap
+} from '@terrestris/react-geo/dist/Hook/useMap';
+
+import Layer from '@terrestris/shogun-util/dist/model/Layer';
+import SHOGunApplicationUtil from '@terrestris/shogun-util/dist/parser/SHOGunApplicationUtil';
+
+import useQueryParams from './useQueryParams';
+import useSHOGunAPIClient from './useSHOGunAPIClient';
+
+export const useRestoreTransientLayers = async () => {
+  const map = useMap();
+  const client = useSHOGunAPIClient();
+  const queryParams = useQueryParams();
+  const {
+    t
+  } = useTranslation();
+
+  const layers = queryParams.get('layers');
+
+  if (!map) {
+    return;
+  }
+
+  const identifier = (l: BaseLayer) => l.get('name');
+  const filter = (l: BaseLayer) => (l instanceof OlLayerTile || l instanceof OlLayerImage);
+  const configString = PermalinkUtil.applyLink(map, ';', identifier, filter);
+
+  if (!configString) {
+    return;
+  }
+
+  const addLayerGroup = (name: string) => {
+    const layerGroup = new OlLayerGroup({
+      layers: []
+    });
+    layerGroup.set('name', name);
+    const existingGroups = map.getLayerGroup().getLayers();
+    existingGroups.insertAt(existingGroups?.getLength() || 0, layerGroup);
+
+    return layerGroup;
+  };
+
+  try {
+    const config = JSON.parse(configString);
+
+    if (!client) {
+      throw new Error('Client is not available');
+    }
+
+    const parser = new SHOGunApplicationUtil({
+      client
+    });
+
+    for (let i = 0; i < config.length; i++) {
+      const cfg = config[i];
+      if (!_isEmpty(cfg?.layerConfig)) {
+        const layerConfig: Layer = cfg.layerConfig;
+        const olLayer = await parser.parseLayer(layerConfig);
+
+        if (!olLayer) {
+          continue;
+        }
+
+        if (cfg.isExternalLayer) {
+          olLayer.set('isExternalLayer', cfg.isExternalLayer);
+        }
+
+        if (cfg.isUploadedLayer) {
+          olLayer.set('isUploadedLayer', cfg.isUploadedLayer);
+        }
+
+        olLayer.set('groupName', cfg.groupName);
+        olLayer.set('layerConfig', cfg.layerConfig);
+
+        olLayer.setVisible(!!layers?.split(';').some(l => l === layerConfig.name));
+
+        if (!(olLayer.get('isExternalLayer') || olLayer.get('isUploadedLayer'))) {
+          continue;
+        }
+
+        let targetGroup: OlLayerGroup;
+
+        if (olLayer.get('groupName')) {
+          // handle custom layer group
+          targetGroup = MapUtil.getLayerByName(map, olLayer.get('groupName')) as OlLayerGroup;
+
+          if (!targetGroup) {
+            targetGroup = addLayerGroup(olLayer.get('groupName'));
+          }
+        } else {
+          // handle default layer group for external layers (external and uploaded layers)
+          targetGroup = MapUtil.getLayersByProperty(map, 'isExternalLayerGroup', true)?.[0] as OlLayerGroup;
+          if (!targetGroup) {
+            targetGroup = addLayerGroup(t('AddLayerModal.externalWmsFolder'));
+            targetGroup.set('isExternalLayerGroup', true);
+          }
+        }
+
+        if (!MapUtil.getLayerByName(map, olLayer.get('name'))) {
+          targetGroup.getLayers().push(olLayer);
+        }
+      }
+    }
+  } catch (error) {
+    Logger.error(error);
+  }
+};
+
+export default useRestoreTransientLayers;


### PR DESCRIPTION
- introduces a new hook `useRestoreTransientLayers` which reads application state information from a provided permalink and restores the contained layers (uploaded / external layers)
- fixes a bug which resulted in duplication of external layers whenever the language was changed while a permalink was active
- dispatches a `change:layers` event when the language is changed
   - this is needed to update the layer group names in the layer tree

@terrestris/devs Please review