### PR TITLE
Removes github api token varaible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         id: semantic
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_API_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           semantic_version: 19


### PR DESCRIPTION
Removes GH Api token from release workflow, see also https://github.com/semantic-release/github/issues/542 and https://github.com/semantic-release/github/releases/tag/v8.0.8.