### PR TITLE
Simplify solr query for multiple feature types

### DIFF
--- a/src/utils/generateSolrQuery.spec.ts
+++ b/src/utils/generateSolrQuery.spec.ts
@@ -71,7 +71,7 @@ describe('<generateSolrQuery />', () => {
       map
     });
 
-    const expectedSolrQuery = '(featureType:"SHOGUN:bar" AND ((foo*^3 OR *foo*^2 OR foo~1 OR foo)))';
+    const expectedSolrQuery = '(featureType:"SHOGUN:bar") AND ((foo^4 OR *foo*^2 OR foo~1))';
 
     expect(generatedQueries).toHaveLength(1);
     expect(generatedQueries[0].query).toEqual(expectedSolrQuery);
@@ -93,8 +93,7 @@ describe('<generateSolrQuery />', () => {
       map
     });
 
-    // eslint-disable-next-line max-len
-    const expectedSolrQuery = '(featureType:"SHOGUN:foo" AND ((foo*^3 OR *foo*^2 OR foo~1 OR foo))) OR (featureType:"SHOGUN:bar" AND ((foo*^3 OR *foo*^2 OR foo~1 OR foo)))';
+    const expectedSolrQuery = '(featureType:"SHOGUN:foo" OR featureType:"SHOGUN:bar") AND ((foo^4 OR *foo*^2 OR foo~1))';
 
     expect(generatedQueries).toHaveLength(1);
     expect(generatedQueries[0].query).toEqual(expectedSolrQuery);
@@ -120,8 +119,7 @@ describe('<generateSolrQuery />', () => {
       map
     });
 
-    // eslint-disable-next-line max-len
-    const expectedSolrQuery = '(featureType:"SHOGUN:foo" AND ((dummy*^3 OR *dummy*^2 OR dummy~1 OR dummy))) OR (featureType:"SHOGUN:bar" AND ((dummy*^3 OR *dummy*^2 OR dummy~1 OR dummy)))';
+    const expectedSolrQuery = '(featureType:"SHOGUN:foo" OR featureType:"SHOGUN:bar") AND ((dummy^4 OR *dummy*^2 OR dummy~1))';
 
     expect(generatedQueries).toHaveLength(1);
     expect(generatedQueries[0].query).toEqual(expectedSolrQuery);
@@ -135,8 +133,8 @@ describe('<generateSolrQuery />', () => {
     });
 
     // eslint-disable-next-line max-len
-    const expectedSolrQueryFoo = '(featureType:"SHOGUN:foo" AND ((lorem*^3 OR *lorem*^2 OR lorem~1 OR lorem)))';
-    const expectedSolrQueryBar = '(featureType:"SHOGUN:bar" AND ((lorem*^3 OR *lorem*^2 OR lorem~1 OR lorem)))';
+    const expectedSolrQueryFoo = '(featureType:"SHOGUN:foo") AND ((lorem^4 OR *lorem*^2 OR lorem~1))';
+    const expectedSolrQueryBar = '(featureType:"SHOGUN:bar") AND ((lorem^4 OR *lorem*^2 OR lorem~1))';
 
     expect(generatedQueries).toHaveLength(2);
     expect(generatedQueries[0].query).toEqual(expectedSolrQueryFoo);
@@ -151,8 +149,8 @@ describe('<generateSolrQuery />', () => {
       map
     });
 
-    const expectedSolrQueryFoo = '(featureType:"SHOGUN:foo" AND ((lorem*^3 OR *lorem*^2 OR lorem~1 OR lorem) AND (ipsum*^3 OR *ipsum*^2 OR ipsum~1 OR ipsum)))';
-    const expectedSolrQueryBar = '(featureType:"SHOGUN:bar" AND ((lorem*^3 OR *lorem*^2 OR lorem~1 OR lorem) AND (ipsum*^3 OR *ipsum*^2 OR ipsum~1 OR ipsum)))';
+    const expectedSolrQueryFoo = '(featureType:"SHOGUN:foo") AND ((lorem^4 OR *lorem*^2 OR lorem~1) AND (ipsum^4 OR *ipsum*^2 OR ipsum~1))';
+    const expectedSolrQueryBar = '(featureType:"SHOGUN:bar") AND ((lorem^4 OR *lorem*^2 OR lorem~1) AND (ipsum^4 OR *ipsum*^2 OR ipsum~1))';
 
     expect(generatedQueries).toHaveLength(2);
     expect(generatedQueries[0].query).toEqual(expectedSolrQueryFoo);

--- a/src/utils/generateSolrQuery.ts
+++ b/src/utils/generateSolrQuery.ts
@@ -45,8 +45,10 @@ export const generateSolrQuery = ({
       .filter(l => isWmsLayer(l))
       .map(l => (l as WmsLayer).getSource()?.getParams()?.LAYERS);
 
-    const queriesPerQueryFields = layerNames.map(layerName => `(featureType:"${layerName}" AND (${generateSearchQuery(parts)}))`);
-    const query = queriesPerQueryFields.join(' OR ');
+    const featureTypeParts = layerNames.map(layerName => `featureType:"${layerName}"`);
+    const featureTypeQuery = featureTypeParts.join(' OR ');
+
+    const query = `(${featureTypeQuery}) AND (${generateSearchQuery(parts)})`;
     searchQueries.push({
       query: query,
       fieldList: key !== 'undefined' ? key.split(',').join(' ') : undefined
@@ -65,7 +67,7 @@ const generateSearchQuery = (
   searchParts: string[]
 ): string => {
   const subQueries = searchParts.map(part => {
-    return `(${part.trim()}*^3 OR *${part.trim()}*^2 OR ${part.trim()}~1 OR ${part.trim()})`;
+    return `(${part.trim()}^4 OR *${part.trim()}*^2 OR ${part.trim()}~1)`;
   });
   return subQueries.join(' AND ');
 };


### PR DESCRIPTION
Problem: When many layers are grouped together into a single query, the query may be too large for solr, resulting in the following error:

`org.apache.lucene.search.IndexSearcher$TooManyNestedClauses: Query contains too many nested clauses; maxClauseCount is set to 1024`

This queries feature types in a separate condition. This way, search parts do not have to be duplicated for each feature type, reducing the overall query length.

Further adjustments:
- reworks the the wildcard and proximity search, reducing its length slightly
- gives the exact search term the highest boosting value instead of the lowest

@terrestris/devs Please review.