### PR TITLE
chore: ignore test-results in subpaths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ dist
 .pnp.*
 
 # Playwright test output
-/test-results/
+test-results/
 /playwright-report/
 /playwright/.cache/
 /storageState.json


### PR DESCRIPTION
This ensures that the `test-results` folder is also ignored as a folder in `src/e2e-tests/`