### PR TITLE
ci: update jest test for changed files to use changedSince

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         git fetch --no-tags --depth=1 origin main
         git checkout -b main
-        git checkout ${{ github.event.pull_request.head.sha }}
+        git checkout ${GITHUB_REF##*/}
         npx jest --config=jest.config.js --coverage --coverageReporters json-summary --changedSince=main --coverageDirectory ./coverage/changed
 
     - name: Check for test results ❓

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -8,6 +8,12 @@ jobs:
     steps:
     - name: Checkout sources 🔰
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Fetch all branches
+      run: git fetch --all
+
     - run: |
         git checkout -b main origin/main
         git checkout -

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
 
     - name: Create local branch based on 'origin/main' 🚧
       run: |
-        git fetch --all
+        git fetch origin main
         git checkout -b main origin/main
         git checkout -
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         git fetch --no-tags --depth=1 origin main
         git checkout -b main
-        git checkout $GITHUB_REF
+        git checkout ${{ github.head_ref|| github.ref_name }}
         npx jest --config=jest.config.js --coverage --coverageReporters json-summary --changedSince=main --coverageDirectory ./coverage/changed
 
     - name: Check for test results ❓

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         git fetch --no-tags --depth=1 origin main
         git checkout -b main
-        git checkout ${GITHUB_REF##*/}
+        git checkout $GITHUB_REF
         npx jest --config=jest.config.js --coverage --coverageReporters json-summary --changedSince=main --coverageDirectory ./coverage/changed
 
     - name: Check for test results ❓

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -32,11 +32,16 @@ jobs:
     - name: Build artifacts 🏗️
       run: npm run build
 
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: |
+        git checkout -b main origin/main
+        git checkout -
+
     - name: Run tests related to current changes ✅
       run: |
-        git fetch --no-tags --depth=1 origin main
-        git checkout -b main
-        git checkout ${{ github.head_ref|| github.ref_name }}
         npx jest --config=jest.config.js --coverage --coverageReporters json-summary --changedSince=main --coverageDirectory ./coverage/changed
 
     - name: Check for test results ❓

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -8,6 +8,9 @@ jobs:
     steps:
     - name: Checkout sources 🔰
       uses: actions/checkout@v4
+    - run: |
+        git checkout -b main origin/main
+        git checkout -
 
     - name: Setup Node.js 🧮
       uses: actions/setup-node@v4
@@ -31,14 +34,6 @@ jobs:
 
     - name: Build artifacts 🏗️
       run: npm run build
-
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - run: |
-        git checkout -b main origin/main
-        git checkout -
 
     - name: Run tests related to current changes ✅
       run: |

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,9 +34,8 @@ jobs:
 
     - name: Run tests related to current changes ✅
       run: |
-        git fetch origin main
-        git diff --name-only origin/main
-        npx jest --config=jest.config.js --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
+        git fetch --no-tags --depth=1 origin main
+        npx jest --config=jest.config.js --coverage --coverageReporters json-summary --changedSince=origin/main --coverageDirectory ./coverage/changed
 
     - name: Check for test results ❓
       id: check-results

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -35,7 +35,9 @@ jobs:
     - name: Run tests related to current changes ✅
       run: |
         git fetch --no-tags --depth=1 origin main
-        npx jest --config=jest.config.js --coverage --coverageReporters json-summary --changedSince=origin/main --coverageDirectory ./coverage/changed
+        git checkout -b main
+        git checkout ${{ github.event.pull_request.head.sha }}
+        npx jest --config=jest.config.js --coverage --coverageReporters json-summary --changedSince=main --coverageDirectory ./coverage/changed
 
     - name: Check for test results ❓
       id: check-results

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -11,10 +11,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Fetch all branches
-      run: git fetch --all
-
-    - run: |
+    - name: Create local branch based on 'origin/main' 🚧
+      run: |
+        git fetch --all
         git checkout -b main origin/main
         git checkout -
 


### PR DESCRIPTION
### Summary
This merge request changes how the jest-tests related to current changes are run, using the `--changedSince`-Option, instead of -`-onlyChanged` since onlyChanged seems to include only diffs from the previous commit, while changedSince includes all diffs from main.
In order for this to work, a local branch is first created based on origin/main, since actions/checkout does checkout only the code relevant to the PR. The changed files are identified based on this local branch.