### PR TITLE
fix: fix GFI edit button disabled status

### DIFF
--- a/src/components/EditFeatureDrawer/EditFeatureFullForm/index.tsx
+++ b/src/components/EditFeatureDrawer/EditFeatureFullForm/index.tsx
@@ -118,7 +118,7 @@ export const EditFeatureFullForm: React.FC<EditFeatureFullFormProps> = ({
         return tabCfg.children?.find(formCfg => formCfg.propertyName === key);
       });
 
-      if (tabConfigs.length > 1) {
+      if (tabConfigs?.length > 1) {
         Logger.warn(`Property ${key} is configured in multiple tabs. Is this intended?`);
       }
 

--- a/src/components/ToolMenu/FeatureInfo/FeaturePropertyGrid/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/FeaturePropertyGrid/index.tsx
@@ -9,6 +9,7 @@ import {
 
 import OlFeature from 'ol/Feature';
 import OlGeometry from 'ol/geom/Geometry';
+import OlLayer from 'ol/layer/Layer';
 import OlLayerVector from 'ol/layer/Vector';
 import OlSourceVector from 'ol/source/Vector';
 
@@ -30,11 +31,13 @@ import './index.less';
 export type FeatureInfoPropertyGridProps = {
   features: OlFeature[];
   layerName: string;
+  layer?: OlLayer;
 } & TableProps<OlFeature>;
 
 export const FeatureInfoPropertyGrid: React.FC<FeatureInfoPropertyGridProps> = ({
   features,
   layerName,
+  layer,
   ...restProps
 }): JSX.Element => {
   const [currentPage, setCurrentPage] = useState<number>();
@@ -119,6 +122,7 @@ export const FeatureInfoPropertyGrid: React.FC<FeatureInfoPropertyGridProps> = (
           features={features}
           selectedFeature={selectedFeature}
           current={currentPage}
+          layer={layer}
           onChange={onChange}
         />
       )}

--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -223,6 +223,7 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
                   <FeatureInfoPropertyGrid
                     features={features}
                     layerName={layerName}
+                    layer={mapLayer}
                   />
               }
             </div>


### PR DESCRIPTION
for layers with `editable: true` the GFI edit button was disabled when **not** using a `featureInfoFormConfig`. This is a fix for this scenario.

Before: 
![image](https://github.com/user-attachments/assets/8b607043-f2f4-4e62-bf67-6989c84c5ea1)

After: 
![image](https://github.com/user-attachments/assets/28e9581d-cee5-40b4-ac0c-6e5fe0112e3c)
