### PR TITLE
fix: fixing onChange by passing the correct state

### DIFF
--- a/src/components/PrintForm/LayoutSelect/index.tsx
+++ b/src/components/PrintForm/LayoutSelect/index.tsx
@@ -45,7 +45,7 @@ export const LayoutSelect: React.FC<LayoutSelectProps> = ({
     <Select
       placeholder={placeholder}
       value={layout}
-      onChange={setLayout}
+      onChange={layout}
       {...restProps}
     >
       {


### PR DESCRIPTION
Title Says it all. 

Two Prints in each format are appended.

[mapfish-print-report (6).pdf](https://github.com/terrestris/shogun-gis-client/files/13362912/mapfish-print-report.6.pdf)
[mapfish-print-report (5).pdf](https://github.com/terrestris/shogun-gis-client/files/13362914/mapfish-print-report.5.pdf)
