### PR TITLE
fix: adjust width in mobile version

### DIFF
--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -90,11 +90,13 @@ export type ToolPanelConfig = {
 };
 
 export type ToolMenuProps = Partial<CollapsePanelProps> & {
+  collapseWidth?: number;
   minWidth?: number;
   maxWidth?: number;
 };
 
 export const ToolMenu: React.FC<ToolMenuProps> = ({
+  collapseWidth = 40,
   minWidth = 240,
   maxWidth = 600,
   ...restProps
@@ -128,8 +130,9 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
 
     if (isMobile) {
       setCollapsed(true);
+      setWidth(collapseWidth);
     }
-  }, []);
+  }, [collapseWidth]);
 
   useEffect(() => {
     if (menuTools.length < 1) {
@@ -419,7 +422,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
             if (collapsed){
               setWidth(noCollapseWidth);
             } else {
-              setWidth(40);
+              setWidth(collapseWidth);
             }
           }}
         />


### PR DESCRIPTION
ToolMenu should be collapsed when starting mobile application as described in [#22048](https://redmine.intranet.terrestris.de/issues/22048?include=journals&journals=all)

view when starting in mobile version now:
![ToolboxMobile](https://github.com/terrestris/shogun-gis-client/assets/161820732/9aca0ce1-ea40-4c91-a093-735d27791db1)

Please review :)
