### PR TITLE
Draw tool redesign

### DIFF
--- a/src/components/ToolMenu/Draw/index.tsx
+++ b/src/components/ToolMenu/Draw/index.tsx
@@ -395,6 +395,7 @@ export const Draw: React.FC<DrawProps> = ({
       />
     </>
   );
+
 };
 
 export default Draw;

--- a/src/components/ToolMenu/Draw/index.tsx
+++ b/src/components/ToolMenu/Draw/index.tsx
@@ -395,7 +395,6 @@ export const Draw: React.FC<DrawProps> = ({
       />
     </>
   );
-
 };
 
 export default Draw;

--- a/src/components/ToolMenu/Draw/index.tsx
+++ b/src/components/ToolMenu/Draw/index.tsx
@@ -5,11 +5,12 @@ import React, {
 } from 'react';
 
 import {
-  faDrawPolygon,
   faGripLines,
   faCircle,
-  faFont,
   faSquare,
+  faFont,
+  faCircleNotch,
+  faShapes,
   faPenToSquare,
   faUpload,
   faTrash,
@@ -198,7 +199,6 @@ export const Draw: React.FC<DrawProps> = ({
         selectedName={selectedButton}
         onChange={onToggleChange}
       >
-
         {showDrawPoint ? (
           <DrawButton
             name="draw-point"
@@ -241,7 +241,7 @@ export const Draw: React.FC<DrawProps> = ({
             type="link"
           >
             <FontAwesomeIcon
-              icon={faDrawPolygon}
+              icon={faShapes}
             />
             <span
               className="draw-polygon"
@@ -258,7 +258,7 @@ export const Draw: React.FC<DrawProps> = ({
             type="link"
           >
             <FontAwesomeIcon
-              icon={faCircle}
+              icon={faCircleNotch}
             />
             <span
               className="draw-circle"
@@ -284,7 +284,6 @@ export const Draw: React.FC<DrawProps> = ({
             </span>
           </DrawButton>
         ) : <></>}
-
         {showDrawAnnotation ? (
           <DrawButton
             name="draw-text"
@@ -301,7 +300,7 @@ export const Draw: React.FC<DrawProps> = ({
             </span>
           </DrawButton>
         ) : <></>}
-
+        <StylingButton />
         {showModifyFeatures ? (
           <ModifyButton
             name="draw-modify"
@@ -318,6 +317,36 @@ export const Draw: React.FC<DrawProps> = ({
             </span>
           </ModifyButton>
         ) : <></>}
+        {showDeleteFeatures ? (
+          <DeleteButton
+            name="draw-delete"
+            type="link"
+          >
+            <FontAwesomeIcon
+              icon={faEraser}
+            />
+            <span
+              className="draw-delete"
+            >
+              {t('Draw.delete')}
+            </span>
+          </DeleteButton>
+        ) : <></>}
+        {showDeleteFeatures ? (
+          <DeleteAllButton
+            name="draw-delete-all"
+            type="link"
+          >
+            <FontAwesomeIcon
+              icon={faTrash}
+            />
+            <span
+              className="draw-delete-all"
+            >
+              {t('DeleteAllButton.deleteAll')}
+            </span>
+          </DeleteAllButton>
+        ):<></>}
 
         {showUploadFeatures ? (
           <UploadButton
@@ -357,37 +386,6 @@ export const Draw: React.FC<DrawProps> = ({
             </span>
           </SimpleButton>
         ) : <></>}
-        {showDeleteFeatures ? (
-          <DeleteButton
-            name="draw-delete"
-            type="link"
-          >
-            <FontAwesomeIcon
-              icon={faEraser}
-            />
-            <span
-              className="draw-delete"
-            >
-              {t('Draw.delete')}
-            </span>
-          </DeleteButton>
-        ) : <></>}
-        {showDeleteFeatures ? (
-          <DeleteAllButton
-            name="draw-delete-all"
-            type="link"
-          >
-            <FontAwesomeIcon
-              icon={faTrash}
-            />
-            <span
-              className="draw-delete-all"
-            >
-              {t('DeleteAllButton.deleteAll')}
-            </span>
-          </DeleteAllButton>
-        ):<></>}
-        <StylingButton />
       </ToggleGroup>
       <AttributionDrawer
         open={openAttributeDrawer}

--- a/src/components/ToolMenu/Draw/index.tsx
+++ b/src/components/ToolMenu/Draw/index.tsx
@@ -48,7 +48,7 @@ import './index.less';
 
 import AttributionDrawer from './Attributions';
 import DeleteAllButton from './DeleteAllButton';
-import { StylingButton } from './StylingDrawerButton';
+import StylingButton from './StylingDrawerButton';
 
 interface DefaultDrawProps {
   showDrawPoint?: boolean;

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -10,7 +10,7 @@ import type {
 import {
   faChevronLeft,
   faChevronRight,
-  faDrawPolygon,
+  faPalette,
   faFileDownload,
   faLanguage,
   faMousePointer,
@@ -253,7 +253,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
         };
       case 'draw_tools':
         return {
-          icon: faDrawPolygon,
+          icon: faPalette,
           title: t('ToolMenu.draw'),
           wrappedComponent: (
             <Draw

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -59,8 +59,6 @@ export default {
         uploadSuccess: 'Die Datei wurde erfolgreich importiert',
         uploadError: 'Der Import ist fehlgeschlagen. Bitte beachten Sie, dass nur .geojson-Dateien unterstützt werden.',
         delete: 'Löschen',
-        deleteAll: 'Alles Löschen',
-        confirmMessage: 'Bitte bestätigen Sie, dass Sie alle Zeichnungen löschen möchten.',
         export: 'Exportieren'
       },
       DeleteAllButton:{
@@ -329,8 +327,6 @@ export default {
         uploadSuccess: 'The file was uploaded successfully',
         uploadError: 'The import failed, please note that only .geojson files are supported',
         delete: 'Delete',
-        deleteAll: 'Delete all',
-        confirmMessage: 'Please confirm, that you wish to delete all drawings.',
         export: 'Export'
       },
       DeleteAllButton:{

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -59,6 +59,8 @@ export default {
         uploadSuccess: 'Die Datei wurde erfolgreich importiert',
         uploadError: 'Der Import ist fehlgeschlagen. Bitte beachten Sie, dass nur .geojson-Dateien unterstützt werden.',
         delete: 'Löschen',
+        deleteAll: 'Alles Löschen',
+        confirmMessage: 'Bitte bestätigen Sie, dass Sie alle Zeichnungen löschen möchten.',
         export: 'Exportieren'
       },
       DeleteAllButton:{
@@ -327,6 +329,8 @@ export default {
         uploadSuccess: 'The file was uploaded successfully',
         uploadError: 'The import failed, please note that only .geojson files are supported',
         delete: 'Delete',
+        deleteAll: 'Delete all',
+        confirmMessage: 'Please confirm, that you wish to delete all drawings.',
         export: 'Export'
       },
       DeleteAllButton:{


### PR DESCRIPTION
This commit changes the order of the draw tool components. The order prioritizes drawing, altering drawings, deleting and finally exporting/importing. Also the logos of some components were changed since they did not fit to the functionality of the component or the logo was used multiple times. 