### PR TITLE
fix: fixes of dynamic width of toolbar

### DIFF
--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -138,5 +138,5 @@
   bottom: 0;
   z-index: 100;
   cursor:ew-resize;
-  user-select: none
+  user-select: none;
 }

--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -137,5 +137,6 @@
   right: 0;
   bottom: 0;
   z-index: 100;
-  cursor:ew-resize
+  cursor:ew-resize;
+  user-select: none
 }

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -393,7 +393,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
         onChange={(keys: string[] | string) => {
           setCollapsed(false);
           dispatch(setActiveKeys(_toArray(keys)));
-          if (collapsed){
+          if (collapsed) {
             setWidth(noCollapseWidth);
           }
         }}

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -89,7 +89,7 @@ export type ToolPanelConfig = {
   wrappedComponent: JSX.Element;
 };
 
-export type ToolMenuProps = Partial<CollapsePanelProps> & { 
+export type ToolMenuProps = Partial<CollapsePanelProps> & {
   minWidth?: number;
   maxWidth?: number;
 };
@@ -393,6 +393,9 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
         onChange={(keys: string[] | string) => {
           setCollapsed(false);
           dispatch(setActiveKeys(_toArray(keys)));
+          if (collapsed){
+            setWidth(noCollapseWidth);
+          }
         }}
         {...restProps}
       >


### PR DESCRIPTION
This PR is a follow-up of [PR 1563](https://github.com/terrestris/shogun-gis-client/pull/1563) and fixes the highlighting of the text by disabling it in the less-file as well as setting the width to its previous value (before collapsing) when (re)opening the drawer by clicking on one of the icons. 

Please review @dnlkoch :)