### PR TITLE
ci: adjust paths for sonarqube scan

### DIFF
--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -117,3 +117,5 @@ jobs:
         with:
           host: ${{ secrets.SONARQUBE_HOST }}
           login: ${{ secrets.SONARQUBE_TOKEN }}
+          projectBaseDir: .
+          

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -118,4 +118,3 @@ jobs:
           host: ${{ secrets.SONARQUBE_HOST }}
           login: ${{ secrets.SONARQUBE_TOKEN }}
           projectBaseDir: .
-          

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.testExecutionReportPaths=./coverage/jest-report.xml
+sonar.testExecutionReportPaths=./coverage/all/jest-report.xml
 sonar.tests=src
 sonar.sources=src
 sonar.test.inclusions=**/*.spec.tsx,**/*.spec.ts


### PR DESCRIPTION
### Summary
Minor fix updating the report path and base path used by SonarQube to make sure the SonarQube-Scan is carried out correctly and the report path matches the coverageDirectory specified in jest-config.
Currently test results can not be read by SonarQube resulting in missing coverage results:
![image](https://github.com/terrestris/shogun-gis-client/assets/132580338/b91b0440-507c-4657-9b17-05945d60a821)
