### PR TITLE
Feature info: make copy tools configurable via tool-config in admin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9482,6 +9482,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12787,6 +12788,7 @@
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -25278,6 +25280,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -27947,6 +27950,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "clean:dist": "rimraf ./dist/*",
     "husky": "husky install",
     "lint": "eslint -c .eslintrc.js --ext .ts,.tsx src/",
+    "lint:fix": "eslint -c .eslintrc.js --ext .ts,.tsx src/ --fix",
     "prepare": "npm run husky",
     "semantic-release": "npm run clean; npm run build; npx semantic-release",
     "start": "webpack serve --config webpack.dev.js",

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -87,6 +87,7 @@ import {
   setUserEditMode,
   EditLevel
 } from './store/editFeature';
+import { setFeatureInfoActiveCopyTools } from './store/featureInfo';
 import {
   setLegal
 } from './store/legal';
@@ -226,6 +227,9 @@ const setApplicationToStore = async (application?: Application) => {
         }
         if (tool.name === 'search' && tool.config.engines.length > 0) {
           store.dispatch(setSearchEngines(tool.config.engines));
+        }
+        if (tool.name === 'feature_info' && tool.config.activeCopyTools?.length > 0) {
+          store.dispatch(setFeatureInfoActiveCopyTools(tool.config.activeCopyTools));
         }
       });
     store.dispatch(setAvailableTools(availableTools));

--- a/src/components/ToolMenu/FeatureInfo/FeatureInfoTabs/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/FeatureInfoTabs/index.tsx
@@ -8,6 +8,7 @@ import {
   TabsProps
 } from 'antd';
 
+import _isNil from 'lodash/isNil';
 import OlFeature from 'ol/Feature';
 import OlLayer from 'ol/layer/Layer';
 import OlLayerVector from 'ol/layer/Vector';
@@ -127,7 +128,7 @@ export const FeatureInfoTabs: React.FC<FeatureInfoTabsProps> = ({
   };
 
   const items = tabConfig
-    .filter(config => config !== undefined)
+    .filter(config => !_isNil(config))
     .map((config, idx) => {
       return {
         label: config.title,
@@ -152,12 +153,12 @@ export const FeatureInfoTabs: React.FC<FeatureInfoTabsProps> = ({
       className="feature-info-tabs"
     >
       <PaginationToolbar
-        features={features}
-        selectedFeature={selectedFeature}
         current={currentPage}
+        exportFilter={exportFilter}
+        features={features}
         layer={layer}
         onChange={onChange}
-        exportFilter={exportFilter}
+        selectedFeature={selectedFeature}
       />
       <Tabs
         items={items}

--- a/src/components/ToolMenu/FeatureInfo/FeaturePropertyGrid/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/FeaturePropertyGrid/index.tsx
@@ -7,8 +7,6 @@ import {
   TableProps
 } from 'antd';
 
-import _isFinite from 'lodash/isFinite';
-
 import OlFeature from 'ol/Feature';
 import OlGeometry from 'ol/geom/Geometry';
 import OlLayerVector from 'ol/layer/Vector';

--- a/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
@@ -21,8 +21,7 @@ import copy from 'copy-to-clipboard';
 import {
   Feature
 } from 'geojson';
-
-import _isFinite from 'lodash/isFinite';
+import _clone from 'lodash/clone';
 
 import {
   getUid
@@ -53,21 +52,24 @@ import {
 import {
   show as showEditFeatureDrawer
 } from '../../../../store/editFeatureDrawerOpen';
+import { CopyTools } from '../../../../store/featureInfo';
 
 import './index.less';
 
 export type PaginationToolbarProps = {
-  features: OlFeature[];
-  selectedFeature: OlFeature;
   exportFilter?: (propertyName: string, propertyValue: string) => boolean;
+  features: OlFeature[];
+  isCopyAsGeoJsonEnabled?: boolean;
   layer?: OlLayer;
+  selectedFeature: OlFeature;
 } & PaginationProps;
 
 export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
-  features,
-  selectedFeature,
-  layer,
   exportFilter,
+  features,
+  isCopyAsGeoJsonEnabled = true,
+  layer,
+  selectedFeature,
   ...passThroughProps
 }): JSX.Element => {
 
@@ -76,6 +78,8 @@ export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
   } = useTranslation();
   const dispatch = useAppDispatch();
   const map = useMap();
+
+  const activeCopyTools = useAppSelector(state => state.featureInfo.activeCopyTools);
 
   const allowedEditMode = useAppSelector(
     state => state.editFeature.userEditMode
@@ -111,7 +115,7 @@ export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
       return;
     }
 
-    let props = Object.entries(structuredClone(selectedFeature.getProperties()))
+    let props = Object.entries(_clone(selectedFeature.getProperties()))
       .filter(([, value]) => !(value instanceof OlGeometry));
 
     if (exportFilter) {
@@ -195,26 +199,34 @@ export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
             </Tooltip>
           )
         }
-        <Tooltip
-          title={t('PaginationToolbar.copyAsGeoJson')}
-        >
-          <Button
-            type="primary"
-            size="small"
-            onClick={onCopyAsGeoJSONClick}
-            icon={<FontAwesomeIcon icon={faClipboardCheck} />}
-          />
-        </Tooltip>
-        <Tooltip
-          title={t('PaginationToolbar.copyAsObject')}
-        >
-          <Button
-            type="primary"
-            size="small"
-            onClick={onCopyAsObjectClick}
-            icon={<FontAwesomeIcon icon={faClipboardList} />}
-          />
-        </Tooltip>
+        {
+          activeCopyTools?.includes(CopyTools.COPY_AS_GEOJSON) && (
+            <Tooltip
+              title={t('PaginationToolbar.copyAsGeoJson')}
+            >
+              <Button
+                type="primary"
+                size="small"
+                onClick={onCopyAsGeoJSONClick}
+                icon={<FontAwesomeIcon icon={faClipboardCheck} />}
+              />
+            </Tooltip>
+          )
+        }
+        {
+          activeCopyTools?.includes(CopyTools.COPY_AS_OBJECT) && (
+            <Tooltip
+              title={t('PaginationToolbar.copyAsObject')}
+            >
+              <Button
+                type="primary"
+                size="small"
+                onClick={onCopyAsObjectClick}
+                icon={<FontAwesomeIcon icon={faClipboardList} />}
+              />
+            </Tooltip>
+          )
+        }
       </div>
     </div>
   );

--- a/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
@@ -59,7 +59,6 @@ import './index.less';
 export type PaginationToolbarProps = {
   exportFilter?: (propertyName: string, propertyValue: string) => boolean;
   features: OlFeature[];
-  isCopyAsGeoJsonEnabled?: boolean;
   layer?: OlLayer;
   selectedFeature: OlFeature;
 } & PaginationProps;
@@ -67,7 +66,6 @@ export type PaginationToolbarProps = {
 export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
   exportFilter,
   features,
-  isCopyAsGeoJsonEnabled = true,
   layer,
   selectedFeature,
   ...passThroughProps

--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -54,7 +54,7 @@ export type FeatureInfoConfig = {
   activeCopyTools?: CopyTools[];
 };
 
-export type FeatureInfoProps = FormProps & FeatureInfoConfig & Partial<CoordinateInfoProps>;
+export type FeatureInfoProps = FormProps & Partial<CoordinateInfoProps>;
 
 type LayerIndex = {
   layerName: string;

--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -1,18 +1,12 @@
 import React, {
-  useCallback,
-  useEffect,
-  useState
+  useCallback, useEffect, useState
 } from 'react';
 
 import {
-  Tabs,
-  FormProps,
-  Spin
+  FormProps, Spin, Tabs
 } from 'antd';
 
-import {
-  getUid
-} from 'ol';
+import { getUid } from 'ol';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import OlLayerBase from 'ol/layer/Base';
 import OlLayerImage from 'ol/layer/Image';
@@ -20,53 +14,47 @@ import OlLayerTile from 'ol/layer/Tile';
 import OlSourceImageWMS from 'ol/source/ImageWMS';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 
-import {
-  Tab
-} from 'rc-tabs/lib/interface';
+import { Tab } from 'rc-tabs/lib/interface';
 
-import {
-  useTranslation
-} from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 import CoordinateInfo, {
-  CoordinateInfoState,
-  CoordinateInfoProps
+  CoordinateInfoProps,
+  CoordinateInfoState
 } from '@terrestris/react-geo/dist/CoordinateInfo/CoordinateInfo';
+import { useMap } from '@terrestris/react-geo/dist/Hook/useMap';
 import {
-  useMap
-} from '@terrestris/react-geo/dist/Hook/useMap';
-import {
-  isWmsLayer,
-  WmsLayer
+  isWmsLayer, WmsLayer
 } from '@terrestris/react-geo/dist/Util/typeUtils';
 
-import {
-  getBearerTokenHeader
-} from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
+import { getBearerTokenHeader } from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
 
 import useAppDispatch from '../../../hooks/useAppDispatch';
+import useAppSelector from '../../../hooks/useAppSelector';
 import usePlugins from '../../../hooks/usePlugins';
 import useSHOGunAPIClient from '../../../hooks/useSHOGunAPIClient';
 
-import {
-  isFeatureInfoIntegration
-} from '../../../plugin';
+import { isFeatureInfoIntegration } from '../../../plugin';
 
+import { CopyTools } from '../../../store/featureInfo';
 import {
-  SelectedFeatures,
-  setSelectedFeatures
+  SelectedFeatures, setSelectedFeatures
 } from '../../../store/selectedFeatures';
 
 import FeatureInfoTabs from './FeatureInfoTabs';
+
 import FeatureInfoPropertyGrid from './FeaturePropertyGrid';
 
 import './index.less';
 
-export type FeatureInfoProps = FormProps & {
+export type FeatureInfoConfig = {
   enabled?: boolean;
-} & Partial<CoordinateInfoProps>;
+  activeCopyTools?: CopyTools[];
+};
+
+export type FeatureInfoProps = FormProps & FeatureInfoConfig & Partial<CoordinateInfoProps>;
 
 type LayerIndex = {
   layerName: string;
@@ -74,9 +62,9 @@ type LayerIndex = {
 };
 
 export const FeatureInfo: React.FC<FeatureInfoProps> = ({
-  enabled,
   ...restProps
 }): JSX.Element => {
+
   const {
     t
   } = useTranslation();
@@ -88,6 +76,7 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
 
   const [queryLayers, setQueryLayers] = useState<WmsLayer[]>([]);
   const [activeTabKey, setActiveTabKey] = useState<string | undefined>(undefined);
+  const featureInfoEnabled = useAppSelector(state => state.featureInfo.enabled);
 
   const layerFilter = (layer: OlLayerBase) => {
     if (!layer.get('hoverable')) {
@@ -135,7 +124,7 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
   const findMapLayerIndex = (layerName: string) => {
     const allLayers = map.getAllLayers();
 
-    const mapLayerIndex = allLayers.findIndex(l => {
+    return allLayers.findIndex(l => {
       if (isWmsLayer(l)) {
         const source = (l as WmsLayer).getSource();
         const unqualifiedMapLayerName = getUnqualifiedLayerName(source?.getParams().LAYERS);
@@ -145,8 +134,6 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
       }
       return false;
     });
-
-    return mapLayerIndex;
   };
 
   const resultRenderer = (coordinateInfoState: CoordinateInfoState) => {
@@ -246,7 +233,7 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
       layerName.split(':')[0];
   };
 
-  if (!enabled) {
+  if (!featureInfoEnabled) {
     return <></>;
   }
 

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -58,6 +58,7 @@ import {
 import {
   show as showAdd
 } from '../../store/addLayerModal';
+import { setFeatureInfoEnabled } from '../../store/featureInfo';
 import {
   setActiveKeys
 } from '../../store/toolMenu';
@@ -72,8 +73,8 @@ import PrintForm from '../PrintForm';
 import Draw from './Draw';
 import FeatureInfo from './FeatureInfo';
 import LayerTree from './LayerTree';
-import Measure from './Measure';
 
+import Measure from './Measure';
 import './index.less';
 
 export interface TitleEventEntity {
@@ -152,6 +153,8 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
         );
       }
     }
+
+    dispatch(setFeatureInfoEnabled(activeKeys.includes('feature_info')));
   }, [activeKeys, dispatch]);
 
   const getToolPanels = (): JSX.Element[] => {
@@ -265,9 +268,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
           icon: faMousePointer,
           title: t('ToolMenu.featureInfo'),
           wrappedComponent: (
-            <FeatureInfo
-              enabled={activeKeys.includes('feature_info')}
-            />
+            <FeatureInfo />
           )
         };
       case 'print':

--- a/src/store/featureInfo/index.ts
+++ b/src/store/featureInfo/index.ts
@@ -1,0 +1,40 @@
+import {
+  createSlice,
+  PayloadAction
+} from '@reduxjs/toolkit';
+
+import { FeatureInfoConfig } from '../../components/ToolMenu/FeatureInfo';
+
+// eslint-disable-next-line no-shadow
+export enum CopyTools {
+  COPY_AS_GEOJSON = 'COPY_AS_GEOJSON',
+  COPY_AS_OBJECT = 'COPY_AS_OBJECT'
+}
+
+const initialState: FeatureInfoConfig = {
+  enabled: false,
+  activeCopyTools: [CopyTools.COPY_AS_GEOJSON, CopyTools.COPY_AS_OBJECT]
+};
+
+export const slice = createSlice({
+  name: 'featureInfo',
+  initialState,
+  reducers: {
+    setFeatureInfoConfig(state, action: PayloadAction<FeatureInfoConfig>) {
+      state = action.payload;
+    },
+    setFeatureInfoEnabled(state, action: PayloadAction<boolean>) {
+      state.enabled = action.payload;
+    },
+    setFeatureInfoActiveCopyTools(state, action: PayloadAction<CopyTools[]>) {
+      state.activeCopyTools = action.payload;
+    }
+  }
+});
+
+export const {
+  setFeatureInfoEnabled,
+  setFeatureInfoActiveCopyTools
+} = slice.actions;
+
+export default slice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -9,6 +9,7 @@ import appInfo from './appInfo';
 import description from './description';
 import editFeature from './editFeature';
 import editFeatureDrawerOpen from './editFeatureDrawerOpen';
+import featureInfo from './featureInfo';
 import layerDetailsModal from './layerDetailsModal';
 import legal from './legal';
 import logoPath from './logoPath';
@@ -31,6 +32,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     description,
     editFeature,
     editFeatureDrawerOpen,
+    featureInfo,
     layerDetailsModal,
     legal,
     logoPath,


### PR DESCRIPTION
See title

This PR contains a *breaking change*: The `enabled` state is now handled in a new `featureInfo` slice.

In shogun-admin, the copy tools can be provided as follows:

```
...
{
  "name": "feature_info",
  "config": {
    "visible": true,
    "activeCopyTools": [
      "COPY_AS_OBJECT"
    ]
  }
},
...
```

Plz review @terrestris/devs 