### PR TITLE
fix: make metadata configurable

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -97,7 +97,8 @@ import {
 import { setFeatureInfoActiveCopyTools } from './store/featureInfo';
 import {
   setLayerTreeActiveUploadTools,
-  setLayerTreeShowLegends
+  setLayerTreeShowLegends,
+  setMetadataVisible
 } from './store/layerTree';
 import {
   setLegal
@@ -280,6 +281,9 @@ const setApplicationToStore = async (application?: Application) => {
         }
         if (tool.name === 'tree' && tool.config.showLegends) {
           store.dispatch(setLayerTreeShowLegends(tool.config.showLegends));
+        }
+        if (tool.name === 'tree' && typeof tool.config.metadataVisible !== 'undefined') {
+          store.dispatch(setMetadataVisible(tool.config.metadataVisible));
         }
       });
     store.dispatch(setAvailableTools(availableTools));

--- a/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
+++ b/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
@@ -104,6 +104,7 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
   const allowedEditMode = useAppSelector(
     state => state.editFeature.userEditMode
   );
+  const metadataVisible = useAppSelector(state => state.layerTree.metadataVisible);
 
   const onContextMenuItemClick = (evt: MenuInfo): void => {
     if (evt?.key.startsWith('downloadLayer')) {
@@ -292,10 +293,12 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
     });
   }
 
-  dropdownMenuItems.push({
-    label: t('LayerTreeContextMenu.layerDetails'),
-    key: 'layerDetails'
-  });
+  if (metadataVisible) {
+    dropdownMenuItems.push({
+      label: t('LayerTreeContextMenu.layerDetails'),
+      key: 'layerDetails'
+    });
+  }
 
   return (
     <div

--- a/src/store/layerTree/index.ts
+++ b/src/store/layerTree/index.ts
@@ -7,6 +7,7 @@ export type LayerTreeConfig = {
   enabled?: boolean;
   activeUploadTools?: UploadTools[];
   showLegends?: boolean;
+  metadataVisible?: boolean;
 };
 
 export enum UploadTools {
@@ -17,7 +18,8 @@ export enum UploadTools {
 const initialState: LayerTreeConfig = {
   enabled: false,
   activeUploadTools: [UploadTools.addWMS, UploadTools.dataUpload],
-  showLegends: false
+  showLegends: false,
+  metadataVisible: true
 };
 
 export const slice = createSlice({
@@ -35,6 +37,9 @@ export const slice = createSlice({
     },
     setLayerTreeShowLegends(state, action: PayloadAction<boolean>) {
       state.showLegends = action.payload;
+    },
+    setMetadataVisible(state, action: PayloadAction<boolean>) {
+      state.metadataVisible = action.payload;
     }
   }
 });
@@ -42,7 +47,8 @@ export const slice = createSlice({
 export const {
   setLayerTreeEnabled,
   setLayerTreeActiveUploadTools,
-  setLayerTreeShowLegends
+  setLayerTreeShowLegends,
+  setMetadataVisible
 } = slice.actions;
 
 export default slice.reducer;


### PR DESCRIPTION
This PR adds a configuration to the tree in the tool-config (in shogun-admin) in order to display the metadata of the layers or not.

Adding "metadataVisible": true or not indicating this configuration gives 
![Metadata1](https://github.com/user-attachments/assets/9e7295e8-294b-46b3-bc0c-00db8a9803eb)

Adding  "metadataVisible": false gives 
![Metadata2](https://github.com/user-attachments/assets/9e1d6c1f-a8ac-4768-b110-4e789db29c9e)

Please review :)