### PR TITLE
Fix drag and drop in LayerTree

### DIFF
--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -247,6 +247,9 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
             <div
               className="layer-transparency"
               aria-label='transparency-slider'
+              onClick={e => e.stopPropagation()}
+              onDragStart={e => {e.stopPropagation(); e.preventDefault();}}
+              draggable={true}
             >
               <LayerTransparencySlider
                 tooltip={{


### PR DESCRIPTION
This allows to drag on the layer title node again. Events on the transparency slider are disabled to prevent drag and drop conflicts.

Requires https://github.com/terrestris/react-geo/pull/4155

@terrestris/devs Please review

