### PR TITLE
Draw upload: error handling and userinformation

### DIFF
--- a/src/components/ToolMenu/Draw/index.tsx
+++ b/src/components/ToolMenu/Draw/index.tsx
@@ -1,5 +1,5 @@
 import React, {
-  ChangeEvent
+  ChangeEvent, useState
 } from 'react';
 
 import {
@@ -18,6 +18,7 @@ import {
   FontAwesomeIcon
 } from '@fortawesome/react-fontawesome';
 
+import { message } from 'antd';
 import {
   Feature
 } from 'ol';
@@ -119,6 +120,9 @@ export const Draw: React.FC<DrawProps> = ({
       )
     ) {
       onGeoJSONUpload(uploadedFiles[0]);
+      message.success(t('Draw.uploadSuccess'));
+    } else {
+      message.error(t('Draw.uploadError'));
     }
   };
 

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -45,6 +45,8 @@ export default {
         text: 'Anmerkung',
         modify: 'Bearbeitung',
         upload: 'Hochladen',
+        uploadSuccess: 'Die Datei wurde erfolgreich importiert',
+        uploadError: 'Nur .geojson Dateien können importiert werden',
         delete: 'Löschen',
         export: 'Exportieren'
       },
@@ -282,6 +284,8 @@ export default {
         text: 'Annotation',
         modify: 'Edit',
         upload: 'Upload',
+        uploadSuccess: 'The file was uploaded successfully',
+        uploadError: 'Only files of the type .geojson are supported',
         delete: 'Delete',
         export: 'Export'
       },

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -46,7 +46,7 @@ export default {
         modify: 'Bearbeitung',
         upload: 'Hochladen',
         uploadSuccess: 'Die Datei wurde erfolgreich importiert',
-        uploadError: 'Nur .geojson Dateien können importiert werden',
+        uploadError: 'Der Import ist fehlgeschlagen. Bitte beachten Sie, dass nur .geojson-Dateien unterstützt werden.',
         delete: 'Löschen',
         export: 'Exportieren'
       },
@@ -285,7 +285,7 @@ export default {
         modify: 'Edit',
         upload: 'Upload',
         uploadSuccess: 'The file was uploaded successfully',
-        uploadError: 'Only files of the type .geojson are supported',
+        uploadError: 'The import failed, please note that only .geojson files are supported',
         delete: 'Delete',
         export: 'Export'
       },


### PR DESCRIPTION
On a successful upload a message will appear informing the user about a successful upload.
On an error, a error message will appear informing the user, that only .geojson files can be uploaded.