### PR TITLE
feat: adds dynamic width to menu toolbar

### DIFF
--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -5,7 +5,6 @@
   margin-top: var(--headerHeight);
   max-height: calc(100% - var(--headerHeight) - var(--footerHeight));
   overflow: hidden;
-  width: 350px;
   box-shadow: var(--componentShadow);
   overflow-x: hidden;
 
@@ -46,7 +45,6 @@
 
   &.collapsed {
     min-width: unset;
-    width: 40px;
 
     >.ant-collapse .ant-collapse-item {
       overflow: hidden;

--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -129,3 +129,13 @@
     text-shadow: 0.5px 0.5px 0.5px color-mix(in srgb, var(--secondaryColor), black 20%);
   }
 }
+
+.dynamicWidth {
+  position: absolute;
+  width: 10px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
+  cursor:ew-resize
+}

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -109,6 +109,9 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
 
   const [collapsed, setCollapsed] = useState<boolean>(false);
   const [menuTools, setMenuTools] = useState<string[]>([]);
+  const [isResizing, setIsResizing] = useState(false);
+  const [width, setWidth] = useState(320);
+  const [noCollapseWidth, setNoCollapseWidth] = useState(width);
 
   useEffect(() => {
     const mobileQuery = window.matchMedia('only screen and (max-width: 450px) and (orientation: portrait),' +
@@ -343,10 +346,41 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
     }
   };
 
+  const onMouseDown = () => {
+    setIsResizing(true);
+  };
+
+  const onMouseUp = () => {
+    setIsResizing(false);
+  };
+
+  const onMouseMove = (e: MouseEvent) => {
+    if (isResizing && !collapsed) {
+      let offsetLeft = (e.clientX - document.body.offsetLeft);
+      const minWidth = 240;
+      const maxWidth = 600;
+      if (offsetLeft > minWidth && offsetLeft < maxWidth) {
+        setWidth(offsetLeft);
+        setNoCollapseWidth(offsetLeft);
+      }
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+  });
+
   return (
     <div
       aria-label="tool-menu"
       className={`tool-menu ${collapsed ? 'collapsed' : ''}`}
+      style={{width: width} as React.CSSProperties}
     >
       <Collapse
         expandIconPosition='end'
@@ -375,9 +409,28 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
           onClick={() => {
             dispatch(setActiveKeys([]));
             setCollapsed(!collapsed);
+            if (collapsed){
+              setWidth(noCollapseWidth);
+            } else {
+              setWidth(40);
+            }
           }}
         />
       </Tooltip>
+      {!collapsed ? (
+        <div
+          style={{
+            position: 'absolute',
+            width: '10px',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            zIndex: 100,
+            cursor:'ew-resize'
+          }}
+          onMouseDown={onMouseDown}
+        />
+      ) : <></>}
     </div>
   );
 };

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -1,4 +1,5 @@
 import React, {
+  useCallback,
   useEffect,
   useState
 } from 'react';
@@ -88,9 +89,14 @@ export type ToolPanelConfig = {
   wrappedComponent: JSX.Element;
 };
 
-export type ToolMenuProps = Partial<CollapsePanelProps>;
+export type ToolMenuProps = Partial<CollapsePanelProps> & { 
+  minWidth?: number;
+  maxWidth?: number;
+};
 
 export const ToolMenu: React.FC<ToolMenuProps> = ({
+  minWidth = 240,
+  maxWidth = 600,
   ...restProps
 }): JSX.Element => {
   const {
@@ -346,25 +352,23 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
     }
   };
 
-  const onMouseDown = () => {
+  const onMouseDown = useCallback(() => {
     setIsResizing(true);
-  };
+  }, []);
 
-  const onMouseUp = () => {
+  const onMouseUp = useCallback(() => {
     setIsResizing(false);
-  };
+  }, []);
 
-  const onMouseMove = (e: MouseEvent) => {
+  const onMouseMove = useCallback((e: MouseEvent) => {
     if (isResizing && !collapsed) {
       let offsetLeft = (e.clientX - document.body.offsetLeft);
-      const minWidth = 240;
-      const maxWidth = 600;
       if (offsetLeft > minWidth && offsetLeft < maxWidth) {
         setWidth(offsetLeft);
         setNoCollapseWidth(offsetLeft);
       }
     }
-  };
+  }, [isResizing, collapsed, minWidth, maxWidth]);
 
   useEffect(() => {
     document.addEventListener('mousemove', onMouseMove);
@@ -374,7 +378,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
     };
-  });
+  }, [onMouseMove, onMouseUp]);
 
   return (
     <div
@@ -419,15 +423,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
       </Tooltip>
       {!collapsed ? (
         <div
-          style={{
-            position: 'absolute',
-            width: '10px',
-            top: 0,
-            right: 0,
-            bottom: 0,
-            zIndex: 100,
-            cursor:'ew-resize'
-          }}
+          className ="dynamicWidth"
           onMouseDown={onMouseDown}
         />
       ) : <></>}


### PR DESCRIPTION
This PR allows to dynamically change the width of the menu toolbar. The width of the menu toolbar is now only set in the ToolMenu/index.tsx file and not in the ToolMenu/index.less file.

From ticket [#21431](https://redmine.intranet.terrestris.de/issues/21431?include=journals&journals=all)

Please review @dnlkoch 
![featDynamicWidth](https://github.com/terrestris/shogun-gis-client/assets/161820732/f633aab0-1616-49cf-86c5-73ef9027d689)
