### PR TITLE
feat: make loading mask configurable

### DIFF
--- a/resources/public/index.ejs
+++ b/resources/public/index.ejs
@@ -13,7 +13,7 @@
     <base href="<%= htmlWebpackPlugin.options.appPrefix %>">
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
     <div id="loadmask" class="loadmask">
-      <img src="./shogun_spinner.gif" alt="Loading, please wait…">
+      <img id="loadmaskImage" alt="Loading, please wait…">
     </div>
     <title><%= htmlWebpackPlugin.options.title %></title>
     <style>
@@ -77,6 +77,18 @@
       if (!window.clientConfig) {
         console.warn('No config found, client defaults will be used.');
         window.clientConfig = {};
+      }
+    </script>
+    <script>
+      const regex = /\?applicationId=(\d+)/;
+      const appId = location.search.match(regex)[1]
+      let logoPath = './shogun_spinner.gif';
+      if (appId) {
+        logoPath = localStorage.getItem(`SHOGun_Logo_Path_${appId}`);
+      }
+      const loadingImageElement = document.getElementById('loadmaskImage');
+      if (logoPath && loadingImageElement) {
+        loadingImageElement.src = logoPath;
       }
     </script>
     <div id="app" class="app"></div>

--- a/resources/public/index.ejs
+++ b/resources/public/index.ejs
@@ -80,8 +80,8 @@
       }
     </script>
     <script>
-      const regex = /\?applicationId=(\d+)/;
-      const appId = location.search.match(regex)[1]
+      const regex = /\applicationId=(\d+)/;
+      const appId = location.search.match(regex)[1];
       let logoPath = './shogun_spinner.gif';
       if (appId) {
         logoPath = localStorage.getItem(`SHOGun_Logo_Path_${appId}`);

--- a/resources/public/index.ejs
+++ b/resources/public/index.ejs
@@ -13,7 +13,7 @@
     <base href="<%= htmlWebpackPlugin.options.appPrefix %>">
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
     <div id="loadmask" class="loadmask">
-      <img id="loadmaskImage" alt="Loading, please wait…">
+      <img id="loadmask-image" alt="Loading, please wait…">
     </div>
     <title><%= htmlWebpackPlugin.options.title %></title>
     <style>
@@ -86,7 +86,7 @@
       if (appId) {
         logoPath = localStorage.getItem(`SHOGun_Logo_Path_${appId}`);
       }
-      const loadingImageElement = document.getElementById('loadmaskImage');
+      const loadingImageElement = document.getElementById('loadmask-image');
       if (logoPath && loadingImageElement) {
         loadingImageElement.src = logoPath;
       }

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -288,7 +288,7 @@ const setUserToStore = async (user?: User) => {
 };
 
 const setLoadingImage = (path = './shogun_spinner.gif', id: number) => {
-  const loadingImageElement = document.getElementById('loadmaskImage') as HTMLImageElement;
+  const loadingImageElement = document.getElementById('loadmask-image') as HTMLImageElement;
   if (!loadingImageElement) {
     return;
   }

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -287,6 +287,17 @@ const setUserToStore = async (user?: User) => {
   store.dispatch(setUser(user));
 };
 
+const setLoadingImage = (path = './shogun_spinner.gif', id: number) => {
+  const loadingImageElement = document.getElementById('loadmaskImage') as HTMLImageElement;
+  if (!loadingImageElement) {
+    return;
+  }
+  loadingImageElement.src = path;
+  if (id) {
+    localStorage.setItem(`SHOGun_Logo_Path_${id}`, path);
+  }
+};
+
 const initKeycloak = async () => {
   const keycloakEnabled = ClientConfiguration.keycloak?.enabled;
   const keycloakOnLoad = ClientConfiguration.keycloak?.onLoadAction;
@@ -650,10 +661,10 @@ const renderApp = async () => {
     if (!applicationId && !ClientConfiguration.enableFallbackConfig && !ClientConfiguration.staticAppConfigUrl) {
       throw new Error(LoadingErrorCode.APP_ID_NOT_SET);
     }
-
     let appConfig;
     if (applicationId && client) {
       appConfig = await getApplicationConfiguration(client, applicationId);
+      setLoadingImage(appConfig?.clientConfig?.theme?.logoPath, applicationId);
     } else if (ClientConfiguration.staticAppConfigUrl) {
       appConfig = await getStaticApplicationConfiguration(ClientConfiguration.staticAppConfigUrl);
 

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -287,15 +287,13 @@ const setUserToStore = async (user?: User) => {
   store.dispatch(setUser(user));
 };
 
-const setLoadingImage = (path = './shogun_spinner.gif', id: number) => {
+const setLoadingImage = (id: number, path = './shogun_spinner.gif') => {
   const loadingImageElement = document.getElementById('loadmask-image') as HTMLImageElement;
   if (!loadingImageElement) {
     return;
   }
   loadingImageElement.src = path;
-  if (id) {
-    localStorage.setItem(`SHOGun_Logo_Path_${id}`, path);
-  }
+  localStorage.setItem(`SHOGun_Logo_Path_${id}`, path);
 };
 
 const initKeycloak = async () => {
@@ -664,7 +662,7 @@ const renderApp = async () => {
     let appConfig;
     if (applicationId && client) {
       appConfig = await getApplicationConfiguration(client, applicationId);
-      setLoadingImage(appConfig?.clientConfig?.theme?.logoPath, applicationId);
+      setLoadingImage(applicationId, appConfig?.clientConfig?.theme?.logoPath);
     } else if (ClientConfiguration.staticAppConfigUrl) {
       appConfig = await getStaticApplicationConfiguration(ClientConfiguration.staticAppConfigUrl);
 


### PR DESCRIPTION
This MR uses the logo defined under 'logoPath' within the client-config as a loading image.

It is also saved within the cookies to ensure a faster image loading process.

co authored by @AmandaTamanda & Noémie