### PR TITLE
Fix searching over multiple attributes

### DIFF
--- a/src/utils/generateSolrQuery.spec.ts
+++ b/src/utils/generateSolrQuery.spec.ts
@@ -81,7 +81,7 @@ describe('<generateSolrQuery />', () => {
     });
 
     // eslint-disable-next-line max-len
-    const expectedSolrQuery = '(featureType:"SHOGUN:foo" AND ((attr1:"lorem" OR attr2:"lorem") OR ((attr1:lorem*^3 OR attr1:*lorem*^2 OR attr1:lorem~1) AND (attr2:lorem*^3 OR attr2:*lorem*^2 OR attr2:lorem~1)))) OR (featureType:"SHOGUN:bar" AND ((attr3:"lorem" OR attr4:"lorem") OR ((attr3:lorem*^3 OR attr3:*lorem*^2 OR attr3:lorem~1) AND (attr4:lorem*^3 OR attr4:*lorem*^2 OR attr4:lorem~1))))';
+    const expectedSolrQuery = '(featureType:"SHOGUN:foo" AND ((attr1:"lorem" OR attr2:"lorem") OR ((attr1:lorem*^3 OR attr1:*lorem*^2 OR attr1:lorem~1) OR (attr2:lorem*^3 OR attr2:*lorem*^2 OR attr2:lorem~1)))) OR (featureType:"SHOGUN:bar" AND ((attr3:"lorem" OR attr4:"lorem") OR ((attr3:lorem*^3 OR attr3:*lorem*^2 OR attr3:lorem~1) OR (attr4:lorem*^3 OR attr4:*lorem*^2 OR attr4:lorem~1))))';
 
     expect(generatedQuery).toEqual(expectedSolrQuery);
   });
@@ -93,7 +93,7 @@ describe('<generateSolrQuery />', () => {
     });
 
     // eslint-disable-next-line max-len
-    const expectedSolrQuery = '(featureType:"SHOGUN:foo" AND ((attr1:"lorem ipsum" OR attr2:"lorem ipsum") OR ((attr1:lorem*^3 OR attr1:*lorem*^2 OR attr1:lorem~1 OR attr1:ipsum*^3 OR attr1:*ipsum*^2 OR attr1:ipsum~1) AND (attr2:lorem*^3 OR attr2:*lorem*^2 OR attr2:lorem~1 OR attr2:ipsum*^3 OR attr2:*ipsum*^2 OR attr2:ipsum~1)))) OR (featureType:"SHOGUN:bar" AND ((attr3:"lorem ipsum" OR attr4:"lorem ipsum") OR ((attr3:lorem*^3 OR attr3:*lorem*^2 OR attr3:lorem~1 OR attr3:ipsum*^3 OR attr3:*ipsum*^2 OR attr3:ipsum~1) AND (attr4:lorem*^3 OR attr4:*lorem*^2 OR attr4:lorem~1 OR attr4:ipsum*^3 OR attr4:*ipsum*^2 OR attr4:ipsum~1))))';
+    const expectedSolrQuery = '(featureType:"SHOGUN:foo" AND ((attr1:"lorem ipsum" OR attr2:"lorem ipsum") OR ((attr1:lorem*^3 OR attr1:*lorem*^2 OR attr1:lorem~1 OR attr1:ipsum*^3 OR attr1:*ipsum*^2 OR attr1:ipsum~1) OR (attr2:lorem*^3 OR attr2:*lorem*^2 OR attr2:lorem~1 OR attr2:ipsum*^3 OR attr2:*ipsum*^2 OR attr2:ipsum~1)))) OR (featureType:"SHOGUN:bar" AND ((attr3:"lorem ipsum" OR attr4:"lorem ipsum") OR ((attr3:lorem*^3 OR attr3:*lorem*^2 OR attr3:lorem~1 OR attr3:ipsum*^3 OR attr3:*ipsum*^2 OR attr3:ipsum~1) OR (attr4:lorem*^3 OR attr4:*lorem*^2 OR attr4:lorem~1 OR attr4:ipsum*^3 OR attr4:*ipsum*^2 OR attr4:ipsum~1))))';
 
     expect(generatedQuery).toEqual(expectedSolrQuery);
   });

--- a/src/utils/generateSolrQuery.ts
+++ b/src/utils/generateSolrQuery.ts
@@ -66,7 +66,7 @@ const generateFuzzySearchQuery = (
     return `(${innerPartsQuery.join(' OR ')})`;
   });
 
-  const fuzzyPart = allPartsQuery.join(' AND ');
+  const fuzzyPart = allPartsQuery.join(' OR ');
 
   return `(${exactPart}) OR (${fuzzyPart})`;
 


### PR DESCRIPTION
This fixes the generated solr query when searching over multiple attributes. Previously, these were joined by `AND`. This meant that that the search term had to be in all attributes at the same time, which does not make sense. Now, the parts for each attribute are joined by `OR`.

@terrestris/devs Please review