### PR TITLE
Activate layer on search result click

### DIFF
--- a/resources/config/gis-client-config.js
+++ b/resources/config/gis-client-config.js
@@ -28,6 +28,7 @@ var clientConfig = {
     useNominatim: true,
     groupByCategory: true,
     useSolrHighlighting: true,
+    activateLayerOnClick: true,
     delay: 1000,
     minChars: 3,
     solrQueryConfig: {

--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -515,6 +515,20 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
       );
     }
 
+    const onSearchResultClick = (item: Item) => {
+      zoomOffsetOnClick(item);
+      if (ClientConfiguration.search?.activateLayerOnClick) {
+        activateLayer(item);
+      }
+    };
+
+    const activateLayer = (item: Item) => {
+      const layer = item?.feature.get('layer');
+      if (layer) {
+        layer.setVisible(true);
+      }
+    };
+
     const zoomOffsetOnClick = (item: Item) => {
       const extent = item.feature.getGeometry()?.getExtent();
       const toolMenuElement = document.getElementsByClassName('tool-menu');
@@ -537,7 +551,7 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
         searchTerms={searchValue.split(' ')}
         actionsCreator={actionsCreator}
         layerStyle={layerStyle}
-        onClick={zoomOffsetOnClick}
+        onClick={onSearchResultClick}
       />
     );
   };

--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -523,7 +523,7 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
     };
 
     const activateLayer = (item: Item) => {
-      const layer = item?.feature.get('layer');
+      const layer = item?.feature?.get('layer');
       if (layer) {
         layer.setVisible(true);
       }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -34,6 +34,7 @@ declare module 'clientConfig' {
     minChars?: number;
     coreName?: string;
     solrQueryConfig?: SolrQueryConfig;
+    activateLayerOnClick?: boolean;
   };
   type ClientConfiguration = {
     shogunBase?: string | false;


### PR DESCRIPTION
When clicking on a search result, the selected layer is automatically activated in the layer tree. This prevents having to search for the layer manually.

The behavior is configurable by setting `clientConfig.search.activateLayerOnClick`

@terrestris/devs Please review.