### PR TITLE
Enable releases from next and 8.x branches

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,17 @@
 {
   "branches": [
-    "main"
+    {
+      "name": "8.x",
+      "range": "8.x",
+      "channel": "8.x"
+    },
+    {
+      "name": "main"
+    },
+    {
+      "name": "next",
+      "prerelease": true
+    }
   ],
   "plugins": [
     [


### PR DESCRIPTION
This enables releases from the `next` and `8.x` branches.