### PR TITLE
Use info icon for feature info tool

### DIFF
--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -14,7 +14,7 @@ import {
   faPalette,
   faFileDownload,
   faLanguage,
-  faMousePointer,
+  faCircleInfo,
   faPlus,
   faRuler,
   faShareNodes,
@@ -297,7 +297,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
         };
       case 'feature_info':
         return {
-          icon: faMousePointer,
+          icon: faCircleInfo,
           title: t('ToolMenu.featureInfo'),
           wrappedComponent: (
             <FeatureInfo />


### PR DESCRIPTION
Replaces arrow icon with info icon.

Before:

![image](https://github.com/user-attachments/assets/7db40586-fb88-4e00-89b8-14e68fc1959c)

Now:

![image](https://github.com/user-attachments/assets/d6bc2086-8253-4d84-8e5e-322c596bec4a)

@terrestris/devs Please review.