### PR TITLE
Fix development server websocket configuration

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,6 @@ FROM node:18.18.2-alpine3.17
 
 WORKDIR /app
 
-EXPOSE 3000
+EXPOSE 8080
 
 ENTRYPOINT ["npm", "run", "start"]

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -12,8 +12,11 @@ module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
   devServer: {
-    server: 'https',
-    port: 3000,
+    server: 'http',
+    port: 8080,
+    client: {
+      webSocketURL: 'http://0.0.0.0:0/client/ws'
+    },
     hot: true,
     static: path.join(__dirname, 'resources', 'public')
   },


### PR DESCRIPTION
This updates the webpack development server configuration by:

- changing the protocol from `https` to `http` (in the [recommended setup](https://github.com/terrestris/shogun-docker) it's proxied by a https server anyway).
- fixing the websocket client path to match the location given in the [nginx](https://github.com/terrestris/shogun-docker/blob/main/shogun-nginx/dev/default.conf#L95) proxy.
- setting the http port to 8080 (not needed in particular to be honest).

Together with [PR 92](https://github.com/terrestris/shogun-docker/pull/92) this fixes the need to manually confirm the development certificate for the web socket connection.

Please review @terrestris/devs.