### PR TITLE
Simplify searching over multiple attributes

### DIFF
--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -347,8 +347,10 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
 
     if (highlightResult) {
       const filteredHighlightKeys = Object.keys(highlightResult).filter(key => !blacklistedAttributes.includes(key));
-      const highlightValue = highlightResult[filteredHighlightKeys[0]];
-      return `${highlightValue} [${filteredHighlightKeys[0]}]`;
+      if (filteredHighlightKeys.length > 0) {
+        const highlightValue = highlightResult[filteredHighlightKeys[0]];
+        return `${highlightValue} [${filteredHighlightKeys[0]}]`;
+      }
     }
 
     Object.keys(dsResult)

--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -92,6 +92,21 @@ export type HighlightingResults = {
   [key: string]: HighlightingResult;
 };
 
+const isFulfilled = <T, >(p: PromiseSettledResult<T>): p is PromiseFulfilledResult<T> => p.status === 'fulfilled';
+
+export type SolrQueryConfig = {
+  q: string;
+  fq?: string;
+  defType?: 'lucene' | 'dismax' | 'edismax';
+  qf?: string;
+  rows?: number;
+  hl?: boolean;
+  'hl.fl'?: string;
+  'hl.tag.pre'?: string;
+  'hl.tag.post'?: string;
+  'hl.requireFieldMatch'?: boolean;
+};
+
 export const MultiSearch: React.FC<MultiSearchProps> = ({
   useNominatim,
   useSolrHighlighting = true,
@@ -212,55 +227,63 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
 
     if (searchData && map) {
       try {
-        const query = generateSolrQuery({
+        const searchUrl = new URL(`${window.location.origin}${solrSearchBasePath}`);
+        const queriesPerLayer = generateSolrQuery({
           searchValue,
           map
         });
-        const searchUrl = new URL(`${window.location.origin}${solrSearchBasePath}`);
 
-        const solrQueryConfig: {
-          q: string;
-          fq?: string;
-          rows?: number;
-          hl?: boolean;
-          'hl.fl'?: string;
-          'hl.tag.pre'?: string;
-          'hl.tag.post'?: string;
-          'hl.requireFieldMatch'?: boolean;
-        } = {
-          q: query,
-          rows: 100
-        };
+        const promises = queriesPerLayer.map(q => {
+          const solrQueryConfig: SolrQueryConfig = {
+            q: q.query,
+            rows: 100,
+            defType: 'edismax'
+          };
 
-        if (useViewBox && viewBox) {
-          const bboxFilter = `geometry:[${viewBox[1]},${viewBox[0]} TO ${viewBox[3]},${viewBox[2]}]`;
-          solrQueryConfig.fq = bboxFilter;
-        }
+          if (q.fieldList) {
+            solrQueryConfig.qf = q.fieldList;
+          } else {
+            solrQueryConfig.qf = 'search';
+          }
 
-        if (useSolrHighlighting) {
-          solrQueryConfig.hl = true;
-          solrQueryConfig['hl.fl'] = '*';
-          solrQueryConfig['hl.tag.pre'] = '<b>';
-          solrQueryConfig['hl.tag.post'] = '</b>';
-          solrQueryConfig['hl.requireFieldMatch'] = true;
-        }
+          if (useViewBox && viewBox) {
+            const bboxFilter = `geometry:[${viewBox[1]},${viewBox[0]} TO ${viewBox[3]},${viewBox[2]}]`;
+            solrQueryConfig.fq = bboxFilter;
+          }
 
-        const defaultHeaders = {
-          'Content-Type': 'application/json'
-        };
+          if (useSolrHighlighting) {
+            solrQueryConfig.hl = true;
+            solrQueryConfig['hl.fl'] = '*';
+            solrQueryConfig['hl.tag.pre'] = '<b>';
+            solrQueryConfig['hl.tag.post'] = '</b>';
+            solrQueryConfig['hl.requireFieldMatch'] = true;
+          }
 
-        response = await fetch(searchUrl.href, {
-          method: 'POST',
-          headers: {
-            ...defaultHeaders,
-            ...getBearerTokenHeader(client?.getKeycloak())
-          },
-          body: JSON.stringify(solrQueryConfig)
+          const defaultHeaders = {
+            'Content-Type': 'application/json'
+          };
+
+          return fetch(searchUrl.href, {
+            method: 'POST',
+            headers: {
+              ...defaultHeaders,
+              ...getBearerTokenHeader(client?.getKeycloak())
+            },
+            body: JSON.stringify(solrQueryConfig)
+          });
         });
 
-        const dataJson = await response.json();
-        setDataSearchResults(dataJson?.response?.docs);
-        setHighlightingResults(dataJson?.highlighting);
+        const results = await Promise.allSettled(promises.map(async pr => {
+          const res = await pr;
+          return res.json();
+        }));
+
+        const successfulResults = results.filter(isFulfilled);
+        const dataResults = successfulResults.flatMap(sR => sR.value?.response?.docs);
+        const hlResults = Object.assign({}, ...successfulResults.map(sr => sr.value?.highlighting));
+
+        setDataSearchResults(dataResults);
+        setHighlightingResults(hlResults);
       } catch (error) {
         setDataSearchResults([]);
         setHighlightingResults({});

--- a/src/utils/generateSolrQuery.spec.ts
+++ b/src/utils/generateSolrQuery.spec.ts
@@ -69,9 +69,10 @@ describe('<generateSolrQuery />', () => {
       map
     });
 
-    const expectedSolrQuery = '(featureType:"SHOGUN:bar" AND ((search:"foo") OR ((search:foo*^3 OR search:*foo*^2 OR search:foo~1))))';
+    const expectedSolrQuery = '(featureType:"SHOGUN:bar" AND ((foo*^3 OR *foo*^2 OR foo~1)))';
 
-    expect(generatedQuery).toEqual(expectedSolrQuery);
+    expect(generatedQuery).toHaveLength(1);
+    expect(generatedQuery[0].query).toEqual(expectedSolrQuery);
   });
 
   it('returns the correct solr query (single term, two attributes specified)', () => {
@@ -81,9 +82,12 @@ describe('<generateSolrQuery />', () => {
     });
 
     // eslint-disable-next-line max-len
-    const expectedSolrQuery = '(featureType:"SHOGUN:foo" AND ((attr1:"lorem" OR attr2:"lorem") OR ((attr1:lorem*^3 OR attr1:*lorem*^2 OR attr1:lorem~1) OR (attr2:lorem*^3 OR attr2:*lorem*^2 OR attr2:lorem~1)))) OR (featureType:"SHOGUN:bar" AND ((attr3:"lorem" OR attr4:"lorem") OR ((attr3:lorem*^3 OR attr3:*lorem*^2 OR attr3:lorem~1) OR (attr4:lorem*^3 OR attr4:*lorem*^2 OR attr4:lorem~1))))';
+    const expectedSolrQueryFoo = '(featureType:"SHOGUN:foo" AND ((lorem*^3 OR *lorem*^2 OR lorem~1)))';
+    const expectedSolrQueryBar = '(featureType:"SHOGUN:bar" AND ((lorem*^3 OR *lorem*^2 OR lorem~1)))';
 
-    expect(generatedQuery).toEqual(expectedSolrQuery);
+    expect(generatedQuery).toHaveLength(2);
+    expect(generatedQuery[0].query).toEqual(expectedSolrQueryFoo);
+    expect(generatedQuery[1].query).toEqual(expectedSolrQueryBar);
   });
 
   it('returns the correct solr query (search phrase, two attributes specified)', () => {
@@ -92,10 +96,12 @@ describe('<generateSolrQuery />', () => {
       map
     });
 
-    // eslint-disable-next-line max-len
-    const expectedSolrQuery = '(featureType:"SHOGUN:foo" AND ((attr1:"lorem ipsum" OR attr2:"lorem ipsum") OR ((attr1:lorem*^3 OR attr1:*lorem*^2 OR attr1:lorem~1 OR attr1:ipsum*^3 OR attr1:*ipsum*^2 OR attr1:ipsum~1) OR (attr2:lorem*^3 OR attr2:*lorem*^2 OR attr2:lorem~1 OR attr2:ipsum*^3 OR attr2:*ipsum*^2 OR attr2:ipsum~1)))) OR (featureType:"SHOGUN:bar" AND ((attr3:"lorem ipsum" OR attr4:"lorem ipsum") OR ((attr3:lorem*^3 OR attr3:*lorem*^2 OR attr3:lorem~1 OR attr3:ipsum*^3 OR attr3:*ipsum*^2 OR attr3:ipsum~1) OR (attr4:lorem*^3 OR attr4:*lorem*^2 OR attr4:lorem~1 OR attr4:ipsum*^3 OR attr4:*ipsum*^2 OR attr4:ipsum~1))))';
+    const expectedSolrQueryFoo = '(featureType:"SHOGUN:foo" AND ((lorem*^3 OR *lorem*^2 OR lorem~1) AND (ipsum*^3 OR *ipsum*^2 OR ipsum~1)))';
+    const expectedSolrQueryBar = '(featureType:"SHOGUN:bar" AND ((lorem*^3 OR *lorem*^2 OR lorem~1) AND (ipsum*^3 OR *ipsum*^2 OR ipsum~1)))';
 
-    expect(generatedQuery).toEqual(expectedSolrQuery);
+    expect(generatedQuery).toHaveLength(2);
+    expect(generatedQuery[0].query).toEqual(expectedSolrQueryFoo);
+    expect(generatedQuery[1].query).toEqual(expectedSolrQueryBar);
   });
 
 });

--- a/src/utils/generateSolrQuery.spec.ts
+++ b/src/utils/generateSolrQuery.spec.ts
@@ -73,6 +73,7 @@ describe('<generateSolrQuery />', () => {
 
     expect(generatedQuery).toHaveLength(1);
     expect(generatedQuery[0].query).toEqual(expectedSolrQuery);
+    expect(generatedQuery[0].fieldList).toBeUndefined();
   });
 
   it('returns the correct solr query (single term, two attributes specified)', () => {
@@ -88,6 +89,8 @@ describe('<generateSolrQuery />', () => {
     expect(generatedQuery).toHaveLength(2);
     expect(generatedQuery[0].query).toEqual(expectedSolrQueryFoo);
     expect(generatedQuery[1].query).toEqual(expectedSolrQueryBar);
+    expect(generatedQuery[0].fieldList).toEqual('attr1 attr2');
+    expect(generatedQuery[1].fieldList).toEqual('attr3 attr4');
   });
 
   it('returns the correct solr query (search phrase, two attributes specified)', () => {
@@ -102,6 +105,8 @@ describe('<generateSolrQuery />', () => {
     expect(generatedQuery).toHaveLength(2);
     expect(generatedQuery[0].query).toEqual(expectedSolrQueryFoo);
     expect(generatedQuery[1].query).toEqual(expectedSolrQueryBar);
+    expect(generatedQuery[0].fieldList).toEqual('attr1 attr2');
+    expect(generatedQuery[1].fieldList).toEqual('attr3 attr4');
   });
 
 });

--- a/src/utils/generateSolrQuery.ts
+++ b/src/utils/generateSolrQuery.ts
@@ -11,6 +11,11 @@ export interface SolrQueryProps {
   map: Map;
 }
 
+type SolrQuery = {
+  query: string;
+  fieldList?: string;
+};
+
 /**
  * Generates a solr search query based on the `searchConfiguration` and `searchable` properties of each layer. This
  * currently considers all layers which are part of the layer tree / map.
@@ -18,7 +23,7 @@ export interface SolrQueryProps {
 export const generateSolrQuery = ({
   searchValue,
   map
-}: SolrQueryProps): string => {
+}: SolrQueryProps): SolrQuery[] => {
   // parse searchValue into an array of search terms,
   // removing special characters and white spaces
   let parts = searchValue.trim()
@@ -27,7 +32,7 @@ export const generateSolrQuery = ({
     .map(s => s.trim())
     .filter(s => s !== '');
 
-  const subQueriesPerLayer: string[] = [];
+  const subQueriesPerLayer: SolrQuery[] = [];
   const layers = map.getAllLayers();
   layers.forEach(layer => {
     if (layer.get('searchable') && isWmsLayer(layer)) {
@@ -35,41 +40,32 @@ export const generateSolrQuery = ({
       const fullLayerName = layer.getSource()?.getParams().LAYERS;
       if (searchConfig?.attributes) {
         // search only configured attributes
-        subQueriesPerLayer.push(`(featureType:"${fullLayerName}" AND (${generateFuzzySearchQuery(parts, searchConfig.attributes)}))`);
+        subQueriesPerLayer.push({
+          query: `(featureType:"${fullLayerName}" AND (${generateFuzzySearchQuery(parts)}))`,
+          fieldList: searchConfig.attributes.join(' ')
+        });
       } else {
         // search all attributes of this layer
-        subQueriesPerLayer.push(`(featureType:"${fullLayerName}" AND (${generateFuzzySearchQuery(parts, ['search'])}))`);
+        subQueriesPerLayer.push({
+          query: `(featureType:"${fullLayerName}" AND (${generateFuzzySearchQuery(parts)}))`
+        });
       }
     }
   });
-  return subQueriesPerLayer.join(' OR ');
+  return subQueriesPerLayer;
 };
 
 /**
- * Generates a solr (sub)query for multiple search terms which searches over a list of specified search attributes.
+ * Applies operators for wildcard and fuzzy search to a solr (sub)query for multiple search terms.
  * @param searchParts The search input which may consist of multiple search terms, e.g. ["foo", "bar"]
- * @param searchAttributes The search attributes, e.g. ["name", "street"]
  */
 const generateFuzzySearchQuery = (
-  searchParts: string[],
-  searchAttributes: string[]
+  searchParts: string[]
 ): string => {
-
-  let exactPart = searchAttributes
-    .map(a => `${a}:\"${searchParts.join(' ')}\"`)
-    .join(' OR ');
-
-  const allPartsQuery = searchAttributes.map(a => {
-    const innerPartsQuery = searchParts.map(
-      (part: string) => `${a}:${part.trim()}*^3 OR ${a}:*${part.trim()}*^2 OR ${a}:${part.trim()}~1`
-    );
-    return `(${innerPartsQuery.join(' OR ')})`;
+  const subQueries = searchParts.map(part => {
+    return `(${part.trim()}*^3 OR *${part.trim()}*^2 OR ${part.trim()}~1)`;
   });
-
-  const fuzzyPart = allPartsQuery.join(' OR ');
-
-  return `(${exactPart}) OR (${fuzzyPart})`;
-
+  return subQueries.join(' AND ');
 };
 
 export default generateSolrQuery;


### PR DESCRIPTION
- switches to the `edismax` query parser (https://solr.apache.org/guide/6_6/the-extended-dismax-query-parser.html)
- this allows us to specify the search fields via the Query Fields parameter (`qf`) and in return allows for a much shorter query
- bugfix for search highlighting when no search attributes are configured

@terrestris/devs please review