### PR TITLE
Build image for current state of the main branch

### DIFF
--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -40,6 +40,38 @@ jobs:
         folder: build
         target-folder: latest
 
+    - name: Login to Nexus ⌨️
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.DOCKER_REGISTRY }}
+        username: ${{ secrets.NEXUS_USERNAME }}
+        password: ${{ secrets.NEXUS_PASSWORD }}
+
+    - name: Build docker image (main) 🏗️
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        tags: |
+          ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:main
+        load: true
+
+    - name: Push docker image to Nexus (main) 📠
+      run: |
+        docker push ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:main
+
+    - name: Build docker image e2e-tests (main) 🏗️
+      uses: docker/build-push-action@v2
+      with:
+        file: Dockerfile.e2e
+        context: .
+        tags: |
+          ${{ env.DOCKER_REGISTRY }}/shogun-gis-client-e2e-tests:main
+        load: true
+
+    - name: Push docker image to Nexus (main) 📠
+      run: |
+        docker push ${{ env.DOCKER_REGISTRY }}/shogun-gis-client-e2e-tests:main
+
   sonarqube:
     name: SonarQube Trigger
     runs-on: ubuntu-latest


### PR DESCRIPTION
This updates the pipeline to create and push an image for the current state of the `main` branch. The image is tagged as `main` and can be used for testing purposes.

Please review @terrestris/devs.