### PR TITLE
Coloring ol-control

### DIFF
--- a/src/App.less
+++ b/src/App.less
@@ -6,6 +6,7 @@
   width: 100%;
 
   .ol-control button {
+    color: var(--secondaryColor);
     background-color: var(--primaryColor);
     &:focus,
     &:hover {


### PR DESCRIPTION
This fix makes use of the secondary color variable for the attribution control button.

I chose the --secondary-color instead of a default (like white or black) since the background color is customizable too.