### PR TITLE
Reactivate drill down feature info requests

### DIFF
--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -302,6 +302,7 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
         resultRenderer={resultRenderer}
         fetchOpts={getFetchOpts}
         onSuccess={onSuccess}
+        drillDown={true}
         {...restProps}
       />
     </div>


### PR DESCRIPTION
This (re)enables `drillDown` in the `FeatureInfo` component thus querying all stacked layers.

Please review @terrestris/devs.