### PR TITLE
ci: fix coverage-comment for changed files

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -62,7 +62,7 @@ jobs:
           All, ./coverage/all/coverage-summary.json
           only changed, ./coverage/changed/coverage-summary.json
       
-    - name: Get coverage comment id
+    - name: Get Coverage Comment Id ➡️
       if: env.no_tests_found == 'true'
       id: get-comment-id
       run: |
@@ -74,10 +74,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Post No Tests Found Comment ⚠️
+    - name: Post To No Tests Found Comment ⚠️
       if: env.no_tests_found == 'true'
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ env.COVERAGE_COMMENT_ID }}
         body: |
-          No tests were found related to the files changed
+          ❌ No tests were found related to the files changed

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Post No Tests Found Comment ⚠️
       if: env.no_tests_found == 'true'
       run: |
-        COMMENT="⚠️ No tests were found related to the files changed since the last commit."
+        COMMENT="⚠️ No tests were found related to the files changed."
         PR_NUMBER=${{ github.event.pull_request.number }}
         COMMENTS_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments")
@@ -91,7 +91,7 @@ jobs:
           curl -s -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{\"body\": \"$UPDATED_COMMENT\"}" \
+            -d "$(jq -nc --arg body "${UPDATED_COMMENT}" '{body: $body}')" \
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}"
         fi
       env:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         echo "BASE_BRANCH=main" >> $GITHUB_ENV
         git fetch origin ${{ env.BASE_BRANCH }}
+        git diff --name-only origin/${{ env.BASE_BRANCH }}
         npx jest --config=jest.config.js --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
 
     - name: Check for test results 
@@ -44,7 +45,7 @@ jobs:
         if [ -f ./coverage/changed/coverage-summary.json ]; then
           COVERAGE_CONTENT=$(cat ./coverage/changed/coverage-summary.json)
           if echo "$COVERAGE_CONTENT" | jq '.total.lines.pct' | grep -q '0'; then
-            echo "no_tests_found=true" >> $GITHUB_ENV
+            echo "no_tests_found=true" 
           else
             echo "no_tests_found=false" >> $GITHUB_ENV
           fi

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -61,42 +61,23 @@ jobs:
         multiple-files: |
           All, ./coverage/all/coverage-summary.json
           only changed, ./coverage/changed/coverage-summary.json
-
-    - name: Post No Tests Found Comment ⚠️
+      
+    - name: Get coverage comment id
       if: env.no_tests_found == 'true'
+      id: get-comment-id
       run: |
-        COMMENT="⚠️ No tests were found related to the files changed."
         PR_NUMBER=${{ github.event.pull_request.number }}
         COMMENTS_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments")
         COVERAGE_COMMENT_ID=$(echo "${COMMENTS_JSON}" | jq -r 'map(select(.user.login == "github-actions[bot]")) | sort_by(.created_at) | .[0].id')
-        echo "COVERAGE_COMMENT_ID: ${COVERAGE_COMMENT_ID}"
-
-        if [ -z "$COVERAGE_COMMENT_ID" ]; then
-          echo "No existing coverage comment found, creating a new comment."
-          curl -s -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"body\": \"$COMMENT\"}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
-        else
-          echo "Existing coverage comment found, updating the comment."
-          EXISTING_COMMENT=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}" | \
-            jq -r '.body')
-          echo "EXISTING_COMMENT: ${EXISTING_COMMENT}"
-
-          UPDATED_COMMENT="${EXISTING_COMMENT}n\n${COMMENT}"
-          echo "UPDATED_COMMENT: ${UPDATED_COMMENT}""
-
-          PAYLOAD=$(jq -nc --arg body "$UPDATED_COMMENT" '{body: $body}')
-          echo "PAYLOAD: ${PAYLOAD}"
-
-          curl -s -X PATCH \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "${PAYLOAD}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}"
-        fi
+        echo "COVERAGE_COMMENT_ID=${COVERAGE_COMMENT_ID}" >> $GITHUB_ENV
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Post No Tests Found Comment ⚠️
+      if: env.no_tests_found == 'true'
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ env.COVERAGE_COMMENT_ID }}
+        body: |
+          No tests were found related to the files changed

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,8 +34,8 @@ jobs:
 
     - name: Run tests related to current changes ✅
       run: |
-        echo "BASE_BRANCH=main" >> $GITHUB_ENV
-        git fetch origin ${{ env.BASE_BRANCH }}
+        git fetch origin main
+        git diff --name-only origin/main
         npx jest --config=jest.config.js --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
 
     - name: Check for test results 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -86,12 +86,12 @@ jobs:
             jq -r '.body')
           echo "EXISTING_COMMENT: ${EXISTING_COMMENT}"
 
-          UPDATED_COMMENT="${EXISTING_COMMENT}\n\n${COMMENT}"
+          ESCAPED_UPDATED_COMMENT=$(jq -Rs '.' <<<"${UPDATED_COMMENT}")
           echo "UPDATED_COMMENT: ${UPDATED_COMMENT}"
           curl -s -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "$(jq -nc --arg body "${UPDATED_COMMENT}" '{body: $body}')" \
+            -d "{\"body\": ${ESCAPED_UPDATED_COMMENT}}"
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}"
         fi
       env:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -87,15 +87,15 @@ jobs:
           echo "EXISTING_COMMENT: ${EXISTING_COMMENT}"
 
           UPDATED_COMMENT="${EXISTING_COMMENT}\n\n${COMMENT}"
-          echo "UPDATED_COMMENT: ${UPDATED_COMMENT}"
+          echo "UPDATED_COMMENT: ${UPDATED_COMMENT}""
 
-          ESCAPED_UPDATED_COMMENT=$(jq -Rs '.' <<<"${UPDATED_COMMENT}")
+          ESCAPED_UPDATED_COMMENT=$(printf '%s' "${UPDATED_COMMENT}" | jq -Rsa .)
           echo "ESCAPED_UPDATED_COMMENT: ${ESCAPED_UPDATED_COMMENT}"
 
           curl -s -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{\"body\": ${ESCAPED_UPDATED_COMMENT}}" \
+            -d "{\"body\": \"${ESCAPED_UPDATED_COMMENT}\"}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}"
         fi
       env:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -70,7 +70,7 @@ jobs:
         COVERAGE_COMMENT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" | \
           jq -r '.[] | select(.user.login == "github-actions[bot]") | .id')
-        echo "COVERAGE_COMMENT: ${COVERAGE_COMMENT}"
+        echo "COVERAGE_COMMENT_ID: ${COVERAGE_COMMENT_ID}"
 
         if [ -z "$COVERAGE_COMMENT_ID" ]; then
           echo "No existing coverage comment found, creating a new comment."

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         if [ -f ./coverage/changed/coverage-summary.json ]; then
           COVERAGE_CONTENT=$(cat ./coverage/changed/coverage-summary.json)
-          if echo "$COVERAGE_CONTENT" | jq '.total.lines.pct' | grep -q '0'; then
+          if echo "$COVERAGE_CONTENT" | jq '.total.lines.pct' | grep -q 'Unknown'; then
             echo "no_tests_found=true" >> $GITHUB_ENV
           else
             echo "no_tests_found=false" >> $GITHUB_ENV

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,16 +34,22 @@ jobs:
 
     - name: Run tests related to current changes ✅
       run: |
-        git fetch origin main
+        echo "BASE_BRANCH=main" >> $GITHUB_ENV
+        git fetch origin ${{ env.BASE_BRANCH }}
         npx jest --config=jest.config.js --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
 
     - name: Check for test results 
       id: check-results
       run: |
-        if [ ! -s ./coverage/changed/coverage-summary.json ]; then
-          echo "no_tests_found=true" >> $GITHUB_ENV
+        if [ -f ./coverage/changed/coverage-summary.json ]; then
+          COVERAGE_CONTENT=$(cat ./coverage/changed/coverage-summary.json)
+          if echo "$COVERAGE_CONTENT" | jq '.total.lines.pct' | grep -q '0'; then
+            echo "no_tests_found=true" >> $GITHUB_ENV
+          else
+            echo "no_tests_found=false" >> $GITHUB_ENV
+          fi
         else
-          echo "no_tests_found=false" >> $GITHUB_ENV
+          echo "no_tests_found=true" >> $GITHUB_ENV
         fi
 
     - name: Jest Coverage Comment 💬
@@ -56,7 +62,7 @@ jobs:
           All, ./coverage/all/coverage-summary.json
           only changed, ./coverage/changed/coverage-summary.json
 
-    - name: Post No Tests Found Comment 💬
+    - name: Post No Tests Found Comment 
       if: env.no_tests_found == 'true'
       run: |
         COMMENT="No tests were found related to the files changed since the last commit."

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -38,7 +38,7 @@ jobs:
         git diff --name-only origin/main
         npx jest --config=jest.config.js --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
 
-    - name: Check for test results 
+    - name: Check for test results ❓
       id: check-results
       run: |
         if [ -f ./coverage/changed/coverage-summary.json ]; then
@@ -62,15 +62,34 @@ jobs:
           All, ./coverage/all/coverage-summary.json
           only changed, ./coverage/changed/coverage-summary.json
 
-    - name: Post No Tests Found Comment 
+    - name: Post No Tests Found Comment ⚠️
       if: env.no_tests_found == 'true'
       run: |
-        COMMENT="No tests were found related to the files changed since the last commit."
+        COMMENT="⚠️ No tests were found related to the files changed since the last commit."
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-        curl -s -X POST \
-          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          -d "{\"body\": \"$COMMENT\"}" \
-          "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
+        COVERAGE_COMMENT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" | \
+          jq -r '.[] | select(.user.login == "github-actions[bot]") | .id')
+
+        if [ -z "$COVERAGE_COMMENT_ID" ]; then
+          echo "No existing coverage comment found, creating a new comment."
+          curl -s -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"body\": \"$COMMENT\"}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
+        else
+          echo "Existing coverage comment found, updating the comment."
+          EXISTING_COMMENT=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COVERAGE_COMMENT_ID" | \
+            jq -r '.body')
+
+          UPDATED_COMMENT="$EXISTING_COMMENT\n\n$COMMENT"
+          curl -s -X PATCH \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"body\": \"$UPDATED_COMMENT\"}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COVERAGE_COMMENT_ID"
+        fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -93,7 +93,7 @@ jobs:
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
             -d "{\"body\": ${ESCAPED_UPDATED_COMMENT}}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}")
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}"
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -66,7 +66,7 @@ jobs:
       if: env.no_tests_found == 'true'
       run: |
         COMMENT="⚠️ No tests were found related to the files changed since the last commit."
-        PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        PR_NUMBER=${{ github.event.pull_request.number }}
         COVERAGE_COMMENT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" | \
           jq -r '.[] | select(.user.login == "github-actions[bot]") | .id')

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -52,15 +52,22 @@ jobs:
           echo "no_tests_found=true" >> $GITHUB_ENV
         fi
 
+    - name: Construct jest coverage comment input 💬
+      id: construct-input
+      run: |
+        if [ "${{ env.no_tests_found }}" == "true" ]; then
+          echo "MULTIPLE_FILES='All, ./coverage/all/coverage-summary.json'" >> $GITHUB_ENV
+        else
+          echo "MULTIPLE_FILES='All, ./coverage/all/coverage-summary.json\nonly changed, ./coverage/changed/coverage-summary.json'" >> $GITHUB_ENV
+        fi
+
     - name: Jest Coverage Comment 💬
       uses: MishaKav/jest-coverage-comment@main
       with:
         hide-comment: false
         create-new-comment: false
         hide-summary: false
-        multiple-files: |
-          All, ./coverage/all/coverage-summary.json
-          only changed, ./coverage/changed/coverage-summary.json
+        multiple-files: ${{ env.MULTIPLE_FILES }}
       
     - name: Get Coverage Comment Id ➡️
       if: env.no_tests_found == 'true'

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -70,6 +70,7 @@ jobs:
         COVERAGE_COMMENT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" | \
           jq -r '.[] | select(.user.login == "github-actions[bot]") | .id')
+        echo "COVERAGE_COMMENT: ${COVERAGE_COMMENT}"
 
         if [ -z "$COVERAGE_COMMENT_ID" ]; then
           echo "No existing coverage comment found, creating a new comment."
@@ -81,16 +82,16 @@ jobs:
         else
           echo "Existing coverage comment found, updating the comment."
           EXISTING_COMMENT=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COVERAGE_COMMENT_ID" | \
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}" | \
             jq -r '.body')
-          echo "EXISTING_COMMENT: $EXISTING_COMMENT"
+          echo "EXISTING_COMMENT: ${EXISTING_COMMENT}"
 
-          UPDATED_COMMENT="$EXISTING_COMMENT\n\n$COMMENT"
+          UPDATED_COMMENT="${EXISTING_COMMENT}\n\n$COMMENT"
           curl -s -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
             -d "{\"body\": \"$UPDATED_COMMENT\"}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COVERAGE_COMMENT_ID"
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}"
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,8 +34,17 @@ jobs:
 
     - name: Run tests related to current changes ✅
       run: |
-        git fetch origin
-        npx jest --collectCoverageFrom='["**/*.{ts,tsx,js,jsx}"]' --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
+        git fetch origin main
+        npx jest --config=jest.config.js --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
+
+    - name: Check for test results 
+      id: check-results
+      run: |
+        if [ ! -s ./coverage/changed/coverage-summary.json ]; then
+          echo "no_tests_found=true" >> $GITHUB_ENV
+        else
+          echo "no_tests_found=false" >> $GITHUB_ENV
+        fi
 
     - name: Jest Coverage Comment 💬
       uses: MishaKav/jest-coverage-comment@main
@@ -46,3 +55,16 @@ jobs:
         multiple-files: |
           All, ./coverage/all/coverage-summary.json
           only changed, ./coverage/changed/coverage-summary.json
+
+    - name: Post No Tests Found Comment 💬
+      if: env.no_tests_found == 'true'
+      run: |
+        COMMENT="No tests were found related to the files changed since the last commit."
+        PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        curl -s -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d "{\"body\": \"$COMMENT\"}" \
+          "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,7 +36,6 @@ jobs:
       run: |
         echo "BASE_BRANCH=main" >> $GITHUB_ENV
         git fetch origin ${{ env.BASE_BRANCH }}
-        git diff --name-only origin/${{ env.BASE_BRANCH }}
         npx jest --config=jest.config.js --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
 
     - name: Check for test results 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -67,9 +67,9 @@ jobs:
       run: |
         COMMENT="⚠️ No tests were found related to the files changed since the last commit."
         PR_NUMBER=${{ github.event.pull_request.number }}
-        COVERAGE_COMMENT_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" | \
-          jq -r '.[] | select(.user.login == "github-actions[bot]") | .id')
+        COMMENTS_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments")
+        COVERAGE_COMMENT_ID=$(echo "${COMMENTS_JSON}" | jq -r 'map(select(.user.login == "github-actions[bot]")) | sort_by(.created_at) | .[0].id')
         echo "COVERAGE_COMMENT_ID: ${COVERAGE_COMMENT_ID}"
 
         if [ -z "$COVERAGE_COMMENT_ID" ]; then

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -56,9 +56,9 @@ jobs:
       id: construct-input
       run: |
         if [ "${{ env.no_tests_found }}" == "true" ]; then
-          echo "MULTIPLE_FILES='All, ./coverage/all/coverage-summary.json'" >> $GITHUB_ENV
+          echo "MULTIPLE_FILES=All, ./coverage/all/coverage-summary.json" >> $GITHUB_ENV
         else
-          echo "MULTIPLE_FILES='All, ./coverage/all/coverage-summary.json\nonly changed, ./coverage/changed/coverage-summary.json'" >> $GITHUB_ENV
+          echo "MULTIPLE_FILES=All, ./coverage/all/coverage-summary.json\nonly changed, ./coverage/changed/coverage-summary.json" >> $GITHUB_ENV
         fi
 
     - name: Jest Coverage Comment 💬

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -83,6 +83,7 @@ jobs:
           EXISTING_COMMENT=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COVERAGE_COMMENT_ID" | \
             jq -r '.body')
+          echo "EXISTING_COMMENT: $EXISTING_COMMENT"
 
           UPDATED_COMMENT="$EXISTING_COMMENT\n\n$COMMENT"
           curl -s -X PATCH \

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,6 +34,7 @@ jobs:
 
     - name: Run tests related to current changes ✅
       run: |
+        git fetch origin
         npx jest --collectCoverageFrom='["**/*.{ts,tsx,js,jsx}"]' --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
 
     - name: Jest Coverage Comment 💬

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -86,7 +86,8 @@ jobs:
             jq -r '.body')
           echo "EXISTING_COMMENT: ${EXISTING_COMMENT}"
 
-          UPDATED_COMMENT="${EXISTING_COMMENT}\n\n$COMMENT"
+          UPDATED_COMMENT="${EXISTING_COMMENT}\n\n${COMMENT}"
+          echo "UPDATED_COMMENT: ${UPDATED_COMMENT}"
           curl -s -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -86,7 +86,7 @@ jobs:
             jq -r '.body')
           echo "EXISTING_COMMENT: ${EXISTING_COMMENT}"
 
-          UPDATED_COMMENT="${EXISTING_COMMENT}\n\n${COMMENT}"
+          UPDATED_COMMENT="${EXISTING_COMMENT}n\n${COMMENT}"
           echo "UPDATED_COMMENT: ${UPDATED_COMMENT}""
 
           PAYLOAD=$(jq -nc --arg body "$UPDATED_COMMENT" '{body: $body}')

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -45,7 +45,7 @@ jobs:
         if [ -f ./coverage/changed/coverage-summary.json ]; then
           COVERAGE_CONTENT=$(cat ./coverage/changed/coverage-summary.json)
           if echo "$COVERAGE_CONTENT" | jq '.total.lines.pct' | grep -q '0'; then
-            echo "no_tests_found=true" 
+            echo "no_tests_found=true" >> $GITHUB_ENV
           else
             echo "no_tests_found=false" >> $GITHUB_ENV
           fi

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -87,12 +87,13 @@ jobs:
           echo "EXISTING_COMMENT: ${EXISTING_COMMENT}"
 
           ESCAPED_UPDATED_COMMENT=$(jq -Rs '.' <<<"${UPDATED_COMMENT}")
+
           echo "UPDATED_COMMENT: ${UPDATED_COMMENT}"
           curl -s -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{\"body\": ${ESCAPED_UPDATED_COMMENT}}"
-            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}"
+            -d "{\"body\": ${ESCAPED_UPDATED_COMMENT}}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}")
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -89,13 +89,13 @@ jobs:
           UPDATED_COMMENT="${EXISTING_COMMENT}\n\n${COMMENT}"
           echo "UPDATED_COMMENT: ${UPDATED_COMMENT}""
 
-          ESCAPED_UPDATED_COMMENT=$(printf '%s' "${UPDATED_COMMENT}" | jq -Rsa .)
-          echo "ESCAPED_UPDATED_COMMENT: ${ESCAPED_UPDATED_COMMENT}"
+          PAYLOAD=$(jq -nc --arg body "$UPDATED_COMMENT" '{body: $body}')
+          echo "PAYLOAD: ${PAYLOAD}"
 
           curl -s -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{\"body\": \"${ESCAPED_UPDATED_COMMENT}\"}" \
+            -d "${PAYLOAD}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${COVERAGE_COMMENT_ID}"
         fi
       env:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -86,9 +86,12 @@ jobs:
             jq -r '.body')
           echo "EXISTING_COMMENT: ${EXISTING_COMMENT}"
 
-          ESCAPED_UPDATED_COMMENT=$(jq -Rs '.' <<<"${UPDATED_COMMENT}")
-
+          UPDATED_COMMENT="${EXISTING_COMMENT}\n\n${COMMENT}"
           echo "UPDATED_COMMENT: ${UPDATED_COMMENT}"
+
+          ESCAPED_UPDATED_COMMENT=$(jq -Rs '.' <<<"${UPDATED_COMMENT}")
+          echo "ESCAPED_UPDATED_COMMENT: ${ESCAPED_UPDATED_COMMENT}"
+
           curl -s -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
### Summary:
This merge request edits the on-pull-request pipeline. The coverage comment is now edited when there are no tests found related to the files changed.
### Screenshots
![image](https://github.com/terrestris/shogun-gis-client/assets/132580338/eccfb9d4-ac37-4113-8810-993a96dea5f2)
