### PR TITLE
Tool menu layout

### DIFF
--- a/src/components/ToolMenu/Draw/index.less
+++ b/src/components/ToolMenu/Draw/index.less
@@ -6,7 +6,7 @@
 
     &.btn-pressed {
       background-color: white;
-      color: var(--ant-primary-10);
+      color: var(--secondaryColor);
       font-weight: 500;
     }
   }

--- a/src/components/ToolMenu/Measure/index.less
+++ b/src/components/ToolMenu/Measure/index.less
@@ -6,7 +6,7 @@
 
     &.btn-pressed {
       background-color: white;
-      color: var(--ant-primary-10);
+      color: var(--secondaryColor);
       font-weight: 500;
     }
   }

--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -129,6 +129,6 @@
 
   .react-geo-togglebutton.btn-pressed {
     font-size: 1.2em;
-    text-shadow: 0.5px 0.5px 0.5px grey;
+    text-shadow: 0.5px 0.5px 0.5px var(--secondaryColor);
   }
 }

--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -129,6 +129,6 @@
 
   .react-geo-togglebutton.btn-pressed {
     font-size: 1.2em;
-    text-shadow: 0.5px 0.5px 0.5px var(--secondaryColor);
+    text-shadow: 0.5px 0.5px 0.5px color-mix(in srgb, var(--secondaryColor), black 20%);
   }
 }


### PR DESCRIPTION
This MR changes the color of the active Button within the toolbar.

Instead of a default Black the secondary color is now used, which can be adjusted dynamically via the admin-client.

![styling](https://github.com/terrestris/shogun-gis-client/assets/100765498/baa9bc7f-e091-45bd-a5e7-5ebfb210d918)
