### PR TITLE
Allow empty array of copy tools in FeatureInfo

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -233,7 +233,7 @@ const setApplicationToStore = async (application?: Application) => {
         if (tool.name === 'search' && tool.config.engines.length > 0) {
           store.dispatch(setSearchEngines(tool.config.engines));
         }
-        if (tool.name === 'feature_info' && tool.config.activeCopyTools?.length > 0) {
+        if (tool.name === 'feature_info' && Array.isArray(tool.config.activeCopyTools)) {
           store.dispatch(setFeatureInfoActiveCopyTools(tool.config.activeCopyTools));
         }
       });

--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -6,7 +6,6 @@ import {
   FormProps, Spin, Tabs
 } from 'antd';
 
-import { getUid } from 'ol';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import OlLayerBase from 'ol/layer/Base';
 import OlLayerImage from 'ol/layer/Image';


### PR DESCRIPTION
Using the following `feature_info` configuration in SHOGun-admin

```
  {
    "name": "feature_info",
    "config": {
      "visible": true,
      "activeCopyTools": []
    }
  }
```

its possible now to deactivate all copy tools in `PaginationToolbar` if required

Plz review @terrestris/devs  