### PR TITLE
Update onDrawEnd to really replace the geometry

### DIFF
--- a/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
+++ b/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
@@ -174,11 +174,17 @@ export const EditFeatureGeometryToolbar: React.FC<EditFeatureGeometryToolbarProp
   };
 
   const onDrawEnd = (e: OlDrawEvent) => {
-    updateRevision();
+    // overwrite existing geometry of feature
     if (!feature.geometry.type.toLocaleLowerCase().startsWith('multi')) {
-      // replace the existing geometry by the new one
-      editLayer?.getSource()?.clear();
+      const source = editLayer?.getSource();
+      const existingFeature = source?.getFeatures()[0];
+      if (existingFeature) {
+        // drawbutton automatically adds the feature to the source so we need to remove it again
+        source?.once('addfeature', (e2) => source.removeFeature(e2.feature!));
+        existingFeature.setGeometry(e.feature.getGeometry());
+      }
     }
+    updateRevision();
   };
 
   const updateRevision = () => {


### PR DESCRIPTION
This updates the `onDrawEnd` function of the `EditFeatureGeometryToolbar`.

It is kind of hackish to add a once listenere to the source but the code of the [react-geo/DrawButton](https://github.com/terrestris/react-geo/blob/main/src/Button/DrawButton/DrawButton.tsx#L125-L135) automatically assigns the digitizeLayer so the drawn feature is allways added. Usually it is possible to use the DrawInteraction without source to manually handle what should happen with the drawn features.