### PR TITLE
Parse `mapInteractions`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@terrestris/react-geo": "25.1.2",
         "@terrestris/react-util": "^9.0.0",
         "@terrestris/shogun-e2e-tests": "^1.0.8",
-        "@terrestris/shogun-util": "^9.1.1",
+        "@terrestris/shogun-util": "^10.1.0",
         "antd": "^5.21.4",
         "color": "^4.2.3",
         "dotenv": "^16.4.5",
@@ -5936,14 +5936,13 @@
       }
     },
     "node_modules/@terrestris/shogun-util": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-9.1.1.tgz",
-      "integrity": "sha512-dpYQOf5IuaM7k1fZFLTdy3e4N4Rsk8lP5aCX0Vy5e2X7/7cwuXzbuFjBdjtUvZgq4rM/pYN5sTiMURzF31d/Wg==",
-      "license": "BSD-2-Clause",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-10.1.0.tgz",
+      "integrity": "sha512-Z2d6N73xuUizF7Cqz9h6RONusF1+NsY+1R9sU0H8NCy3WAZbfpwLcmVIFHInx49m9NRBSvmxPpmxWCiG4mqW8A==",
       "dependencies": {
-        "@terrestris/base-util": "^2.0.0",
+        "@terrestris/base-util": "^3.0.0",
         "geojson": "^0.5.0",
-        "keycloak-js": "^26.0.1",
+        "keycloak-js": "^26.0.5",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -5953,6 +5952,23 @@
       "peerDependencies": {
         "@terrestris/ol-util": ">=20",
         "ol": ">=10"
+      }
+    },
+    "node_modules/@terrestris/shogun-util/node_modules/@terrestris/base-util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/base-util/-/base-util-3.0.0.tgz",
+      "integrity": "sha512-nAiM5BlURBQiI3Uc56PDcdtzK7vqcT2UH9QXRngrnisiTA/fhLJxJaSZJYDShYbqNKXt21UjwDCVGW6AY9UerA==",
+      "dependencies": {
+        "@ungap/url-search-params": "^0.2.2",
+        "lodash": "^4.17.21",
+        "loglevel": "^1.8.0",
+        "query-string": "^9.0.0",
+        "url-parse": "^1.5.10",
+        "validator": "^13.11.0"
+      },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -18333,10 +18349,9 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/keycloak-js": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.0.1.tgz",
-      "integrity": "sha512-Fhn7a9FVKTpno2yfhL6/eiQrmEgBkiM+toVBJ1+g8kasG6CeiMKnI93byL5W8W3M7Ld3Im1QD3kuL/z4vJHGcg==",
-      "license": "Apache-2.0"
+      "version": "26.0.5",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.0.5.tgz",
+      "integrity": "sha512-3biQ5e+yX8EkU3+2ZO+YbWl0emooXt1wyKgZdGCFW8gT0oKeQh/AK6R9a53ACWBzDVoTBI+0GbXP2jF1sFMznw=="
     },
     "node_modules/keygrip": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@terrestris/react-geo": "25.1.2",
     "@terrestris/react-util": "^9.0.0",
     "@terrestris/shogun-e2e-tests": "^1.0.8",
-    "@terrestris/shogun-util": "^9.1.1",
+    "@terrestris/shogun-util": "^10.1.0",
     "antd": "^5.21.4",
     "color": "^4.2.3",
     "dotenv": "^16.4.5",

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -405,12 +405,15 @@ const setupSHOGunMap = async (application: Application) => {
     layers = await parser.parseLayerTreeNodes(application, layersConfig, projection);
   }
 
+  const interactions = await parser.parseMapInteractions(application);
+
   return new OlMap({
     view,
     layers,
     controls: OlControlDefaults({
       zoom: false
-    })
+    }),
+    interactions
   });
 };
 


### PR DESCRIPTION
This adds the missing piece to parse the [configurable mapInteractions](https://github.com/terrestris/shogun/pull/942).

It updates the shogun-util to version [10.1.0](https://github.com/terrestris/shogun-util/releases/tag/v10.1.0) which includes the parsing part.