### PR TITLE
Removes all competing actions in the map tools

### DIFF
--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -141,15 +141,26 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
   }, [menuTools, availableTools]);
 
   useEffect(() => {
-    if (
-      activeKeys.includes('print') &&
-      activeKeys.includes('measure_tools')
-    ) {
-      if (activeKeys.indexOf('print') < activeKeys.indexOf('measure_tools')) {
-        dispatch(setActiveKeys(activeKeys.filter(keys => keys !== 'print')));
-      } else {
+    const exclusiveTools = [
+      'print',
+      'measure_tools',
+      'draw_tools',
+      'feature_info'
+    ];
+
+    const activeExclusiveTools = exclusiveTools.filter(tool =>
+      activeKeys.includes(tool)
+    );
+
+    if (activeExclusiveTools.length > 1) {
+      const lastExclusiveTool = activeKeys
+        .slice(0, activeKeys.length - 1)
+        .reverse()
+        .find(tool => exclusiveTools.includes(tool));
+
+      if (lastExclusiveTool) {
         dispatch(
-          setActiveKeys(activeKeys.filter(keys => keys !== 'measure_tools'))
+          setActiveKeys(activeKeys.filter(keys => keys !== lastExclusiveTool))
         );
       }
     }


### PR DESCRIPTION
With this PR, all competing actions are removed. This means that of the 4 tools "Measure", "Draw", "Query MapFeatures" and "Print", only one map interaction is active at a time.

![Peek 2024-01-15 12-01](https://github.com/terrestris/shogun-gis-client/assets/43119593/4b7a41cb-e04b-4e4f-b1cc-a6043e7836b1)

@terrestris/devs please review