### PR TITLE
Additional toolbar role config

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -529,7 +529,8 @@ const checkRoles = (
   const {
     authorizedRolesForCreate,
     authorizedRolesForUpdate,
-    authorizedRolesForDelete
+    authorizedRolesForDelete,
+    authorizedRolesForEditingGeometries
   } = featureEditRoles;
 
   const result: EditLevel[] = [];
@@ -543,6 +544,9 @@ const checkRoles = (
     }
     if (authorizedRolesForDelete?.some(role => matchRole(role, element))) {
       result.push('DELETE');
+    }
+    if (authorizedRolesForEditingGeometries?.some(role => matchRole(role, element))) {
+      result.push('EDIT_GEOMETRY');
     }
   }
   return result;

--- a/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
+++ b/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
@@ -193,91 +193,94 @@ export const EditFeatureGeometryToolbar: React.FC<EditFeatureGeometryToolbarProp
     return <></>;
   }
 
-  return (
-    <Toolbar
-      className="geometry-edit-tb"
-      alignment="vertical"
-    >
-      <ToggleGroup>
-        {
-          allowedEditMode.includes('CREATE') ?
-            <DrawButton
-              icon={
-                <FontAwesomeIcon icon={faPencil} />
-              }
-              pressedIcon={
-                <FontAwesomeIcon icon={faPencil} />
-              }
-              name="draw"
-              digitizeLayer={editLayer}
-              tooltip={t('EditFeatureGeometryToolbar.draw')}
-              drawType={feature.geometry.type as DrawType}
-              onDrawEnd={onDrawEnd}
-              {...btnTooltipProps}
+  if (allowedEditMode.includes('EDIT_GEOMETRY')) {
+    return (
+      <Toolbar
+        className="geometry-edit-tb"
+        alignment="vertical"
+      >
+        <ToggleGroup>
+          {
+            allowedEditMode.includes('CREATE') ?
+              <DrawButton
+                icon={
+                  <FontAwesomeIcon icon={faPencil} />
+                }
+                pressedIcon={
+                  <FontAwesomeIcon icon={faPencil} />
+                }
+                name="draw"
+                digitizeLayer={editLayer}
+                tooltip={t('EditFeatureGeometryToolbar.draw')}
+                drawType={feature.geometry.type as DrawType}
+                onDrawEnd={onDrawEnd}
+                {...btnTooltipProps}
+              />
+              : <></>
+          }
+          {
+            allowedEditMode.includes('UPDATE') ?
+              <ModifyButton
+                icon={
+                  <FontAwesomeIcon icon={faDrawPolygon} />
+                }
+                pressedIcon={
+                  <FontAwesomeIcon icon={faDrawPolygon} />
+                }
+                name="edit"
+                digitizeLayer={editLayer}
+                tooltip={t('EditFeatureGeometryToolbar.edit')}
+                onModifyStart={updateRevision}
+                onModifyEnd={updateRevision}
+                onTranslateEnd={updateRevision}
+                {...btnTooltipProps}
+              />
+              : <></>
+          }
+          {
+            allowedEditMode.includes('DELETE') ?
+              <DeleteButton
+                icon={
+                  <FontAwesomeIcon icon={faTrash} />
+                }
+                pressedIcon={
+                  <FontAwesomeIcon icon={faTrash} />
+                }
+                name="delete"
+                digitizeLayer={editLayer}
+                tooltip={t('EditFeatureGeometryToolbar.delete')}
+                onFeatureRemove={updateRevision}
+                {...btnTooltipProps}
+              />
+              : <></>
+          }
+        </ToggleGroup>
+        <SimpleButton
+          icon={
+            <FontAwesomeIcon icon={faUndo} />
+          }
+          tooltip={t('EditFeatureGeometryToolbar.undo')}
+          onClick={undoEdit}
+          disabled={editHistory.current.past?.length === 0}
+          {...btnTooltipProps}
+        />
+        <SimpleButton
+          icon={
+            <FontAwesomeIcon
+              icon={faUndo}
+              flip="horizontal"
             />
-            : <></>
-        }
-        {
-          allowedEditMode.includes('UPDATE') ?
-            <ModifyButton
-              icon={
-                <FontAwesomeIcon icon={faDrawPolygon} />
-              }
-              pressedIcon={
-                <FontAwesomeIcon icon={faDrawPolygon} />
-              }
-              name="edit"
-              digitizeLayer={editLayer}
-              tooltip={t('EditFeatureGeometryToolbar.edit')}
-              onModifyStart={updateRevision}
-              onModifyEnd={updateRevision}
-              onTranslateEnd={updateRevision}
-              {...btnTooltipProps}
-            />
-            : <></>
-        }
-        {
-          allowedEditMode.includes('DELETE') ?
-            <DeleteButton
-              icon={
-                <FontAwesomeIcon icon={faTrash} />
-              }
-              pressedIcon={
-                <FontAwesomeIcon icon={faTrash} />
-              }
-              name="delete"
-              digitizeLayer={editLayer}
-              tooltip={t('EditFeatureGeometryToolbar.delete')}
-              onFeatureRemove={updateRevision}
-              {...btnTooltipProps}
-            />
-            : <></>
-        }
-      </ToggleGroup>
-      <SimpleButton
-        icon={
-          <FontAwesomeIcon icon={faUndo} />
-        }
-        tooltip={t('EditFeatureGeometryToolbar.undo')}
-        onClick={undoEdit}
-        disabled={editHistory.current.past?.length === 0}
-        {...btnTooltipProps}
-      />
-      <SimpleButton
-        icon={
-          <FontAwesomeIcon
-            icon={faUndo}
-            flip="horizontal"
-          />
-        }
-        tooltip={t('EditFeatureGeometryToolbar.redo')}
-        onClick={redoEdit}
-        disabled={editHistory.current.future?.length === 0}
-        {...btnTooltipProps}
-      />
-    </Toolbar>
-
-  );
+          }
+          tooltip={t('EditFeatureGeometryToolbar.redo')}
+          onClick={redoEdit}
+          disabled={editHistory.current.future?.length === 0}
+          {...btnTooltipProps}
+        />
+      </Toolbar>
+    );
+  } else {
+    return <></>;
+  }
 };
 
 export default EditFeatureGeometryToolbar;

--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -472,26 +472,28 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
       setResultsVisible(false);
     };
 
-    if (
-      allowedEditMode.includes('CREATE') ||
-      allowedEditMode.includes('DELETE') ||
-      allowedEditMode.includes('UPDATE')
-    ) {
-      return [
-        <Tooltip
-          key="edit"
-          title={t('EditFeatureButton.title')}
-          placement="bottom"
-        >
-          <Button
-            onClick={onEditFeatureBtnClick}
-            icon={<EditOutlined />}
-          />
-        </Tooltip>
-      ];
-    } else {
-      return [<></>];
-    }
+    // button is temporarily disabled
+    return [<></>];
+    // if (
+    //   allowedEditMode.includes('CREATE') ||
+    //   allowedEditMode.includes('DELETE') ||
+    //   allowedEditMode.includes('UPDATE')
+    // ) {
+    //   return [
+    //     <Tooltip
+    //       key="edit"
+    //       title={t('EditFeatureButton.title')}
+    //       placement="bottom"
+    //     >
+    //       <Button
+    //         onClick={onEditFeatureBtnClick}
+    //         icon={<EditOutlined />}
+    //       />
+    //     </Tooltip>
+    //   ];
+    // } else {
+    //   return [<></>];
+    // }
   };
 
   const layerStyle = useMemo(() => (

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,6 +15,7 @@ declare module 'clientConfig' {
     authorizedRolesForCreate?: (string | RegExp)[];
     authorizedRolesForUpdate?: (string | RegExp)[];
     authorizedRolesForDelete?: (string | RegExp)[];
+    authorizedRolesForEditingGeometries?: (string | RegExp)[];
   };
   type ClientConfiguration = {
     shogunBase?: string;

--- a/src/store/editFeature/index.ts
+++ b/src/store/editFeature/index.ts
@@ -7,7 +7,12 @@ import {
   Feature
 } from 'geojson';
 
-export type EditLevel = 'CREATE' | 'UPDATE' | 'DELETE' | 'NONE';
+export type EditLevel =
+  | 'CREATE'
+  | 'UPDATE'
+  | 'DELETE'
+  | 'EDIT_GEOMETRY'
+  | 'NONE';
 export interface EditFeatureState {
   layerId: string | null;
   feature: Feature | null;


### PR DESCRIPTION
The configuration is extended so that only certain roles (`authorizedRolesForEditingGeometries`) can see the buttons for creating or editing geometries at all.

Additionally, the button in the `MultiSearch` for editing feature attributes is temporarily hidden.

@terrestris/devs please review