### PR TITLE
Fix several code smells that a SonarQube check identified

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,6 @@ module.exports = {
     KEYCLOAK_REALM: 'SHOGun',
     KEYCLOAK_CLIENT_ID: 'shogun-client'
   },
-  moduleFileExtensions: ['ts', 'js'],
   transform: {
     '^.+\\.jsx?$': '<rootDir>/node_modules/babel-jest',
     '^.+\\.tsx?$': '<rootDir>/node_modules/babel-jest'

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -256,7 +256,7 @@ const setApplicationToStore = async (application?: Application) => {
   if (application.toolConfig && application.toolConfig.length > 0) {
     const availableTools: string[] = [];
     application.toolConfig
-      .map((tool: DefaultApplicationToolConfig) => {
+      .forEach((tool: DefaultApplicationToolConfig) => {
         if (tool.config.visible && tool.name !== 'search') {
           availableTools.push(tool.name);
         }

--- a/src/components/AddLayerModal/index.tsx
+++ b/src/components/AddLayerModal/index.tsx
@@ -48,7 +48,7 @@ import {
 
 import './index.less';
 
-export type AddLayerModalProps = {} & Partial<ModalProps>;
+export type AddLayerModalProps = Partial<ModalProps>;
 
 export const AddLayerModal: React.FC<AddLayerModalProps> = ({
   ...restProps

--- a/src/components/EditFeatureDrawer/index.tsx
+++ b/src/components/EditFeatureDrawer/index.tsx
@@ -50,7 +50,7 @@ import EditFeatureSwitch from './EditFeatureSwitch';
 
 import './index.less';
 
-export type EditFeatureDrawerProps = MapDrawerProps & {};
+export type EditFeatureDrawerProps = MapDrawerProps;
 
 export const EditFeatureDrawer: React.FC<EditFeatureDrawerProps> = ({
   ...passThroughProps

--- a/src/components/LayerDetailsModal/index.tsx
+++ b/src/components/LayerDetailsModal/index.tsx
@@ -39,7 +39,7 @@ import LayerDetails from './LayerDetails';
 
 import './index.less';
 
-export type LayerDetailsModalProps = {} & Partial<ModalProps>;
+export type LayerDetailsModalProps = Partial<ModalProps>;
 
 export const LayerDetailsModal: React.FC<LayerDetailsModalProps> = ({
   ...restProps

--- a/src/components/MapDrawer/index.tsx
+++ b/src/components/MapDrawer/index.tsx
@@ -14,7 +14,7 @@ import useMap from '@terrestris/react-geo/dist/Hook/useMap';
 
 import './index.less';
 
-export type MapDrawerProps = DrawerProps & {};
+export type MapDrawerProps = DrawerProps;
 
 export const MapDrawer: React.FC<MapDrawerProps> = ({
   open,

--- a/src/components/StylingDrawer/index.tsx
+++ b/src/components/StylingDrawer/index.tsx
@@ -16,7 +16,7 @@ import useAppSelector from '../../hooks/useAppSelector';
 import { setStylingDrawerVisibility } from '../../store/stylingDrawerVisibility';
 import StylingComponent from '../ToolMenu/Draw/StylingDrawerButton/StylingComponent';
 
-export type StylingDrawerProps = DrawerProps & {};
+export type StylingDrawerProps = DrawerProps;
 
 export const StylingDrawer: React.FC<StylingDrawerProps> = ({
   ...passThroughProps

--- a/src/components/ToolMenu/Draw/StylingDrawerButton/StylingComponent/index.tsx
+++ b/src/components/ToolMenu/Draw/StylingDrawerButton/StylingComponent/index.tsx
@@ -32,7 +32,7 @@ import {
   useMap
 } from '@terrestris/react-geo/dist/Hook/useMap';
 
-export type StylingComponentProps = CardStyleProps & {};
+export type StylingComponentProps = CardStyleProps;
 
 export const StylingComponent: React.FC<StylingComponentProps> = ({
   ...passThroughProps

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -47,7 +47,7 @@ import LayerTreeContextMenu from './LayerTreeContextMenu';
 import './index.less';
 import LoadingIndicator from './LoadingIndicator';
 
-export type LayerTreeProps = {} & Partial<RgLayerTreeProps>;
+export type LayerTreeProps = Partial<RgLayerTreeProps>;
 
 export type LayerTileLoadCounter = {
   [key: string]: {

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -88,7 +88,7 @@ export type ToolPanelConfig = {
   wrappedComponent: JSX.Element;
 };
 
-export type ToolMenuProps = {} & Partial<CollapsePanelProps>;
+export type ToolMenuProps = Partial<CollapsePanelProps>;
 
 export const ToolMenu: React.FC<ToolMenuProps> = ({
   ...restProps

--- a/src/components/UploadDataModal/index.tsx
+++ b/src/components/UploadDataModal/index.tsx
@@ -93,7 +93,7 @@ export type LayerUploadResponse = {
   baseUrl: string;
 };
 
-export type UploadDataModalProps = {} & Partial<ModalProps>;
+export type UploadDataModalProps = Partial<ModalProps>;
 
 export const UploadDataModal: React.FC<UploadDataModalProps> = ({
   ...restProps


### PR DESCRIPTION
This PR fixes 3 types of SonarQube detected code smells:

* No duplicated key in the Jest config => dfd44be857b75c4ec78beb7244ec9972b8efcc21
* using `[].forEach` and not `[].map` in one instance => 59f0d60c3b101874c9884d263331404561dde8dd
* not using type intersections like `export type HumptyProps = {} | SomeOtherProps` or `export type HumptyProps = {} | Partial<SomeOtherProps>` => c77d18325bec2bcec0b2d7390bde7db19d5f0875

WRT the first two commits above I am quite quite sure they do the correct thing™

I am not so sure about the effects of c77d18325bec2bcec0b2d7390bde7db19d5f0875. @dnlkoch nodded an OK after a quick 15 seconds explanation around the coffee machine ;-)

Please review.

