### PR TITLE
Reset print form fields

### DIFF
--- a/src/components/PrintForm/index.tsx
+++ b/src/components/PrintForm/index.tsx
@@ -251,13 +251,14 @@ export const PrintForm: React.FC<PrintFormProps> = ({
   useEffect(() => {
     if (active) {
       if (!printManager) {
+        form.resetFields();
         initializeMapProvider();
       }
     } else {
       printManager?.shutdownManager();
       setPrintManager(null);
     }
-  }, [printManager, active, initializeMapProvider]);
+  }, [printManager, active, initializeMapProvider, form]);
 
   useEffect(() => {
     if (printManager) {


### PR DESCRIPTION
During normal usage of the `PrintForm`, the fields are already reset when a new print is  configured. However, if `PrintForm` was used as a plugin, this action did not take place and remarks, titles, etc. from a previous print were still present in the fields and had to be removed or adjusted manually. 

With this PR the form fields are now also reset when used as a plug-in for a new print.

@terrestris/devs please review