### PR TITLE
Fix resetting the `EditFeatureFullForm`

### DIFF
--- a/src/components/EditFeatureDrawer/EditFeatureFullForm/index.tsx
+++ b/src/components/EditFeatureDrawer/EditFeatureFullForm/index.tsx
@@ -190,11 +190,11 @@ export const EditFeatureFullForm: React.FC<EditFeatureFullFormProps> = ({
 
     await Promise.all(setPropertiesPromises);
 
+    setInitialValues(properties);
     form.resetFields();
     form.setFieldsValue(properties);
 
     setTabConfig(editFormConfig);
-    setInitialValues(properties);
   }, [map, client, layer, feature?.properties, form, imageUrlToBase64]);
 
   useEffect(() => {


### PR DESCRIPTION
This moves the setting of initial values above the `resetFields` call. As `resetFields` resets the form to the initial values. In the current state these are the intialValues of the previously used feature.