### PR TITLE
fix: don't clone the feature to keep the existing id intact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@terrestris/base-util": "^1.0.1",
         "@terrestris/mapfish-print-manager": "^10.0.0",
         "@terrestris/ol-util": "^12.0.1",
-        "@terrestris/react-geo": "^23.0.0",
+        "@terrestris/react-geo": "^23.0.1",
         "@terrestris/react-util": "^3.0.0",
         "@terrestris/shogun-e2e-tests": "^1.0.4",
         "@terrestris/shogun-util": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@terrestris/base-util": "^1.0.1",
     "@terrestris/mapfish-print-manager": "^10.0.0",
     "@terrestris/ol-util": "^12.0.1",
-    "@terrestris/react-geo": "^23.0.0",
+    "@terrestris/react-geo": "^23.0.1",
     "@terrestris/react-util": "^3.0.0",
     "@terrestris/shogun-e2e-tests": "^1.0.4",
     "@terrestris/shogun-util": "^7.2.0",

--- a/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
@@ -126,8 +126,7 @@ export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
       return;
     }
 
-    const selectedFeatureClone = selectedFeature.clone();
-    const geojsonFeatureString = new OlFormatGeoJSON().writeFeature(selectedFeatureClone);
+    const geojsonFeatureString = new OlFormatGeoJSON().writeFeature(selectedFeature);
 
     try {
       const geojsonFeature = JSON.parse(geojsonFeatureString) as Feature;


### PR DESCRIPTION
This is required to keep the existing id passed from the server.

Requires https://github.com/terrestris/react-geo/pull/3532

Please review @terrestris/devs.