### PR TITLE
fix: prevent overlapping property labels

### DIFF
--- a/src/components/ToolMenu/FeatureInfo/FeatureInfoForm/index.less
+++ b/src/components/ToolMenu/FeatureInfo/FeatureInfoForm/index.less
@@ -1,0 +1,18 @@
+.feature-info-form {
+  .ant-input-number,
+  .ant-picker {
+    width: 100%;
+  }
+
+  .ant-form-item {
+    .ant-row {
+      .ant-col.ant-form-item-label {
+        margin-right: 5px;
+        label {
+          word-break: break-word;
+          hyphens: auto;
+        }
+      }
+    }
+  }
+}

--- a/src/components/ToolMenu/FeatureInfo/FeatureInfoForm/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/FeatureInfoForm/index.tsx
@@ -19,6 +19,8 @@ import {
 
 import DisplayField from '../../../DisplayField';
 
+import './index.less';
+
 export type FeatureInfoFormProps = FormProps & {
   formConfig?: PropertyFormItemReadConfig[];
   feature: OlFeature;
@@ -66,7 +68,7 @@ export const FeatureInfoForm: React.FC<FeatureInfoFormProps> = ({
       className="feature-info-form"
       form={form}
       labelCol={{
-        span: 6
+        span: 8
       }}
       labelAlign="left"
       labelWrap

--- a/src/components/ToolMenu/FeatureInfo/index.less
+++ b/src/components/ToolMenu/FeatureInfo/index.less
@@ -1,1 +1,10 @@
-
+.feature-info-panel {
+  .ant-drawer-content-wrapper {
+    max-width: 100vw;
+  }
+  .ant-drawer-body {
+    .error-alert {
+      margin-bottom: 20px;
+    }
+  }
+}


### PR DESCRIPTION
prevents overlapping property labels (uses the fixes of https://github.com/terrestris/shogun-gis-client/pull/976)