### PR TITLE
Adds missing pre-check for fieldProps

### DIFF
--- a/src/components/EditFeatureDrawer/EditFeatureForm/index.tsx
+++ b/src/components/EditFeatureDrawer/EditFeatureForm/index.tsx
@@ -199,7 +199,7 @@ export const EditFeatureForm: React.FC<EditFeatureFormProps> = ({
           />
         );
       case 'UPLOAD':
-        if (fieldCfg?.fieldProps.type === 'IMAGE') {
+        if (fieldCfg?.fieldProps?.type === 'IMAGE') {
           return (
             <ImageUpload
               {...fieldCfg?.fieldProps}


### PR DESCRIPTION
This MR adds a missing pre-check if the member variable `fieldProps` is present for the object `fieldCfg`

@terrestris/devs please review