### PR TITLE
Redirect to login after logout

### DIFF
--- a/src/components/UserMenu/index.tsx
+++ b/src/components/UserMenu/index.tsx
@@ -72,7 +72,9 @@ export const UserMenu: React.FC<UserProps> = (): JSX.Element => {
         break;
       case 'logout':
         if (keycloak) {
-          keycloak.logout();
+          keycloak.logout({
+            redirectUri: keycloak.createLoginUrl()
+          });
         }
         break;
       default:


### PR DESCRIPTION
This redirects to the login page after logging out instead of reloading the client which may case an unexpected "You're not allowed to see this application" error.

Please review @terrestris/devs.