### PR TITLE
Multiple fixes to the attribute editor

### DIFF
--- a/src/components/ToolMenu/Draw/Attributions/AttributionRow/index.less
+++ b/src/components/ToolMenu/Draw/Attributions/AttributionRow/index.less
@@ -1,3 +1,0 @@
-.attribute-row {
-  display: flex;
-}

--- a/src/components/ToolMenu/Draw/Attributions/AttributionRow/index.tsx
+++ b/src/components/ToolMenu/Draw/Attributions/AttributionRow/index.tsx
@@ -1,27 +1,29 @@
 import React from 'react';
 
 import {
-  Form, Input
+  AutoComplete,
+  Form,
+  Input
 } from 'antd';
 
-import './index.less';
-import { useTranslation } from 'react-i18next';
+import {
+  useTranslation
+} from 'react-i18next';
+
+import type {
+  FormData
+} from '..';
 
 export type AttributionRowProps = {
-  keyName: string;
-  onChange: (evt: React.ChangeEvent<HTMLInputElement>) => void;
-};
-
-export type InputFields = {
-  [fields: string]: {
-    name: string;
-    value: any;
-  };
+  keyName: string | number;
+  onChange?: (value: string) => void;
+  options?: string[];
 };
 
 const AttributionRow: React.FC<AttributionRowProps> = ({
   keyName,
-  onChange
+  onChange = () => {},
+  options
 }) => {
 
   const {
@@ -31,30 +33,36 @@ const AttributionRow: React.FC<AttributionRowProps> = ({
   return (
     <>
       <Form.Item
-        name={['fields', keyName, 'name']}
+        name={[keyName, 'name']}
         rules={[{
           required: true,
           message: t('AttributionRow.missingKey')
         }, ({ getFieldsValue }) => ({
           validator(_, value: string) {
-            const fields: InputFields = getFieldsValue(true);
-            const filtered = Object.entries(fields.fields).filter(([key, val]) => val.name === value);
+            const fields: FormData = getFieldsValue(true);
 
-            if (filtered.length > 1) {
-              return Promise.reject(new Error(t('AttributionRow.keyInUse')));
+            if (fields.fields) {
+              const filtered = Object.entries(fields.fields).filter(([, val]) => val?.name === value);
+
+              if (filtered.length > 1) {
+                return Promise.reject(new Error(t('AttributionRow.keyInUse')));
+              }
             }
 
             return Promise.resolve();
           }
         })]}
       >
-        <Input
+        <AutoComplete
           placeholder={t('AttributionRow.keyPlaceholder')}
-          onChange={onChange}
+          onChange={(value) => {
+            onChange(value);
+          }}
+          options={options?.map(o => ({ value: o }))}
         />
       </Form.Item>
       <Form.Item
-        name={['fields', keyName, 'value']}
+        name={[keyName, 'value']}
         rules={[{
           required: true,
           message: t('AttributionRow.missingValue')
@@ -62,7 +70,9 @@ const AttributionRow: React.FC<AttributionRowProps> = ({
       >
         <Input
           placeholder={t('AttributionRow.valuePlaceholder')}
-          onChange={onChange}
+          onChange={evt => {
+            onChange(evt.target.value);
+          }}
         />
       </Form.Item>
     </>

--- a/src/components/ToolMenu/Draw/Attributions/index.less
+++ b/src/components/ToolMenu/Draw/Attributions/index.less
@@ -4,9 +4,28 @@
   bottom: var(--footerHeight);
   z-index: 499;
 
-  .anticon.anticon-minus-circle {
-    padding-bottom: 25px;
-    padding-left: 5px;
+  form {
+    width: 100%;
+
+    .attribute-row {
+      display: flex;
+
+      .ant-form-item {
+        flex: 1;
+      }
+    }
+
+    .add-attribute-button {
+      width: 100%;
+
+      span {
+        padding-left: 5px;
+      }
+    }
+
+    .submit-attributes-button {
+      width: 100%;
+    }
   }
 }
 

--- a/src/components/ToolMenu/Draw/Attributions/index.tsx
+++ b/src/components/ToolMenu/Draw/Attributions/index.tsx
@@ -147,12 +147,6 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
 
   const onFinish = (input: FormData) => {
     if (!selectedFeature) {
-      notification.destroy();
-      notification.error({
-        message: (t('notificationApplyText.notSelected')),
-        placement: 'top',
-        duration: 3.0
-      });
       return;
     }
     notification.destroy();
@@ -306,6 +300,7 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
               type="primary"
               htmlType="submit"
               disabled={!isFormValid}
+              hidden={selectedFeature ? false: true}
             >
               {t('Attribution.submit')}
             </Button>

--- a/src/components/ToolMenu/Draw/Attributions/index.tsx
+++ b/src/components/ToolMenu/Draw/Attributions/index.tsx
@@ -20,6 +20,8 @@ import {
   DrawerProps,
   Form,
   FormListFieldData,
+  Popconfirm,
+  notification,
   Row
 } from 'antd';
 
@@ -42,6 +44,7 @@ import {
 import AttributionRow from './AttributionRow';
 
 import './index.less';
+import { log } from 'console';
 
 export type FormData = {
   fields?: [{
@@ -63,7 +66,7 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
   const [isFormValid, setIsFormIsValid] = useState(true);
   const [availableFeatureCollectionAttributes, setAvailableFeatureCollectionAttributes] = useState<string[]>([]);
   const [availableFeatureAttributes, setAvailableFeatureAttributes] = useState<string[]>([]);
-
+  const [api, contextHolder] = notification.useNotification();
   const [form] = Form.useForm<FormData>();
 
   const map = useMap();
@@ -146,8 +149,20 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
 
   const onFinish = (input: FormData) => {
     if (!selectedFeature) {
+      notification.destroy();
+      notification.error({
+        message: (t('notificationApplyText.notSelected')),
+        placement: 'top',
+        duration: 3.0
+      });
       return;
     }
+    notification.destroy();
+    notification.success({
+      message: (t('notificationApplyText.title')),
+      placement: 'top',
+      duration: 3.5
+    });
 
     for (const property in selectedFeature.getProperties()) {
       if (!(selectedFeature.get(property) instanceof OlGeometry)) {
@@ -160,7 +175,6 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
         if (!field?.name) {
           return;
         }
-
         selectedFeature.set(field.name, field.value);
       });
     }
@@ -185,6 +199,16 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
 
   const getFormItems = (fields: FormListFieldData[], rmFn: any) => {
     return fields.map((field) => {
+      const removeAndMessage = () => {
+        notification.destroy();
+        notification.info({
+          message: (t('notificationDeleteText.title')),
+          description: (t('notificationDeleteText.info')),
+          placement: 'top',
+          duration: 6
+        });
+        remove(rmFn, field.name);
+      };
       return (
         <div
           key={field.key}
@@ -196,17 +220,26 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
             onChange={onChange}
             options={availableFeatureAttributes}
           />
-          <Button
-            className="remove-attribute-button"
-            onClick={() => remove(rmFn, field.name)}
-            type='primary'
-            danger={true}
-            icon={
-              <FontAwesomeIcon
-                icon={faMinusSquare}
-              />
-            }
-          />
+          <Popconfirm
+            title={t('AttributionPopConfirm.title')}
+            okText={t('AttributionPopConfirm.okText')}
+            cancelText={t('AttributionPopConfirm.cancelText')}
+            placement='topRight'
+            onConfirm={removeAndMessage}
+          >
+            {contextHolder}
+            <Button
+              className="remove-attribute-button"
+              // onClick={console.log('hi')}
+              type='primary'
+              danger={true}
+              icon={
+                <FontAwesomeIcon
+                  icon={faMinusSquare}
+                />
+              }
+            />
+          </Popconfirm>
         </div>
       );
     });

--- a/src/components/ToolMenu/Draw/Attributions/index.tsx
+++ b/src/components/ToolMenu/Draw/Attributions/index.tsx
@@ -120,10 +120,7 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
         }
       });
     });
-
     setAvailableFeatureCollectionAttributes(Array.from(featureCollectionAttributes));
-
-    // updateAvailableFeatureAttributes(form.getFieldsValue());
   }, [selectedFeature, form, map]);
 
   useEffect(() => {
@@ -222,7 +219,6 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
             {contextHolder}
             <Button
               className="remove-attribute-button"
-              // onClick={console.log('hi')}
               type='primary'
               danger={true}
               icon={
@@ -240,7 +236,7 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
   return (
     <Drawer
       title={t('Attribution.title')}
-      className='attribution-drawer'
+      className="attribution-drawer"
       placement="right"
       mask={false}
       maskClosable={false}

--- a/src/components/ToolMenu/Draw/Attributions/index.tsx
+++ b/src/components/ToolMenu/Draw/Attributions/index.tsx
@@ -44,7 +44,6 @@ import {
 import AttributionRow from './AttributionRow';
 
 import './index.less';
-import { log } from 'console';
 
 export type FormData = {
   fields?: [{

--- a/src/components/ToolMenu/Draw/Attributions/index.tsx
+++ b/src/components/ToolMenu/Draw/Attributions/index.tsx
@@ -58,6 +58,7 @@ export interface AttributionDrawerProps extends DrawerProps {
 
 const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
   onCustomClose,
+  open,
   onClose,
   ...passThroughProps
 }) => {
@@ -125,6 +126,10 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
     // updateAvailableFeatureAttributes(form.getFieldsValue());
   }, [selectedFeature, form, map]);
 
+  useEffect(() => {
+    setSelectedFeature(undefined);
+  }, [open]);
+
   // todo revisit react-geo to make name of the slect-interaction configurable
   const selectInteraction = map?.getInteractions().getArray().filter(interaction => {
     if (interaction.get('active') === true && interaction.get('name') === 'react-geo-select-interaction') {
@@ -139,12 +144,6 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
       setSelectedFeature(selectInteraction.getFeatures().getArray()[0]);
     });
   }
-
-  const handleClose = () => {
-    if (onCustomClose) {
-      onCustomClose(false);
-    }
-  };
 
   const onFinish = (input: FormData) => {
     if (!selectedFeature) {
@@ -252,7 +251,7 @@ const AttributionDrawer: React.FC<AttributionDrawerProps> = ({
       mask={false}
       maskClosable={false}
       closable={false}
-      onClose={handleClose}
+      open={open}
       {...passThroughProps}
     >
       {!selectedFeature &&

--- a/src/components/ToolMenu/Draw/index.tsx
+++ b/src/components/ToolMenu/Draw/index.tsx
@@ -1,6 +1,5 @@
 import React, {
   ChangeEvent,
-  useEffect,
   useState
 } from 'react';
 
@@ -78,7 +77,7 @@ export const Draw: React.FC<DrawProps> = ({
   showUploadFeatures,
   showDeleteFeatures
 }): JSX.Element => {
-  const [openAttributeDrawer, setOpenAttributeDrawer] = useState(false);
+  const [isAttributeDrawerOpen, setIsAttributeDrawerOpen] = useState(false);
   const [selectedButton, setSelectedButton] = useState<string>();
 
   const {
@@ -185,12 +184,7 @@ export const Draw: React.FC<DrawProps> = ({
   };
 
   const onModifyButtonToggle = (active: boolean) => {
-    if (openAttributeDrawer === false && active === true) {
-      setOpenAttributeDrawer(true);
-    }
-    if (openAttributeDrawer === true && active === false && selectedButton === 'draw-modify') {
-      setOpenAttributeDrawer(false);
-    }
+    setIsAttributeDrawerOpen(active);
   };
 
   return (
@@ -388,8 +382,8 @@ export const Draw: React.FC<DrawProps> = ({
         ) : <></>}
       </ToggleGroup>
       <AttributionDrawer
-        open={openAttributeDrawer}
-        onCustomClose={() => setOpenAttributeDrawer(false)}
+        open={isAttributeDrawerOpen}
+        onCustomClose={() => setIsAttributeDrawerOpen(false)}
       />
     </>
   );

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -246,7 +246,7 @@ export default {
         info: 'Wenn auf „Übernehmen“ nicht geklick wird, werden alle an dieser Zeichnung vorgenommenen Änderungen verworfen.'
       },
       notificationApplyText:{
-        title: 'Änderungen wurden erfolgreich gespeichert!',
+        title: 'Änderungen wurden erfolgreich gespeichert!'
       },
       SaveButton: {
         title: 'Speichern'
@@ -525,7 +525,7 @@ export default {
         info: 'Not pressing "Apply" will reverse all changes made to this drawing.'
       },
       notificationApplyText:{
-        title: 'Changes were applied successfully!',
+        title: 'Changes were applied successfully!'
       },
       SaveButton: {
         title: 'Save'

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -247,7 +247,6 @@ export default {
       },
       notificationApplyText:{
         title: 'Änderungen wurden erfolgreich gespeichert!',
-        notSelected: 'Bitte eine Geometrie auswählen.'
       },
       SaveButton: {
         title: 'Speichern'
@@ -527,7 +526,6 @@ export default {
       },
       notificationApplyText:{
         title: 'Changes were applied successfully!',
-        notSelected: 'Please select a geometry.'
       },
       SaveButton: {
         title: 'Save'

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -243,7 +243,7 @@ export default {
       },
       notificationDeleteText:{
         title: 'Drücke "Speichern" um die Änderung zu bestätigen.',
-        info: 'Wenn auf „Übernehmen“ nicht geklick wird, werden alle an dieser Zeichnung vorgenommenen Änderungen verworfen.'
+        info: 'Wenn "Übernehmen" nicht geklickt wird, werden alle an dieser Zeichnung vorgenommenen Änderungen verworfen.'
       },
       notificationApplyText:{
         title: 'Änderungen wurden erfolgreich gespeichert!'

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -233,8 +233,21 @@ export default {
         valuePlaceholder: 'Wert',
         keyInUse: 'Dieser Name existiert bereits!'
       },
+      AttributionPopConfirm:{
+        title: 'Attribut löschen?',
+        okText: 'Löschen',
+        cancelText: 'Abbrechen'
+      },
       ResetButton: {
         title: 'Zurücksetzen'
+      },
+      notificationDeleteText:{
+        title: 'Drücke "Speichern" um die Änderung zu bestätigen.',
+        info: 'Wenn auf „Übernehmen“ nicht geklick wird, werden alle an dieser Zeichnung vorgenommenen Änderungen verworfen.'
+      },
+      notificationApplyText:{
+        title: 'Änderungen wurden erfolgreich gespeichert!',
+        notSelected: 'Bitte eine Geometrie auswählen.'
       },
       SaveButton: {
         title: 'Speichern'
@@ -500,8 +513,21 @@ export default {
         valuePlaceholder: 'Value',
         keyInUse: 'Key already exists!'
       },
+      AttributionPopConfirm:{
+        title: 'Delete property?',
+        okText: 'Delete',
+        cancelText: 'Cancel'
+      },
       ResetButton: {
         title: 'Reset'
+      },
+      notificationDeleteText:{
+        title: 'Press "Apply" to confirm changes.',
+        info: 'Not pressing "Apply" will reverse all changes made to this drawing.'
+      },
+      notificationApplyText:{
+        title: 'Changes were applied successfully!',
+        notSelected: 'Please select a geometry.'
       },
       SaveButton: {
         title: 'Save'


### PR DESCRIPTION
This fixes the attribute editor of the `draw` tools: 

- Allow adding multiple rows at once (without the need to save the feature first).
- Don't delete the attribute directly on the feature.
- Remove unneeded state copy of the feature attributes
- Show all available attributes in a dropdown