### PR TITLE
ci: use Version varable from env

### DIFF
--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -116,4 +116,4 @@ jobs:
         with:
           host: ${{ secrets.SONARQUBE_HOST }}
           login: ${{ secrets.SONARQUBE_TOKEN }}
-          projectVersion: ${{ VERSION }}
+          projectVersion: ${{ env.VERSION }}


### PR DESCRIPTION
The variable 'Version' could not be used since it was not taken from env.