### PR TITLE
feat: allow static configurations without calling shogun

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ We recommend to install the client via the prebuilt Docker image `docker-public.
 
 Even if the client can be used without any backend providing a context configuration, it is designed to run on top of a [SHOGun backend](https://github.com/terrestris/shogun) while reading the configuration from the [`/applications`](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/terrestris/shogun/gh-pages/api/swagger.json#/application-controller)  REST interface. To specify a configuration the query parameter `applicationId` must be set (e.g. `https://localhost/client/?applicationId=18` to get the configuration for the application with the ID 18).
 If no ID is given (e.g. because no backend is available) or the requested application is not accessible, the client will load a fallback configuration.
+It is possible to load the application config from a static URL with the configuration parameter `staticAppConfigUrl`.
 
 ### Print
 To use print apps for different languages just name them after the language code (`ISO_639-1`). The print app that has the name of the currently selected language will be used.
@@ -20,40 +21,42 @@ To use print apps for different languages just name them after the language code
 
 Several global settings for the client can be configured via the [`gis-client-config.js`](https://github.com/terrestris/shogun-gis-client/blob/main/resources/config/gis-client-config.js) file:
 
-| Name | Description | Default |
-| ---- | ----------- | ------- |
-| shogunBase | The base URL of SHOGun, e.g. `/api` or `https://my-shogun.org/` | '/' |
-| keycloak.enabled | Whether Keycloak is used for authentication or not. Usually this should only set to `false` in client only mode or if no authentication is needed to access any SHOGun endpoints at all | false |
-| keycloak.host | The Keycloak host, e.g. `https://localhost/auth` | null |
-| keycloak.realm | The Keycloak realm that should be used for authentication, e.g. `SHOGun` | null |
-| keycloak.clientId | The Keycloak client that should be used for authentication, e.g. `shogun-client` | null |
-| keycloak.onLoadAction | See [here](https://www.keycloak.org/docs/latest/securing_apps/#_javascript_adapter) for details | 'check-sso' |
-| print.url | The url of the MapFish Print servlet | '/print' |
-| plugins | The list of plugins to be loaded | [] |
-| plugin.name | The name of the plugin | undefined |
-| plugin.exposedPaths | The list of exposed paths | undefined |
-| plugin.resourcePath | The resource path | undefined |
-| geoserver.base | The base url of the GeoServer | '/geoserver' |
-| geoserver.upload.workspace | The workspace the uploads should be placed in | 'SHOGUN' |
-| geoserver.upload.limit | The upload size limit in bytes (note: this is the client evaluation only!) | 200000000 (= 200MB) |
-| geoserver.upload.authorizedRoles | The list of role names the upload should be allowed/visible to (note: this is the client evaluation only!) | ['admin'] |
-| featureEditRoles.authorizedRolesForCreate | The list of role names the feature editing tools including the create options should be allowed/visible to (note: this is the client evaluation only!). String and regular expressions are supported. | [] |
-| featureEditRoles.authorizedRolesForUpdate | The list of role names the feature editing tools including the update options should be allowed/visible to (note: this is the client evaluation only!). String and regular expressions are supported. | [] |
-| featureEditRoles.authorizedRolesForDelete | The list of role names the feature editing tools including the delete options should be allowed/visible to (note: this is the client evaluation only!). String and regular expressions are supported. | [] |
-| wfsLockFeatureEnabled | Whether WFS LockFeature is enabled during feature editing or not. | false |
-| enableFallbackConfig | Whether the default application configuration should be loaded without any given application ID or not. | true |
-| search.solrBasePath | Base path to a solr instance. | '/search/query' |
-| search.coreName | Solr core name. | 'search' |
-| search.defaultUseViewBox | Whether the search is restricted to the current view box. | true |
-| search.useNominatim | Whether to use Nominatim. | true |
-| search.useSolrHighlighting | Enable / disable solr search result highlighting. | true |
-| search.delay | Delay in milliseconds before search is triggered (debouncing). | 1000 |
-| search.minChars | Minimum search term length for the search to be triggered. | 3 |
-| search.solrQueryConfig.queryParser | Solr query parser. Must be either 'lucene', 'dismax' or 'edismax' | 'edismax' |
-| search.solrQueryConfig.rowsPerQuery | Number of requested rows per solr query. | 100 |
-| search.solrQueryConfig.tagPre | HTML tag applied before search highlight. | `<b>` |
-| search.solrQueryConfig.tagPost | HTML tag applied after search highlight. | `</b>` |
-| search.solrQueryConfig.requireFieldMatch | Only query terms aligning with the field being highlighted will in turn be highlighted. | true |
+| Name | Description                                                                                                                                                                                              | Default             |
+| ---- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
+| shogunBase | The base URL of SHOGun, e.g. `/api` or `https://my-shogun.org/`. If set to `false` no SHOGUN requests will be made by the application.                                                                   | '/'                 |
+| staticAppConfigUrl | An URL to load an application configuration, this does not have to come frome shogun but has to have the same syntax (See https://github.com/terrestris/shogun-util/blob/main/src/model/Application.ts). | undefined           |
+| layerConfigUrl | An URL to load a list of layers, this does not have to come from shogun but has to have the same syntax (See https://github.com/terrestris/shogun-util/blob/main/src/model/Layer.ts).                    | undefined           |
+| keycloak.enabled | Whether Keycloak is used for authentication or not. Usually this should only set to `false` in client only mode or if no authentication is needed to access any SHOGun endpoints at all                  | false               |
+| keycloak.host | The Keycloak host, e.g. `https://localhost/auth`                                                                                                                                                         | null                |
+| keycloak.realm | The Keycloak realm that should be used for authentication, e.g. `SHOGun`                                                                                                                                 | null                |
+| keycloak.clientId | The Keycloak client that should be used for authentication, e.g. `shogun-client`                                                                                                                         | null                |
+| keycloak.onLoadAction | See [here](https://www.keycloak.org/docs/latest/securing_apps/#_javascript_adapter) for details                                                                                                          | 'check-sso'         |
+| print.url | The url of the MapFish Print servlet                                                                                                                                                                     | '/print'            |
+| plugins | The list of plugins to be loaded                                                                                                                                                                         | []                  |
+| plugin.name | The name of the plugin                                                                                                                                                                                   | undefined           |
+| plugin.exposedPaths | The list of exposed paths                                                                                                                                                                                | undefined           |
+| plugin.resourcePath | The resource path                                                                                                                                                                                        | undefined           |
+| geoserver.base | The base url of the GeoServer                                                                                                                                                                            | '/geoserver'        |
+| geoserver.upload.workspace | The workspace the uploads should be placed in                                                                                                                                                            | 'SHOGUN'            |
+| geoserver.upload.limit | The upload size limit in bytes (note: this is the client evaluation only!)                                                                                                                               | 200000000 (= 200MB) |
+| geoserver.upload.authorizedRoles | The list of role names the upload should be allowed/visible to (note: this is the client evaluation only!)                                                                                               | ['admin']           |
+| featureEditRoles.authorizedRolesForCreate | The list of role names the feature editing tools including the create options should be allowed/visible to (note: this is the client evaluation only!). String and regular expressions are supported.    | []                  |
+| featureEditRoles.authorizedRolesForUpdate | The list of role names the feature editing tools including the update options should be allowed/visible to (note: this is the client evaluation only!). String and regular expressions are supported.    | []                  |
+| featureEditRoles.authorizedRolesForDelete | The list of role names the feature editing tools including the delete options should be allowed/visible to (note: this is the client evaluation only!). String and regular expressions are supported.    | []                  |
+| wfsLockFeatureEnabled | Whether WFS LockFeature is enabled during feature editing or not.                                                                                                                                        | false               |
+| enableFallbackConfig | Whether the default application configuration should be loaded without any given application ID or not.                                                                                                  | true                |
+| search.solrBasePath | Base path to a solr instance.                                                                                                                                                                            | '/search/query'     |
+| search.coreName | Solr core name.                                                                                                                                                                                          | 'search'            |
+| search.defaultUseViewBox | Whether the search is restricted to the current view box.                                                                                                                                                | true                |
+| search.useNominatim | Whether to use Nominatim.                                                                                                                                                                                | true                |
+| search.useSolrHighlighting | Enable / disable solr search result highlighting.                                                                                                                                                        | true                |
+| search.delay | Delay in milliseconds before search is triggered (debouncing).                                                                                                                                           | 1000                |
+| search.minChars | Minimum search term length for the search to be triggered.                                                                                                                                               | 3                   |
+| search.solrQueryConfig.queryParser | Solr query parser. Must be either 'lucene', 'dismax' or 'edismax'                                                                                                                                        | 'edismax'           |
+| search.solrQueryConfig.rowsPerQuery | Number of requested rows per solr query.                                                                                                                                                                 | 100                 |
+| search.solrQueryConfig.tagPre | HTML tag applied before search highlight.                                                                                                                                                                | `<b>`               |
+| search.solrQueryConfig.tagPost | HTML tag applied after search highlight.                                                                                                                                                                 | `</b>`              |
+| search.solrQueryConfig.requireFieldMatch | Only query terms aligning with the field being highlighted will in turn be highlighted.                                                                                                                  | true                |
 
 The configuration file is not bundled and will be loaded before application start from `./gis-client-config.js`. Typically you want to override the file in a production environment and you can pass a custom file by mounting the desired one directly into the nginx container of the client. For example:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@terrestris/react-geo": "^23.3.0",
         "@terrestris/react-util": "^3.0.0",
         "@terrestris/shogun-e2e-tests": "^1.0.4",
-        "@terrestris/shogun-util": "^7.3.2",
+        "@terrestris/shogun-util": "7.2.0-ol7.1",
         "antd": "^4.24.4",
         "color": "^4.2.3",
         "dotenv": "^16.3.1",
@@ -5404,16 +5404,16 @@
       }
     },
     "node_modules/@terrestris/shogun-util": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-7.3.2.tgz",
-      "integrity": "sha512-RO+i94wv+ITCrIH0AxoE5p2R28zTfHTsczZ6/JcjC3uxW29qpBGhLoYjV3dhPahwfKdxFhgsr7Sbv8z9hOq4BQ==",
+      "version": "7.2.0-ol7.1",
+      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-7.2.0-ol7.1.tgz",
+      "integrity": "sha512-DhYfPyBIU4yt7H522He2WgpbdZRbu8tvVOY2PkJ72V2oR/Z8pNiIMH+b0J+1AWLJtfOoiRnEA0RVIw+61Jm0qg==",
       "dependencies": {
-        "@terrestris/base-util": "^1.1.0",
-        "@terrestris/ol-util": "^14.0.0",
+        "@terrestris/base-util": "^1.0.1",
+        "@terrestris/ol-util": "^11.1.0",
         "geojson": "^0.5.0",
-        "keycloak-js": "^23.0.3",
+        "keycloak-js": "^22.0.3",
         "lodash": "^4.17.21",
-        "ol": "^8.1.0"
+        "ol": "^7.5.2"
       },
       "engines": {
         "node": ">=10.13",
@@ -5421,57 +5421,40 @@
       }
     },
     "node_modules/@terrestris/shogun-util/node_modules/@terrestris/ol-util": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-14.0.0.tgz",
-      "integrity": "sha512-6yXfU2bnDU4gIztXZ+vcD5aOTOBxv5UqQuj+IqYgf3E/m0xvE/ZlSsMPMplLHqZP1fu+fJpu6E88WCLamMVIQw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-11.1.0.tgz",
+      "integrity": "sha512-Ah05KNb9NyTn/yE+Z/Z8qorSi96loriFROtygf5f3vODs6mXXwpO2j490gQoxVyJMw8cJd+K1+GiMv2JeDpaVA==",
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.11",
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
-        "fast-xml-parser": "^4.2.7",
-        "geostyler-openlayers-parser": "^4.2.1",
+        "fast-xml-parser": "^4.2.5",
+        "geostyler-openlayers-parser": "^4.1.0",
         "lodash": "^4.17.21",
         "polygon-splitter": "^0.0.11",
-        "proj4": "^2.9.0",
+        "proj4": "^2.8.0",
         "shpjs": "^4.0.4",
-        "typescript": "^5.2.2"
+        "typescript": "^5.0.2"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=9"
+        "node": ">=14",
+        "npm": ">=7"
       },
       "peerDependencies": {
-        "ol": "^8"
+        "ol": "^7.1"
       }
     },
-    "node_modules/@terrestris/shogun-util/node_modules/ol": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-8.2.0.tgz",
-      "integrity": "sha512-/m1ddd7Jsp4Kbg+l7+ozR5aKHAZNQOBAoNZ5pM9Jvh4Etkf0WGkXr9qXd7PnhmwiC1Hnc2Toz9XjCzBBvexfXw==",
-      "dependencies": {
-        "color-rgba": "^3.0.0",
-        "color-space": "^2.0.1",
-        "earcut": "^2.2.3",
-        "geotiff": "^2.0.7",
-        "pbf": "3.2.1",
-        "rbush": "^3.0.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/openlayers"
-      }
+    "node_modules/@terrestris/shogun-util/node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
-    "node_modules/@terrestris/shogun-util/node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
-    },
-    "node_modules/@terrestris/shogun-util/node_modules/rbush": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+    "node_modules/@terrestris/shogun-util/node_modules/keycloak-js": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-22.0.5.tgz",
+      "integrity": "sha512-a7ZwCZeHl8tpeJBy102tZtAnHslDUOA1Nf/sHNF3HYLchKpwoDuaitwIUiS2GnNUe+tlNKLlCqZS+Mi5K79m1w==",
       "dependencies": {
-        "quickselect": "^2.0.0"
+        "base64-js": "^1.5.1",
+        "js-sha256": "^0.9.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -10103,36 +10086,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/color-parse": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
-      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      }
-    },
-    "node_modules/color-parse/node_modules/color-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
-      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
-    "node_modules/color-rgba": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
-      "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
-      "dependencies": {
-        "color-parse": "^2.0.0",
-        "color-space": "^2.0.0"
-      }
-    },
-    "node_modules/color-space": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
-      "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA=="
     },
     "node_modules/color-string": {
       "version": "1.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@terrestris/react-geo": "^23.3.0",
         "@terrestris/react-util": "^3.0.0",
         "@terrestris/shogun-e2e-tests": "^1.0.4",
-        "@terrestris/shogun-util": "^7.2.0",
+        "@terrestris/shogun-util": "^7.3.2",
         "antd": "^4.24.4",
         "color": "^4.2.3",
         "dotenv": "^16.3.1",
@@ -5404,16 +5404,16 @@
       }
     },
     "node_modules/@terrestris/shogun-util": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-7.3.0.tgz",
-      "integrity": "sha512-2SYNiY6DoRT3tGm1fcsdMY5JHA3+gr1DbCmD3J1w73f/PZzebn8KloDH+tQwM30QvmaVNbMpVDWKQ5c5RXNoTw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-7.3.2.tgz",
+      "integrity": "sha512-RO+i94wv+ITCrIH0AxoE5p2R28zTfHTsczZ6/JcjC3uxW29qpBGhLoYjV3dhPahwfKdxFhgsr7Sbv8z9hOq4BQ==",
       "dependencies": {
-        "@terrestris/base-util": "^1.0.1",
-        "@terrestris/ol-util": "^11.1.0",
+        "@terrestris/base-util": "^1.1.0",
+        "@terrestris/ol-util": "^14.0.0",
         "geojson": "^0.5.0",
-        "keycloak-js": "^22.0.3",
+        "keycloak-js": "^23.0.3",
         "lodash": "^4.17.21",
-        "ol": "^7.5.2"
+        "ol": "^8.1.0"
       },
       "engines": {
         "node": ">=10.13",
@@ -5421,40 +5421,57 @@
       }
     },
     "node_modules/@terrestris/shogun-util/node_modules/@terrestris/ol-util": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-11.1.0.tgz",
-      "integrity": "sha512-Ah05KNb9NyTn/yE+Z/Z8qorSi96loriFROtygf5f3vODs6mXXwpO2j490gQoxVyJMw8cJd+K1+GiMv2JeDpaVA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-14.0.0.tgz",
+      "integrity": "sha512-6yXfU2bnDU4gIztXZ+vcD5aOTOBxv5UqQuj+IqYgf3E/m0xvE/ZlSsMPMplLHqZP1fu+fJpu6E88WCLamMVIQw==",
       "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.11",
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
-        "fast-xml-parser": "^4.2.5",
-        "geostyler-openlayers-parser": "^4.1.0",
+        "fast-xml-parser": "^4.2.7",
+        "geostyler-openlayers-parser": "^4.2.1",
         "lodash": "^4.17.21",
         "polygon-splitter": "^0.0.11",
-        "proj4": "^2.8.0",
+        "proj4": "^2.9.0",
         "shpjs": "^4.0.4",
-        "typescript": "^5.0.2"
+        "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=7"
+        "node": ">=18",
+        "npm": ">=9"
       },
       "peerDependencies": {
-        "ol": "^7.1"
+        "ol": "^8"
       }
     },
-    "node_modules/@terrestris/shogun-util/node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
-    "node_modules/@terrestris/shogun-util/node_modules/keycloak-js": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-22.0.5.tgz",
-      "integrity": "sha512-a7ZwCZeHl8tpeJBy102tZtAnHslDUOA1Nf/sHNF3HYLchKpwoDuaitwIUiS2GnNUe+tlNKLlCqZS+Mi5K79m1w==",
+    "node_modules/@terrestris/shogun-util/node_modules/ol": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-8.2.0.tgz",
+      "integrity": "sha512-/m1ddd7Jsp4Kbg+l7+ozR5aKHAZNQOBAoNZ5pM9Jvh4Etkf0WGkXr9qXd7PnhmwiC1Hnc2Toz9XjCzBBvexfXw==",
       "dependencies": {
-        "base64-js": "^1.5.1",
-        "js-sha256": "^0.9.0"
+        "color-rgba": "^3.0.0",
+        "color-space": "^2.0.1",
+        "earcut": "^2.2.3",
+        "geotiff": "^2.0.7",
+        "pbf": "3.2.1",
+        "rbush": "^3.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/@terrestris/shogun-util/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "node_modules/@terrestris/shogun-util/node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -10086,6 +10103,36 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/color-parse/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-rgba": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
+      "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
+      "dependencies": {
+        "color-parse": "^2.0.0",
+        "color-space": "^2.0.0"
+      }
+    },
+    "node_modules/color-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
+      "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA=="
     },
     "node_modules/color-string": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@terrestris/react-geo": "^23.3.0",
     "@terrestris/react-util": "^3.0.0",
     "@terrestris/shogun-e2e-tests": "^1.0.4",
-    "@terrestris/shogun-util": "^7.2.0",
+    "@terrestris/shogun-util": "^7.3.2",
     "antd": "^4.24.4",
     "color": "^4.2.3",
     "dotenv": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@terrestris/react-geo": "^23.3.0",
     "@terrestris/react-util": "^3.0.0",
     "@terrestris/shogun-e2e-tests": "^1.0.4",
-    "@terrestris/shogun-util": "^7.3.2",
+    "@terrestris/shogun-util": "7.2.0-ol7.1",
     "antd": "^4.24.4",
     "color": "^4.2.3",
     "dotenv": "^16.3.1",

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -173,7 +173,7 @@ const getApplicationConfiguration = async (applicationId: number) => {
 
 const getStaticApplicationConfiguration = async (staticAppContextUrl: string) => {
   try {
-    Logger.info(`Loading static application`);
+    Logger.info('Loading static application');
 
     const response = await fetch(staticAppContextUrl);
 
@@ -183,7 +183,7 @@ const getStaticApplicationConfiguration = async (staticAppContextUrl: string) =>
 
     const application = await response.json();
 
-    Logger.info(`Successfully loaded static application`);
+    Logger.info('Successfully loaded static application');
 
     return application;
   } catch (error) {
@@ -192,7 +192,7 @@ const getStaticApplicationConfiguration = async (staticAppContextUrl: string) =>
     }
     Logger.error(`Error while loading static application: ${error}`);
   }
-}
+};
 
 const getApplicationInfo = async () => {
   try {

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -373,9 +373,6 @@ const setupSHOGunMap = async (application: Application) => {
   view.setConstrainResolution(true);
 
   let layers;
-
-  console.log('test')
-
   if (!ClientConfiguration.layerConfigUrl) {
     layers = await parser.parseLayerTree(application, projection);
   } else {

--- a/src/context/SHOGunAPIClientContext.tsx
+++ b/src/context/SHOGunAPIClientContext.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import SHOGunAPIClient from '@terrestris/shogun-util/dist/service/SHOGunAPIClient';
 
 export type SHOGunAPIClientProviderProps = {
-  client: SHOGunAPIClient;
+  client?: SHOGunAPIClient;
   children: JSX.Element;
 };
 
@@ -15,7 +15,7 @@ export const SHOGunAPIClientProvider: React.FC<SHOGunAPIClientProviderProps> = (
 }): JSX.Element => {
   return (
     <SHOGunAPIClientContext.Provider
-      value={client}
+      value={client ?? null}
     >
       {children}
     </SHOGunAPIClientContext.Provider>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -59,11 +59,13 @@ declare module 'clientConfig' {
     featureEditRoles?: FeatureEditConfiguration;
     wfsLockFeatureEnabled?: boolean;
     enableFallbackConfig?: boolean;
+    staticAppConfigUrl?: string;
+    layerConfigUrl?: string;
   };
   const config: ClientConfiguration;
 
   export default config;
-};
+}
 
 // todo: remove when react-geo test util types are exported properly
 declare module '@terrestris/react-geo/dist/Util/rtlTestUtils';

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -35,7 +35,7 @@ declare module 'clientConfig' {
     solrQueryConfig?: SolrQueryConfig;
   };
   type ClientConfiguration = {
-    shogunBase?: string;
+    shogunBase?: string | false;
     keycloak?: {
       enabled?: boolean;
       host?: string;

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -162,6 +162,7 @@ export default {
         errorDescription: 'Aufgrund eines unerwarteten Fehlers konnte die Applikation nicht geladen werden.',
         errorDescriptionAppIdNotSet: 'Keine Applikations-ID angegeben. Bitte geben Sie die ID als Abfrageparameter an, z.B. ?applicationId=1909',
         errorDescriptionAppConfigNotFound: 'Die Applikation mit der ID {{applicationId}} konnte nicht geladen werden.',
+        errorDescriptionAppConfigStaticNotFound: 'Die Applikations Konfiguration konnte nicht geladen werden.',
         permissionDeniedUnauthorized: 'Dies ist keine öffentliche Applikation. Anmeldung erforderlich.'
       },
       Nominatim: {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -162,7 +162,7 @@ export default {
         errorDescription: 'Aufgrund eines unerwarteten Fehlers konnte die Applikation nicht geladen werden.',
         errorDescriptionAppIdNotSet: 'Keine Applikations-ID angegeben. Bitte geben Sie die ID als Abfrageparameter an, z.B. ?applicationId=1909',
         errorDescriptionAppConfigNotFound: 'Die Applikation mit der ID {{applicationId}} konnte nicht geladen werden.',
-        errorDescriptionAppConfigStaticNotFound: 'Die Applikations Konfiguration konnte nicht geladen werden.',
+        errorDescriptionAppConfigStaticNotFound: 'Die Konfiguration der Applikation konnte nicht geladen werden.',
         permissionDeniedUnauthorized: 'Dies ist keine öffentliche Applikation. Anmeldung erforderlich.'
       },
       Nominatim: {
@@ -430,6 +430,7 @@ export default {
         errorDescription: 'An unexpected error occurred while loading the application.',
         errorDescriptionAppIdNotSet: 'No application ID given. Please provide the ID as query parameter, e.g. ?applicationId=1909',
         errorDescriptionAppConfigNotFound: 'The application with ID {{applicationId}} could not be loaded correctly.',
+        errorDescriptionAppConfigStaticNotFound: 'The configuration of the application could not be loaded correctly.',
         permissionDeniedUnauthorized: 'This application is not public. Authentication required.'
       },
       Nominatim: {


### PR DESCRIPTION
This PR introduces two new config parameters, that allow to load the application configuration and the layers from other URLs. This way the client can be used without a shogun backend.

The config parameters are:

* `staticAppConfigUrl`
* `layerConfigUrl`