### PR TITLE
fix: layertree checkbox css

### DIFF
--- a/src/components/ToolMenu/LayerTree/index.less
+++ b/src/components/ToolMenu/LayerTree/index.less
@@ -79,3 +79,8 @@
     }
   }
 }
+
+.tree-wrapper .ant-tree-checkbox {
+  top: 2.5px;
+  align-self: flex-start !important;
+}


### PR DESCRIPTION
This MR fixes the CSS of the layertree checkboxes.
The initial CSS got changed in antd so it needs to be overwritten using `!important`

![image](https://github.com/user-attachments/assets/ba9a98c5-1d12-4822-925b-a40dc467108e)
