### PR TITLE
feat: remove twitter from permalink

### DIFF
--- a/src/components/Permalink/index.tsx
+++ b/src/components/Permalink/index.tsx
@@ -5,7 +5,6 @@ import React, {
 import {
   CopyOutlined,
   MailOutlined,
-  TwitterOutlined,
   WhatsAppOutlined
 } from '@ant-design/icons';
 import {
@@ -161,9 +160,6 @@ export const Permalink: React.FC<PermalinkProps> = () => {
   return (
     <div className="permalink-wrapper">
       <div className="icons">
-        <Tooltip title={t('Permalink.twitterTooltip')}>
-          <TwitterOutlined onClick={onTwitterClick} />
-        </Tooltip>
         <Tooltip title={t('Permalink.whatsAppTooltip')}>
           <WhatsAppOutlined onClick={onWhatsAppClick} />
         </Tooltip>

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -22,7 +22,6 @@ export default {
       },
       Permalink: {
         title: 'Teilen',
-        twitterTooltip: 'Link via Twitter teilen',
         whatsAppTooltip: 'Link via WhatsApp teilen',
         mailTooltip: 'Link via Mail teilen',
         copyTooltip: 'Link in die Zwischenablage kopieren',
@@ -259,7 +258,6 @@ export default {
       },
       Permalink: {
         title: 'Share',
-        twitterTooltip: 'Share link via Twitter',
         whatsAppTooltip: 'Share link via WhatsApp',
         mailTooltip: 'Share link via Mail',
         copyTooltip: 'Copy link to Clipboard',


### PR DESCRIPTION
Removes twitter from permalink share temporally since its now renamed and a x-icon is not existing yet.