### PR TITLE
Add edit button to GFI toolbar

### DIFF
--- a/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
+++ b/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
@@ -84,9 +84,8 @@ export const EditFeatureGeometryToolbar: React.FC<EditFeatureGeometryToolbarProp
 
   const gjFormat = useMemo(() => new OlFormatGeoJson(), []);
 
-  const allowedEditMode = useAppSelector(
-    state => state.editFeature.userEditMode
-  );
+  const allowedEditMode = useAppSelector(state => state.editFeature.userEditMode);
+  const formDirty = useAppSelector(state => state.editFeature.formDirty);
 
   useEffect(() => {
     if (!map) {
@@ -106,7 +105,11 @@ export const EditFeatureGeometryToolbar: React.FC<EditFeatureGeometryToolbarProp
 
   useEffect(() => {
     const isModified = editHistory.current.past.length > 0;
-    dispatch(setFormDirty(isModified));
+    if (isModified && !formDirty) {
+      dispatch(setFormDirty(true));
+    }
+  // we only want to change formDirty state when the editHistory changes
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, editHistory.current.past]);
 
   useEffect(() => {

--- a/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
+++ b/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
@@ -46,8 +46,14 @@ import {
   DigitizeUtil
 } from '@terrestris/react-geo/dist/Util/DigitizeUtil';
 
-import './index.less';
+import useAppDispatch from '../../../hooks/useAppDispatch';
 import useAppSelector from '../../../hooks/useAppSelector';
+
+import {
+  setFormDirty
+} from '../../../store/editFeature';
+
+import './index.less';
 
 export type EditFeatureGeometryToolbarProps = ToolbarProps & {
   feature: Feature;
@@ -71,6 +77,7 @@ export const EditFeatureGeometryToolbar: React.FC<EditFeatureGeometryToolbarProp
   });
 
   const map = useMap();
+  const dispatch = useAppDispatch();
 
   const [editLayer, setEditLayer] = useState<OlLayerVector<OlSourceVector<OlGeometry>>>();
   const [, setRevision] = useState<number>(0);
@@ -96,6 +103,11 @@ export const EditFeatureGeometryToolbar: React.FC<EditFeatureGeometryToolbarProp
       }
     };
   }, [editLayer, map]);
+
+  useEffect(() => {
+    const isModified = editHistory.current.past.length > 0;
+    dispatch(setFormDirty(isModified));
+  }, [dispatch, editHistory.current.past]);
 
   useEffect(() => {
     if (editLayer && feature?.id) {

--- a/src/components/EditFeatureDrawer/index.tsx
+++ b/src/components/EditFeatureDrawer/index.tsx
@@ -65,6 +65,7 @@ export const EditFeatureDrawer: React.FC<EditFeatureDrawerProps> = ({
   const isDrawerOpen = useAppSelector(state => state.editFeatureDrawerOpen);
   const layerId = useAppSelector(state => state.editFeature.layerId);
   const feature = useAppSelector(state => state.editFeature.feature);
+  const formDirty = useAppSelector(state => state.editFeature.formDirty);
 
   const map = useMap();
   const dispatch = useAppDispatch();
@@ -124,7 +125,7 @@ export const EditFeatureDrawer: React.FC<EditFeatureDrawerProps> = ({
   };
 
   const onDrawerClose = () => {
-    if (layer && feature) {
+    if (layer && feature && formDirty) {
       Modal.confirm({
         maskClosable: false,
         title: t('EditFeatureDrawer.closeDrawerWarnTitle'),

--- a/src/components/ToolMenu/FeatureInfo/FeatureInfoTabs/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/FeatureInfoTabs/index.tsx
@@ -36,11 +36,13 @@ export type FeatureInfoTabsProps = TabsProps & {
   features: OlFeature[];
   layerName: string;
   tabConfig?: PropertyFormTabConfig<PropertyFormItemReadConfig>[];
+  layerUuid: string;
 };
 
 export const FeatureInfoTabs: React.FC<FeatureInfoTabsProps> = ({
   features,
   layerName,
+  layerUuid,
   tabConfig,
   ...passThroughProps
 }) => {
@@ -146,6 +148,7 @@ export const FeatureInfoTabs: React.FC<FeatureInfoTabsProps> = ({
         features={features}
         selectedFeature={selectedFeature}
         current={currentPage}
+        layerUuid={layerUuid}
         onChange={onChange}
         exportFilter={exportFilter}
       />

--- a/src/components/ToolMenu/FeatureInfo/FeatureInfoTabs/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/FeatureInfoTabs/index.tsx
@@ -9,6 +9,7 @@ import {
 } from 'antd';
 
 import OlFeature from 'ol/Feature';
+import OlLayer from 'ol/layer/Layer';
 import OlLayerVector from 'ol/layer/Vector';
 import OlSourceVector from 'ol/source/Vector';
 
@@ -36,13 +37,13 @@ export type FeatureInfoTabsProps = TabsProps & {
   features: OlFeature[];
   layerName: string;
   tabConfig?: PropertyFormTabConfig<PropertyFormItemReadConfig>[];
-  layerUuid: string;
+  layer: OlLayer;
 };
 
 export const FeatureInfoTabs: React.FC<FeatureInfoTabsProps> = ({
   features,
   layerName,
-  layerUuid,
+  layer,
   tabConfig,
   ...passThroughProps
 }) => {
@@ -148,7 +149,7 @@ export const FeatureInfoTabs: React.FC<FeatureInfoTabsProps> = ({
         features={features}
         selectedFeature={selectedFeature}
         current={currentPage}
-        layerUuid={layerUuid}
+        layer={layer}
         onChange={onChange}
         exportFilter={exportFilter}
       />

--- a/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
@@ -125,24 +125,34 @@ export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
     if (!layer || !map) {
       return;
     }
+
     const selectedFeatureClone = selectedFeature.clone();
     const geojsonFeatureString = new OlFormatGeoJSON().writeFeature(selectedFeatureClone);
 
     try {
       const geojsonFeature = JSON.parse(geojsonFeatureString) as Feature;
       const editLayer = DigitizeUtil.getDigitizeLayer(map);
-      if (editLayer) {
-        const source = editLayer.getSource();
-        if (source) {
-          source.clear();
-          source.addFeature(selectedFeature);
-          if (!isEmptyOlExtent(source.getExtent())) {
-            map.getView().fit(source.getExtent(), {
-              padding: [150, 150, 150, 150]
-            });
-          }
-        }
+
+      if (!editLayer) {
+        return;
       }
+
+      const source = editLayer.getSource();
+
+      if (!source) {
+        return;
+      }
+
+      source.clear();
+      source.addFeature(selectedFeature);
+
+      if (isEmptyOlExtent(source.getExtent())) {
+        return;
+      }
+
+      map.getView().fit(source.getExtent(), {
+        padding: [150, 150, 150, 150]
+      });
       dispatch(setLayerId(getUid(layer)));
       dispatch(setFeature(geojsonFeature));
       dispatch(showEditFeatureDrawer());

--- a/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
@@ -41,6 +41,7 @@ import {
 import { DigitizeUtil } from '@terrestris/react-geo/dist/Util/DigitizeUtil';
 
 import useAppDispatch from '../../../../hooks/useAppDispatch';
+import useAppSelector from '../../../../hooks/useAppSelector';
 import {
   setLayerId,
   setFeature
@@ -71,6 +72,10 @@ export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
   } = useTranslation();
   const dispatch = useAppDispatch();
   const map = useMap();
+
+  const allowedEditMode = useAppSelector(
+    state => state.editFeature.userEditMode
+  );
 
   const onCopyAsGeoJSONClick = () => {
     if (!selectedFeature) {
@@ -156,18 +161,24 @@ export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
       <div
         className="copy-buttons"
       >
-        <Tooltip
-          key="edit"
-          title={t('PaginationToolbar.editFeature')}
-          placement="bottom"
-        >
-          <Button
-            type="primary"
-            size="small"
-            onClick={onEditFeatureBtnClick}
-            icon={<FontAwesomeIcon icon={faEdit} />}
-          />
-        </Tooltip>
+        {
+          (allowedEditMode.includes('CREATE') ||
+          allowedEditMode.includes('DELETE') ||
+          allowedEditMode.includes('UPDATE')) && (
+            <Tooltip
+              key="edit"
+              title={t('PaginationToolbar.editFeature')}
+              placement="bottom"
+            >
+              <Button
+                type="primary"
+                size="small"
+                onClick={onEditFeatureBtnClick}
+                icon={<FontAwesomeIcon icon={faEdit} />}
+              />
+            </Tooltip>
+          )
+        }
         <Tooltip
           title={t('PaginationToolbar.copyAsGeoJson')}
         >

--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -187,6 +187,7 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
                     tabConfig={mapLayer?.get('featureInfoFormConfig')}
                     features={features[layerName]}
                     layerName={layerName}
+                    layerUuid={getUid(mapLayer)}
                   /> :
                   <FeatureInfoPropertyGrid
                     features={features[layerName]}

--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -187,7 +187,7 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
                     tabConfig={mapLayer?.get('featureInfoFormConfig')}
                     features={features[layerName]}
                     layerName={layerName}
-                    layerUuid={getUid(mapLayer)}
+                    layer={mapLayer}
                   /> :
                   <FeatureInfoPropertyGrid
                     features={features[layerName]}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -218,7 +218,8 @@ export default {
       },
       PaginationToolbar: {
         copyAsGeoJson: 'Als GeoJSON kopieren (inkl. Geometrie)',
-        copyAsObject: 'Als Objekt kopieren (nur angezeigte Werte)'
+        copyAsObject: 'Als Objekt kopieren (nur angezeigte Werte)',
+        editFeature: 'Feature editieren'
       },
       JsonModal: {
         buttonTitle: 'Öffne {{propertyName}}'
@@ -444,7 +445,8 @@ export default {
       },
       PaginationToolbar: {
         copyAsGeoJson: 'Copy as GeoJSON (incl. geometry)',
-        copyAsObject: 'Copy as object (displayed values only)'
+        copyAsObject: 'Copy as object (displayed values only)',
+        editFeature: 'Edit feature'
       },
       JsonModal: {
         buttonTitle: 'Show {{propertyName}}'

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -219,6 +219,7 @@ export default {
       PaginationToolbar: {
         copyAsGeoJson: 'Als GeoJSON kopieren (inkl. Geometrie)',
         copyAsObject: 'Als Objekt kopieren (nur angezeigte Werte)',
+        editDisabled: 'Layer ist nicht editierbar',
         editFeature: 'Feature editieren'
       },
       JsonModal: {
@@ -446,6 +447,7 @@ export default {
       PaginationToolbar: {
         copyAsGeoJson: 'Copy as GeoJSON (incl. geometry)',
         copyAsObject: 'Copy as object (displayed values only)',
+        editDisabled: 'This layer is not editable',
         editFeature: 'Edit feature'
       },
       JsonModal: {


### PR DESCRIPTION
- allows to switch to the edit feature form directly from GFI

![image](https://github.com/terrestris/shogun-gis-client/assets/5795523/22997838-ca43-462c-aa21-ed341a94fd2b)

Bugfixes:

- sets formDirty when geometry is modified
- skip exit confirmation in edit feature form if form is not dirty
- minor fixes

@terrestris/devs Please review