### PR TITLE
Masked-URL

### DIFF
--- a/src/components/DisplayField/index.spec.tsx
+++ b/src/components/DisplayField/index.spec.tsx
@@ -107,7 +107,7 @@ describe('<DisplayField />', () => {
 
     for (const linkValue of linkValues) {
       render(<DisplayField value={linkValue} />);
-      const links = screen.getAllByRole('link', { name: 'Link' });
+      const links = screen.getAllByRole('link');
 
       const link = links.find(l => l.getAttribute('href') === linkValue);
 

--- a/src/components/DisplayField/index.tsx
+++ b/src/components/DisplayField/index.tsx
@@ -50,6 +50,10 @@ export type DisplayFieldProps = {
   value?: ValueType | ValueType[];
   label?: string;
   referenceConfig?: ReferenceConfig;
+  /**
+   * If set, it displays the given value instead of the URL.
+   */
+  urlDisplayValue?: string;
 };
 
 export const DisplayField: React.FC<DisplayFieldProps> = ({
@@ -60,6 +64,7 @@ export const DisplayField: React.FC<DisplayFieldProps> = ({
   value,
   label,
   referenceConfig,
+  urlDisplayValue,
   ...passThroughProps
 }): JSX.Element => {
 
@@ -135,7 +140,7 @@ export const DisplayField: React.FC<DisplayFieldProps> = ({
           target="_blank"
           rel='noreferrer'
         >
-          Link
+          {urlDisplayValue ? urlDisplayValue : value?.toString()}
         </a>
       );
     }


### PR DESCRIPTION
This MR masks an URL if a property `maskedUrl` is set within the `featureInfoFormConfig`. 
If that Property is not set the default value will be shown.