### PR TITLE
test: add accessibility test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "8.5.0",
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@axe-core/playwright": "^4.9.1",
         "@monaco-editor/react": "^4.5.1",
         "@reduxjs/toolkit": "^2.2.3",
         "@terrestris/base-util": "^1.0.1",
@@ -19,6 +20,7 @@
         "@terrestris/shogun-e2e-tests": "^1.0.4",
         "@terrestris/shogun-util": "7.2.0-ol7.2",
         "antd": "^4.24.4",
+        "axe-html-reporter": "^2.2.3",
         "color": "^4.2.3",
         "dotenv": "^16.3.1",
         "geostyler": "^12.0.0",
@@ -170,6 +172,17 @@
       },
       "peerDependencies": {
         "react": ">=16.9.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.9.1.tgz",
+      "integrity": "sha512-8m4WZbZq7/aq7ZY5IG8GqV+ZdvtGn/iJdom+wBg+iv/3BAOBIfNQtIu697a41438DzEEyptXWmC3Xl5Kx/o9/g==",
+      "dependencies": {
+        "axe-core": "~4.9.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/cli": {
@@ -9161,6 +9174,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
+      "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axe-html-reporter": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/axe-html-reporter/-/axe-html-reporter-2.2.3.tgz",
+      "integrity": "sha512-io8aCEt4fJvv43W+33n3zEa8rdplH5Ti2v5fOnth3GBKLhLHarNs7jj46xGfpnGnpaNrz23/tXPHC3HbwTzwwA==",
+      "dependencies": {
+        "mustache": "^4.0.1",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      },
+      "peerDependencies": {
+        "axe-core": ">=3"
       }
     },
     "node_modules/babel-jest": {
@@ -18892,6 +18928,14 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "bin": {
+        "mustache": "bin/mustache"
       }
     },
     "node_modules/mz": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "not IE 11"
   ],
   "dependencies": {
+    "@axe-core/playwright": "^4.9.1",
     "@monaco-editor/react": "^4.5.1",
     "@reduxjs/toolkit": "^2.2.3",
     "@terrestris/base-util": "^1.0.1",
@@ -52,6 +53,7 @@
     "@terrestris/shogun-e2e-tests": "^1.0.4",
     "@terrestris/shogun-util": "7.2.0-ol7.2",
     "antd": "^4.24.4",
+    "axe-html-reporter": "^2.2.3",
     "color": "^4.2.3",
     "dotenv": "^16.3.1",
     "geostyler": "^12.0.0",

--- a/src/e2e-tests/accessibility.spec.ts
+++ b/src/e2e-tests/accessibility.spec.ts
@@ -1,0 +1,19 @@
+
+import { test } from '@playwright/test';
+
+import { scan } from '@terrestris/shogun-e2e-tests/dist/accessibility/client';
+
+test.use({
+  storageState: 'playwright/.auth/admin.json'
+});
+
+test('accessibility', async ({
+  page
+}) => {
+
+  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.waitForTimeout(5000);
+
+  await page.waitForLoadState('networkidle');
+  await scan(page);
+});


### PR DESCRIPTION
### Summary
This merge requests imports an accessibility test (e2e-test) from https://github.com/terrestris/shogun-e2e-tests/pull/8 in order to test the gis-client for accessibility issues based on the Web Content Accessibility Guidelines (WCAG).
The test passes when no violations (issues that fail WCAG standards) are reported.

### TODO:
https://github.com/terrestris/shogun-e2e-tests/pull/8 hast to be released first in order for this to work.
