### PR TITLE
Use github token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         id: semantic
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           semantic_version: 19


### PR DESCRIPTION
An automatically generated GitHub token seems to be required (see also: https://github.com/cycjimmy/semantic-release-action?tab=readme-ov-file#usage). This PR inserts the `GITHUB_TOKEN` secret into the release workflow.

@terrestris/devs please review