### PR TITLE
Fix GeoJSON upload of draw features

### DIFF
--- a/src/components/ToolMenu/Draw/index.tsx
+++ b/src/components/ToolMenu/Draw/index.tsx
@@ -113,7 +113,9 @@ export const Draw: React.FC<DrawProps> = ({
       (uploadedFiles && uploadedFiles.length === 1) &&
       (
         uploadedFiles[0].type === 'application/geo+json' ||
-        uploadedFiles[0].type === 'application/geojson'
+        uploadedFiles[0].type === 'application/geojson' ||
+        uploadedFiles[0].name.includes('.geojson') ||
+        uploadedFiles[0].name.includes('.json')
       )
     ) {
       onGeoJSONUpload(uploadedFiles[0]);


### PR DESCRIPTION
Under some circumstances (e.g. Windows OS) the `type` might be empty. This adds a check for a proper file extension.

Please review @terrestris/devs.