### PR TITLE
feat: show legends per default

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -91,7 +91,10 @@ import {
   EditLevel
 } from './store/editFeature';
 import { setFeatureInfoActiveCopyTools } from './store/featureInfo';
-import { setLayerTreeActiveUploadTools } from './store/layerTree';
+import { 
+  setLayerTreeActiveUploadTools,
+  setLayerTreeShowLegends
+} from './store/layerTree';
 import {
   setLegal
 } from './store/legal';
@@ -270,6 +273,9 @@ const setApplicationToStore = async (application?: Application) => {
         }
         if (tool.name === 'tree' && Array.isArray(tool.config.uploadTools)) {
           store.dispatch(setLayerTreeActiveUploadTools(tool.config.uploadTools));
+        }
+        if (tool.name === 'tree' && tool.config.showLegends) {
+          store.dispatch(setLayerTreeShowLegends(tool.config.showLegends));
         }
       });
     store.dispatch(setAvailableTools(availableTools));

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -91,7 +91,7 @@ import {
   EditLevel
 } from './store/editFeature';
 import { setFeatureInfoActiveCopyTools } from './store/featureInfo';
-import { 
+import {
   setLayerTreeActiveUploadTools,
   setLayerTreeShowLegends
 } from './store/layerTree';

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -40,7 +40,6 @@ import {
 
 import useAppSelector from '../../../hooks/useAppSelector';
 import useSHOGunAPIClient from '../../../hooks/useSHOGunAPIClient';
-import { UploadTools } from '../../../store/layerTree';
 
 import WmsTimeSlider from '../../WmsTimeSlider';
 
@@ -59,12 +58,6 @@ export type LayerTileLoadCounter = {
   };
 };
 
-export type LayerTreeConfig = {
-  enabled?: boolean;
-  activeUploadTools?: UploadTools[];
-  showLegends?: boolean;
-};
-
 export const LayerTree: React.FC<LayerTreeProps> = ({
   ...restProps
 }): JSX.Element => {
@@ -74,13 +67,11 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
     t
   } = useTranslation();
 
-  const showLegendsState = useAppSelector(state => state.layerTree.showLegends);
-  // check if showLegends is defined
-  const showLegends: boolean = showLegendsState ? showLegendsState : false;
+  const showLegendsState: boolean = useAppSelector(state => state.layerTree.showLegends) ?? false;
 
   const initialLayersUid = map?.getAllLayers().map(l => getUid(l));
 
-  const [visibleLegendsIds, setVisibleLegendsIds] = useState<string[]> (showLegends? initialLayersUid ?? [] : []);
+  const [visibleLegendsIds, setVisibleLegendsIds] = useState<string[]> (showLegendsState ? initialLayersUid ?? [] : []);
   const [layerTileLoadCounter, setLayerTileLoadCounter] = useState<LayerTileLoadCounter>({});
 
   const registerTileLoadHandler = useCallback(() => {

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -38,6 +38,7 @@ import {
   getBearerTokenHeader
 } from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
 
+import useAppSelector from '../../../hooks/useAppSelector';
 import useSHOGunAPIClient from '../../../hooks/useSHOGunAPIClient';
 import { UploadTools } from '../../../store/layerTree';
 
@@ -61,6 +62,7 @@ export type LayerTileLoadCounter = {
 export type LayerTreeConfig = {
   enabled?: boolean;
   activeUploadTools?: UploadTools[];
+  showLegends?: boolean;
 };
 
 export const LayerTree: React.FC<LayerTreeProps> = ({
@@ -72,10 +74,14 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
     t
   } = useTranslation();
 
-  const [visibleLegendsIds, setVisibleLegendsIds] = useState<string[]>([]);
-  const [layerTileLoadCounter, setLayerTileLoadCounter] = useState<LayerTileLoadCounter>({});
+  const showLegendsState = useAppSelector(state => state.layerTree.showLegends);
+  //check if showLegends is defined
+  const showLegends: boolean = showLegendsState ? showLegendsState : false;
 
   const initialLayersUid = map?.getAllLayers().map(l => getUid(l));
+
+  const [visibleLegendsIds, setVisibleLegendsIds] = useState<string[]> (showLegends? initialLayersUid ?? [] : []);
+  const [layerTileLoadCounter, setLayerTileLoadCounter] = useState<LayerTileLoadCounter>({});
 
   const registerTileLoadHandler = useCallback(() => {
     if (!map) {

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -75,7 +75,7 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
   } = useTranslation();
 
   const showLegendsState = useAppSelector(state => state.layerTree.showLegends);
-  //check if showLegends is defined
+  // check if showLegends is defined
   const showLegends: boolean = showLegendsState ? showLegendsState : false;
 
   const initialLayersUid = map?.getAllLayers().map(l => getUid(l));

--- a/src/store/layerTree/index.ts
+++ b/src/store/layerTree/index.ts
@@ -3,7 +3,11 @@ import {
   PayloadAction
 } from '@reduxjs/toolkit';
 
-import { LayerTreeConfig } from '../../components/ToolMenu/LayerTree';
+export type LayerTreeConfig = {
+  enabled?: boolean;
+  activeUploadTools?: UploadTools[];
+  showLegends?: boolean;
+};
 
 // eslint-disable-next-line no-shadow
 export enum UploadTools {

--- a/src/store/layerTree/index.ts
+++ b/src/store/layerTree/index.ts
@@ -13,7 +13,8 @@ export enum UploadTools {
 
 const initialState: LayerTreeConfig = {
   enabled: false,
-  activeUploadTools: [UploadTools.addWMS, UploadTools.dataUpload]
+  activeUploadTools: [UploadTools.addWMS, UploadTools.dataUpload],
+  showLegends: false
 };
 
 export const slice = createSlice({
@@ -28,13 +29,17 @@ export const slice = createSlice({
     },
     setLayerTreeActiveUploadTools(state, action: PayloadAction<UploadTools[]>) {
       state.activeUploadTools = action.payload;
+    },
+    setLayerTreeShowLegends(state, action: PayloadAction<boolean>) {
+      state.showLegends = action.payload;
     }
   }
 });
 
 export const {
   setLayerTreeEnabled,
-  setLayerTreeActiveUploadTools
+  setLayerTreeActiveUploadTools,
+  setLayerTreeShowLegends
 } = slice.actions;
 
 export default slice.reducer;


### PR DESCRIPTION
This PR adds an option to set the layer legends visible by default when the layer is visible, so you don't need to select the legend in the context menu. 
Settings in the tool-config in SHOGun-Admin:
{
    "name": "tree",
    "config": {
      "showLegends": false,
      "visible": true
    }
  },
![Legenden1](https://github.com/user-attachments/assets/c5efabaf-eb59-4e2c-8d48-fb52b0186503)

changing the showLegends config to true gives this initial view in the SHOGun-Gis-Client:
![Legenden2](https://github.com/user-attachments/assets/5f65671c-72a7-4fca-b74b-de77ecb448c3)

Please review :)
