### PR TITLE
`AddLayerModal`: Show layer in tree after adding it to the map

### DIFF
--- a/src/components/AddLayerModal/index.tsx
+++ b/src/components/AddLayerModal/index.tsx
@@ -57,9 +57,7 @@ export const AddLayerModal: React.FC<AddLayerModalProps> = ({
   const [layers, setLayers] = useState<(ImageLayer<ImageWMSSource> | TileLayer<TileWMSSource>)[]>([]);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [validationStatus, setValidationStatus] = useState<InputStatus>('');
-  const [url, setUrl] = useState(
-    'https://sgx.geodatenzentrum.de/wms_topplus_open'
-  );
+  const [url, setUrl] = useState('https://sgx.geodatenzentrum.de/wms_topplus_open');
   const [sanitizedUrl, setSanitizedUrl] = useState<string>();
   const [version, setVersion] = useState<string>('1.3.0');
 
@@ -131,14 +129,13 @@ export const AddLayerModal: React.FC<AddLayerModalProps> = ({
 
     const targetFolderName = t('AddLayerModal.externalWmsFolder');
     let targetGroup = MapUtil.getLayerByName(map, targetFolderName) as OlLayerGroup;
+    const targetGroupAvailableInMap = !!targetGroup;
 
     if (!targetGroup) {
       targetGroup = new OlLayerGroup({
         layers: []
       });
       targetGroup.set('name', targetFolderName);
-      const existingGroups = map.getLayerGroup().getLayers();
-      existingGroups.insertAt(existingGroups?.getLength() || 0, targetGroup);
     }
 
     layersToAdd.forEach(layerToAdd => {
@@ -169,6 +166,11 @@ export const AddLayerModal: React.FC<AddLayerModalProps> = ({
         targetGroup.getLayers().push(layerToAdd);
       }
     });
+
+    if (!targetGroupAvailableInMap) {
+      const existingGroups = map.getLayerGroup().getLayers();
+      existingGroups.insertAt(existingGroups?.getLength() || 0, targetGroup);
+    }
 
     closeModal();
   };

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -50,10 +50,10 @@ import LoadingIndicator from './LoadingIndicator';
 export type LayerTreeProps = Partial<RgLayerTreeProps>;
 
 export type LayerTileLoadCounter = Record<string, {
-    loading: number;
-    loaded: number;
-    percent: number;
-  }>;
+  loading: number;
+  loaded: number;
+  percent: number;
+}>;
 
 export const LayerTree: React.FC<LayerTreeProps> = ({
   ...restProps


### PR DESCRIPTION
If the first layer is added to the map in the `AddLayerModal` (and the "External layers" folder is not present in the tree yet) the layer isn't visible in this folder. This fixes this issue by adding the layer to the target group before adding it to the map (to make all event listeners in the react-geo layer tree work as needed).

Please review @terrestris/devs.