### PR TITLE
fix: allow overflow for treenode-content

### DIFF
--- a/src/components/ToolMenu/LayerTree/index.less
+++ b/src/components/ToolMenu/LayerTree/index.less
@@ -15,6 +15,7 @@
 
   .ant-tree-node-content-wrapper {
     flex: 1;
+    overflow-x: scroll;
     .ant-tree-title {
       .tree-node-header {
         display: flex;


### PR DESCRIPTION
By this PR `overflow` is added to treenode content in order to add scroll bar for legends as an example exceeding the LayerTreePanel width.

Plz review @terrestris/devs 