### PR TITLE
Make loading of the fallback application config configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Several global settings for the client can be configured via the [`gis-client-co
 | featureEditRoles.authorizedRolesForUpdate | The list of role names the feature editing tools including the update options should be allowed/visible to (note: this is the client evaluation only!). String and regular expressions are supported. | [] |
 | featureEditRoles.authorizedRolesForDelete | The list of role names the feature editing tools including the delete options should be allowed/visible to (note: this is the client evaluation only!). String and regular expressions are supported. | [] |
 | wfsLockFeatureEnabled | Whether WFS LockFeature is enabled during feature editing or not. | false |
+| enableFallbackConfig | Whether the default application configuration should be loaded without any given application ID or not. | true |
 
 The configuration file is not bundled and will be loaded before application start from `./gis-client-config.js`. Typically you want to override the file in a production environment and you can pass a custom file by mounting the desired one directly into the nginx container of the client. For example:
 

--- a/resources/config/gis-client-config.js
+++ b/resources/config/gis-client-config.js
@@ -26,5 +26,6 @@ var clientConfig = {
     authorizedRolesForUpdate: [],
     authorizedRolesForDelete: []
   },
-  wfsLockFeatureEnabled: false
+  wfsLockFeatureEnabled: false,
+  enableFallbackConfig: true
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -39,6 +39,7 @@ declare module 'clientConfig' {
     };
     featureEditRoles?: FeatureEditConfiguration;
     wfsLockFeatureEnabled?: boolean;
+    enableFallbackConfig?: boolean;
   };
   const config: ClientConfiguration;
 

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -133,8 +133,9 @@ export default {
         applicationLoadErrorDescription: 'Die Applikation mit der ID {{applicationId}} konnte nicht geladen werden. ' +
           'Die Standardkonfiguration wird stattdessen geladen.',
         errorMessage: 'Fehler beim Laden der Applikation',
-        errorDescription: 'Aufgrund eines unerwarteten Fehlers konnte die Applikation nicht geladen werden. ' +
-          'Bitte laden Sie die Seite erneut.'
+        errorDescription: 'Aufgrund eines unerwarteten Fehlers konnte die Applikation nicht geladen werden.',
+        errorDescriptionAppIdNotSet: 'Keine Applikations-ID angegeben. Bitte geben Sie die ID als Abfrageparameter an, z.B. ?applicationId=1909',
+        errorDescriptionAppConfigNotFound: 'Die Applikation mit der ID {{applicationId}} konnte nicht geladen werden.'
       },
       Nominatim: {
         placeholder: 'Ortsname, Straßenname, Stadtteilname, POI usw.'
@@ -349,7 +350,9 @@ export default {
         applicationLoadErrorDescription: 'The application with ID {{applicationId}} could not be loaded correctly. ' +
           'You\'re seeing the default application configuration.',
         errorMessage: 'Error while loading the application',
-        errorDescription: 'An unexpected error occured while loading the application. Please try to reload the page.'
+        errorDescription: 'An unexpected error occured while loading the application.',
+        errorDescriptionAppIdNotSet: 'No application ID given. Please provide the ID as query parameter, e.g. ?applicationId=1909',
+        errorDescriptionAppConfigNotFound: 'The application with ID {{applicationId}} could not be loaded correctly.'
       },
       Nominatim: {
         placeholder: 'Place name, street name, district name, POI, etc.'


### PR DESCRIPTION
This introduces a new client config parameter `enableFallbackConfig` which determines if the client should load the fallback configuration if no application configuration (because not set explicitly or not loaded correctly) is available.

It also fixes an issue with empty locales as `i18n` might not have been initialized in the `catch` block.

Please review @terrestris/devs.