### PR TITLE
feat: make upload options configurable

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -91,6 +91,7 @@ import {
   EditLevel
 } from './store/editFeature';
 import { setFeatureInfoActiveCopyTools } from './store/featureInfo';
+import { setLayerTreeActiveUploadTools } from './store/layerTree';
 import {
   setLegal
 } from './store/legal';
@@ -266,6 +267,9 @@ const setApplicationToStore = async (application?: Application) => {
         }
         if (tool.name === 'feature_info' && Array.isArray(tool.config.activeCopyTools)) {
           store.dispatch(setFeatureInfoActiveCopyTools(tool.config.activeCopyTools));
+        }
+        if (tool.name === 'tree' && Array.isArray(tool.config.uploadTools)) {
+          store.dispatch(setLayerTreeActiveUploadTools(tool.config.uploadTools));
         }
       });
     store.dispatch(setAvailableTools(availableTools));

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -39,6 +39,7 @@ import {
 } from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
 
 import useSHOGunAPIClient from '../../../hooks/useSHOGunAPIClient';
+import { UploadTools } from '../../../store/layerTree';
 
 import WmsTimeSlider from '../../WmsTimeSlider';
 
@@ -55,6 +56,11 @@ export type LayerTileLoadCounter = {
     loaded: number;
     percent: number;
   };
+};
+
+export type LayerTreeConfig = {
+  enabled?: boolean;
+  activeUploadTools?: UploadTools[];
 };
 
 export const LayerTree: React.FC<LayerTreeProps> = ({

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -61,6 +61,9 @@ import {
 } from '../../store/addLayerModal';
 import { setFeatureInfoEnabled } from '../../store/featureInfo';
 import {
+  UploadTools, setLayerTreeEnabled
+} from '../../store/layerTree';
+import {
   setActiveKeys
 } from '../../store/toolMenu';
 import {
@@ -154,7 +157,8 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
       'print',
       'measure_tools',
       'draw_tools',
-      'feature_info'
+      'feature_info',
+      'tree'
     ];
 
     const activeExclusiveTools = exclusiveTools.filter(tool =>
@@ -175,6 +179,8 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
     }
 
     dispatch(setFeatureInfoEnabled(activeKeys.includes('feature_info')));
+    dispatch(setLayerTreeEnabled(activeKeys.includes('tree')));
+
   }, [activeKeys, dispatch]);
 
   const getToolPanels = (): JSX.Element[] => {
@@ -245,6 +251,8 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
     return panels;
   };
 
+  const activeUploadTools = useAppSelector(state => state.layerTree.activeUploadTools);
+
   const getToolPanelConfig = (tool: string): ToolPanelConfig | undefined => {
     switch (tool) {
       case 'measure_tools':
@@ -313,16 +321,20 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
           wrappedComponent: (
             <div className='tree-wrapper'>
               <LayerTree />
-              <Button
-                className='add-wms-button tool-menu-button'
-                icon={<FontAwesomeIcon icon={faPlus} />}
-                onClick={() => dispatch(showAdd())}
-              >
-                {t('ToolMenu.addWms')}
-              </Button>
+              {activeUploadTools?.includes(UploadTools.addWMS) && (
+                <Button
+                  className='add-wms-button tool-menu-button'
+                  icon={<FontAwesomeIcon icon={faPlus} />}
+                  onClick={() => dispatch(showAdd())}
+                >
+                  {t('ToolMenu.addWms')}
+                </Button>
+              )
+              }
               {
                 keycloak && ClientConfiguration.geoserver?.upload?.authorizedRoles?.some(
-                  role => keycloak.hasResourceRole(role, keycloak.clientId)) && (
+                  role => keycloak.hasResourceRole(role, keycloak.clientId)) &&
+                  activeUploadTools?.includes(UploadTools.dataUpload) && (
                   <Button
                     className='upload-data-button tool-menu-button'
                     icon={<FontAwesomeIcon icon={faUpload} />}

--- a/src/store/layerTree/index.ts
+++ b/src/store/layerTree/index.ts
@@ -1,0 +1,40 @@
+import {
+  createSlice,
+  PayloadAction
+} from '@reduxjs/toolkit';
+
+import { LayerTreeConfig } from '../../components/ToolMenu/LayerTree';
+
+// eslint-disable-next-line no-shadow
+export enum UploadTools {
+  addWMS = 'addWMS',
+  dataUpload = 'dataUpload'
+}
+
+const initialState: LayerTreeConfig = {
+  enabled: false,
+  activeUploadTools: [UploadTools.addWMS, UploadTools.dataUpload]
+};
+
+export const slice = createSlice({
+  name: 'tree',
+  initialState,
+  reducers: {
+    setLayerTreeConfig(state, action: PayloadAction<LayerTreeConfig>) {
+      state = action.payload;
+    },
+    setLayerTreeEnabled(state, action: PayloadAction<boolean>) {
+      state.enabled = action.payload;
+    },
+    setLayerTreeActiveUploadTools(state, action: PayloadAction<UploadTools[]>) {
+      state.activeUploadTools = action.payload;
+    }
+  }
+});
+
+export const {
+  setLayerTreeEnabled,
+  setLayerTreeActiveUploadTools
+} = slice.actions;
+
+export default slice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -14,6 +14,7 @@ import editFeature from './editFeature';
 import editFeatureDrawerOpen from './editFeatureDrawerOpen';
 import featureInfo from './featureInfo';
 import layerDetailsModal from './layerDetailsModal';
+import layerTree from './layerTree';
 import legal from './legal';
 import logoPath from './logoPath';
 import print from './print';
@@ -40,6 +41,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     editFeatureDrawerOpen,
     featureInfo,
     layerDetailsModal,
+    layerTree,
     legal,
     logoPath,
     print,


### PR DESCRIPTION
This PR makes the uploading options in the layer tree configurable by setting:
    "name": "tree",
    "config": {
      "visible": true,
      "uploadTools": [
        "addWMS",
        "dataUpload"
      ]
    }
in the tool config in shogun-admin as described in [#22030](https://redmine.intranet.terrestris.de/issues/22030?include=journals&journals=all)

Different upload options are visible depending on the tool-configuration in shogun-admin:
![Konfigurierbarkeit1](https://github.com/terrestris/shogun-gis-client/assets/161820732/69e5b320-6f98-4747-b715-e9bcc6d30010)
![Konfigurierbarkeit2](https://github.com/terrestris/shogun-gis-client/assets/161820732/6d9b60ab-2839-4c20-9e34-50d4e4444987)


Please review :)