### PR TITLE
docs: add sonarqube status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
-
-![on-pull-request]
-(https://github.com/terrestris/shogun-gis-client/actions/workflows/on-pull-request.yml/badge.svg)
-
-![on-push-main](https://github.com/terrestris/shogun-gis-client/actions/workflows/on-push-main.yml/badge.svg?event=push)
-
-![on-release](https://github.com/terrestris/shogun-gis-client/actions/workflows/on-release.yml/badge.svg)
-
-![release](https://github.com/terrestris/shogun-gis-client/actions/workflows/release.yml/badge.svg)
+[![Coverage](https://sq.terrestris.de/api/project_badges/measure?project=shogun-gis-client&metric=coverage&token=sqb_977992296292cb28180b84c03d38805ef4dad8c9)](https://sq.terrestris.de/dashboard?id=shogun-gis-client) 
+[![Security Rating](https://sq.terrestris.de/api/project_badges/measure?project=shogun-gis-client&metric=software_quality_security_rating&token=sqb_977992296292cb28180b84c03d38805ef4dad8c9)](https://sq.terrestris.de/dashboard?id=shogun-gis-client) 
+[![Maintainability Rating](https://sq.terrestris.de/api/project_badges/measure?project=shogun-gis-client&metric=software_quality_maintainability_rating&token=sqb_977992296292cb28180b84c03d38805ef4dad8c9)](https://sq.terrestris.de/dashboard?id=shogun-gis-client)
+[![Reliability Rating](https://sq.terrestris.de/api/project_badges/measure?project=shogun-gis-client&metric=software_quality_reliability_rating&token=sqb_977992296292cb28180b84c03d38805ef4dad8c9)](https://sq.terrestris.de/dashboard?id=shogun-gis-client)
 
 # SHOGun GIS client
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+
+![on-pull-request]
+(https://github.com/terrestris/shogun-gis-client/actions/workflows/on-pull-request.yml/badge.svg)
+
+![on-push-main]
+(https://github.com/terrestris/shogun-gis-client/actions/workflows/on-push-main.yml/badge.svg?event=push)
+
+![on-release]
+(https://github.com/terrestris/shogun-gis-client/actions/workflows/on-release.yml/badge.svg)
+
+![release]
+(https://github.com/terrestris/shogun-gis-client/actions/workflows/release.yml/badge.svg)
+
 # SHOGun GIS client
 
 This repository contains the default WebGIS client used within the [SHOGun project](https://github.com/terrestris/shogun-docker).

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 ![on-pull-request]
 (https://github.com/terrestris/shogun-gis-client/actions/workflows/on-pull-request.yml/badge.svg)
 
-![on-push-main]
-(https://github.com/terrestris/shogun-gis-client/actions/workflows/on-push-main.yml/badge.svg?event=push)
+![on-push-main](https://github.com/terrestris/shogun-gis-client/actions/workflows/on-push-main.yml/badge.svg?event=push)
 
 ![on-release]
 (https://github.com/terrestris/shogun-gis-client/actions/workflows/on-release.yml/badge.svg)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 ![on-push-main](https://github.com/terrestris/shogun-gis-client/actions/workflows/on-push-main.yml/badge.svg?event=push)
 
-![on-release]
-(https://github.com/terrestris/shogun-gis-client/actions/workflows/on-release.yml/badge.svg)
+![on-release](https://github.com/terrestris/shogun-gis-client/actions/workflows/on-release.yml/badge.svg)
 
 ![release](https://github.com/terrestris/shogun-gis-client/actions/workflows/release.yml/badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 ![on-release]
 (https://github.com/terrestris/shogun-gis-client/actions/workflows/on-release.yml/badge.svg)
 
-![release]
-(https://github.com/terrestris/shogun-gis-client/actions/workflows/release.yml/badge.svg)
+![release](https://github.com/terrestris/shogun-gis-client/actions/workflows/release.yml/badge.svg)
 
 # SHOGun GIS client
 


### PR DESCRIPTION
This adds sonarqube status badges to the README file.