### PR TITLE
fix: cursor jumps on keystroke

### DIFF
--- a/src/components/PrintForm/CustomFieldInput/index.tsx
+++ b/src/components/PrintForm/CustomFieldInput/index.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useState
+  useEffect
 } from 'react';
 
 import { Input } from 'antd';
@@ -20,27 +20,20 @@ export const CustomFieldInput: React.FC<CustomFieldInputProps> = ({
   ...restProps
 }): JSX.Element => {
 
-  const [inputText, setInputText] = useState<any>(value);
-
   const dispatch = useAppDispatch();
 
   useEffect(() => {
     if (!_isNil(id)) {
       dispatch(addCustomParam({
-        [id]: inputText
+        [id]: value
       }));
     }
-  }, [inputText, id, dispatch]);
-
-  useEffect(() => {
-    setInputText(value);
-  }, [value]);
+  }, [value, id, dispatch]);
 
   return (
     <Input
       id={id}
-      value={inputText}
-      onChange={(event) => setInputText(event.target.value)}
+      value={value}
       placeholder={placeholder}
       maxLength={maxLength}
       showCount={!!(maxLength && maxLength > 1)}

--- a/src/components/PrintForm/index.tsx
+++ b/src/components/PrintForm/index.tsx
@@ -338,7 +338,6 @@ export const PrintForm: React.FC<PrintFormProps> = ({
                 aria-label='print-title'
                 name="title"
                 label={t('PrintForm.title')}
-                initialValue={t('PrintForm.initialTitle')}
               >
                 <CustomFieldInput
                   aria-label='print-title-input'

--- a/src/components/PrintForm/index.tsx
+++ b/src/components/PrintForm/index.tsx
@@ -338,6 +338,7 @@ export const PrintForm: React.FC<PrintFormProps> = ({
                 aria-label='print-title'
                 name="title"
                 label={t('PrintForm.title')}
+                initialValue={t('PrintForm.initialTitle')}
               >
                 <CustomFieldInput
                   aria-label='print-title-input'


### PR DESCRIPTION
Keeps the users desired cursor position in the react input element instead of springing to the end of the input field