### PR TITLE
Reset form fields before setting values

### DIFF
--- a/src/components/ToolMenu/FeatureInfo/FeatureInfoForm/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/FeatureInfoForm/index.tsx
@@ -35,6 +35,7 @@ export const FeatureInfoForm: React.FC<FeatureInfoFormProps> = ({
   const [form] = useForm();
 
   useEffect(() => {
+    form.resetFields();
     form.setFieldsValue(feature.getProperties());
   }, [feature, form]);
 


### PR DESCRIPTION
This is needed because `form.setFieldsValue()` will not override null values when switching to another feature.

@terrestris/devs Please review 