### PR TITLE
Only trace expected errors

### DIFF
--- a/src/components/DisplayField/index.tsx
+++ b/src/components/DisplayField/index.tsx
@@ -157,7 +157,7 @@ export const DisplayField: React.FC<DisplayFieldProps> = ({
     try {
       v = JSON.parse(v);
     } catch (e) {
-      Logger.error(e);
+      Logger.trace(e);
       return null;
     }
 
@@ -195,7 +195,7 @@ export const DisplayField: React.FC<DisplayFieldProps> = ({
     try {
       v = JSON.parse(v);
     } catch (e) {
-      Logger.error(e);
+      Logger.trace(e);
       return false;
     }
 


### PR DESCRIPTION
Using a `featureInfoFormConfig` currently leads to such errors in case of simple string fields:

![image](https://github.com/user-attachments/assets/a130649b-8081-4eec-a15c-0dafd2acd1e6)

Having a look at the code, it seems that `getUpload` and `isJson` in the `DisplayField` class make use of "expected" fails when calling `JSON.parse`, so they can return `null`, respectively `false`.

We should not spam our console with "expected" parse errors, so i changed this from `error` to `trace` level, which is not even the default (as `debug` is). This should lead to a cleaner console using the GFI tool with `featureInfoFormConfig`