### PR TITLE
Fix LayerTree overflow styling

### DIFF
--- a/src/components/ToolMenu/LayerTree/index.less
+++ b/src/components/ToolMenu/LayerTree/index.less
@@ -15,7 +15,7 @@
 
   .ant-tree-node-content-wrapper {
     flex: 1;
-    overflow-x: scroll;
+    overflow-x: auto;
     .ant-tree-title {
       .tree-node-header {
         display: flex;


### PR DESCRIPTION
Before: 

![image](https://github.com/terrestris/shogun-gis-client/assets/5795523/d3b41466-c20a-4d9d-a272-7621b890d2a9)

After: 

![image](https://github.com/terrestris/shogun-gis-client/assets/5795523/e1c1eb99-246c-4c9f-90e2-7fb5681b8e6c)

@terrestris/devs Please review

