### PR TITLE
Allow disabling plugins via appConfig

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -522,7 +522,7 @@ const loadPluginModules = async (moduleName: string, moduleUrl: string, remoteNa
   return modules;
 };
 
-const loadPlugins = async (map: OlMap, toolConfig?: any[]) => {
+const loadPlugins = async (map: OlMap, toolConfig?: DefaultApplicationToolConfig[]) => {
   if (!ClientConfiguration.plugins || ClientConfiguration.plugins.length === 0) {
     Logger.info('No plugins found');
     return [];


### PR DESCRIPTION
This allows disabling of specific plugins via shogun appConfig. To disable a plugin for a certain application you can add this to your toolconfig:

```json
  {
    "name": "utility-survey-admin-plugin",
    "config": {
      "disabled": true
    }
  }
```

The `name` has to match the `key` of the plugin as configured in the `plugin.ts`.