### PR TITLE
Fix search result display overflow

### DIFF
--- a/src/components/MultiSearch/index.less
+++ b/src/components/MultiSearch/index.less
@@ -19,7 +19,8 @@
 
       .ant-collapse {
 
-        overflow-y: unset;
+        overflow-y: auto;
+        max-height: 80vh;
 
         .ant-collapse-header {
           line-height: unset;


### PR DESCRIPTION
The collapsible panel had a max height of 400px. If there were more results than that, they would not be displayed properly.

@terrestris/devs Please review.