### PR TITLE
feat: allow addition of middlewares in plugin definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@monaco-editor/react": "^4.5.1",
-        "@reduxjs/toolkit": "^1.9.5",
+        "@reduxjs/toolkit": "^2.2.3",
         "@terrestris/base-util": "^1.0.1",
         "@terrestris/mapfish-print-manager": "^10.1.0",
         "@terrestris/ol-util": "^12.0.1",
@@ -4586,18 +4586,18 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
-      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.3.tgz",
+      "integrity": "sha512-76dll9EnJXg4EVcI5YNxZA/9hSAmZsFqzMmNRHvIlzw2WS/twfcVX3ysYrWGJMClwEmChQFC4yRq74tn6fdzRA==",
       "dependencies": {
-        "immer": "^9.0.21",
-        "redux": "^4.2.1",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.8"
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18",
-        "react-redux": "^7.2.1 || ^8.0.2"
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -14853,9 +14853,9 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.4.tgz",
+      "integrity": "sha512-cuBuGK40P/sk5IzWa9QPUaAdvPHjkk1c+xYsd9oZw+YQQEV+10G0P5uMpGctZZKnyQ+ibRO08bD25nWLmYi2pw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -24729,19 +24729,16 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/redux-thunk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
       "peerDependencies": {
-        "redux": "^4"
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -24908,9 +24905,9 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/reselect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "@monaco-editor/react": "^4.5.1",
-    "@reduxjs/toolkit": "^1.9.5",
+    "@reduxjs/toolkit": "^2.2.3",
     "@terrestris/base-util": "^1.0.1",
     "@terrestris/mapfish-print-manager": "^10.1.0",
     "@terrestris/ol-util": "^12.0.1",

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -101,7 +101,7 @@ import {
   setSearchEngines
 } from './store/searchEngines';
 import {
-  createReducer,
+  createReducer, dynamicMiddleware,
   store
 } from './store/store';
 import {
@@ -563,6 +563,10 @@ const loadPlugins = async (map: OlMap) => {
       if (clientPluginDefault.reducers) {
         const reducers = createReducer(clientPluginDefault.reducers);
         store.replaceReducer(reducers);
+      }
+
+      if (Array.isArray(clientPluginDefault.middlewares)) {
+        clientPluginDefault.middlewares?.forEach(mw => dynamicMiddleware.addMiddleware(mw));
       }
 
       clientPlugins.push(clientPluginDefault);

--- a/src/components/BasicMapComponent/index.tsx
+++ b/src/components/BasicMapComponent/index.tsx
@@ -2,8 +2,6 @@ import React, {
   useEffect
 } from 'react';
 
-import _isEmpty from 'lodash/isEmpty';
-
 import { ObjectEvent as OlObjectEvent } from 'ol/Object';
 
 import {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,6 +1,9 @@
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
 
-import type { Middleware, Reducer } from '@reduxjs/toolkit';
+import type {
+  Middleware,
+  Reducer
+} from '@reduxjs/toolkit';
 
 import { CollapsePanelProps } from 'antd';
 import type OlMap from 'ol/Map';

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,6 +1,6 @@
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
 
-import type { Reducer } from '@reduxjs/toolkit';
+import type { Middleware, Reducer } from '@reduxjs/toolkit';
 
 import { CollapsePanelProps } from 'antd';
 import type OlMap from 'ol/Map';
@@ -120,6 +120,11 @@ export type ClientPlugin = {
   reducers?: {
     [key: string]: Reducer;
   };
+  /**
+   * A set of middlewares that should be added to the store
+   * especially useful for usage of redux-rtk
+   */
+  middlewares?: Middleware[];
 };
 
 export type ClientPluginInternal = ClientPlugin & {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,7 +1,10 @@
 import {
+  Action,
   combineReducers,
   configureStore,
-  Reducer
+  createDynamicMiddleware,
+  Reducer,
+  ThunkDispatch
 } from '@reduxjs/toolkit';
 
 import addLayerModal from './addLayerModal';
@@ -25,6 +28,8 @@ import user from './user';
 type AsyncReducer = {
   [key: string]: Reducer;
 };
+
+export const dynamicMiddleware = createDynamicMiddleware();
 
 export const createReducer = (asyncReducers?: AsyncReducer) => {
   return combineReducers({
@@ -50,8 +55,10 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
 };
 
 export const store = configureStore({
-  reducer: createReducer()
+  reducer: createReducer(),
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().prepend(dynamicMiddleware.middleware)
 });
 
 export type RootState = ReturnType<typeof store.getState>;
-export type AppDispatch = typeof store.dispatch;
+export type AppDispatch = typeof store.dispatch & ThunkDispatch<RootState, undefined, Action>;


### PR DESCRIPTION
and bump @reduxjs/toolkit from 1.9.7 to 2.2.3.

The addition of further middlewares is required especially when [`rtk-query`](https://redux-toolkit.js.org/rtk-query/overview)  is used of redux-toolkit.

Please review @terrestris/devs 