### PR TITLE
feat: introduces the new api endpoint applicationName

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@terrestris/react-geo": "^26.2.1",
         "@terrestris/react-util": "^10.0.1",
         "@terrestris/shogun-e2e-tests": "^1.0.8",
-        "@terrestris/shogun-util": "^10.2.0",
+        "@terrestris/shogun-util": "^10.4.0",
         "@types/color": "^4.2.0",
         "@types/js-md5": "^0.7.2",
         "@types/react": "^18.3.17",
@@ -6048,14 +6048,14 @@
       }
     },
     "node_modules/@terrestris/shogun-util": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-10.2.0.tgz",
-      "integrity": "sha512-dj+FmNMc7PBn5X1/159Cc3/aQ0Wb7cVUPoRQqLVMuF2uW+aEfC44QUUwFGsfkzv6MNjrbFiGKk9qwrbOps7Jzw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-10.4.0.tgz",
+      "integrity": "sha512-sQf/LaCwIakYs9aX5QqAg7AdnpWwDtBNMkkRZfXlU5Dl4pnhWS8IKfokhTZLcEPHu8T7X3fvRwanRN1DM2m0nw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@terrestris/base-util": "^3.0.0",
         "geojson": "^0.5.0",
-        "keycloak-js": "^26.0.5",
+        "keycloak-js": "^26.1.0",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -6064,7 +6064,8 @@
       },
       "peerDependencies": {
         "@terrestris/ol-util": ">=20",
-        "ol": ">=10"
+        "ol": ">=10.3.1",
+        "ol-mapbox-style": ">=12.4.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -18288,9 +18289,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/keycloak-js": {
-      "version": "26.0.7",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.0.7.tgz",
-      "integrity": "sha512-vKCk1ISMiouYRLjMzi5fKp58RnYxKEBS29BoDgVfYwVW94IXchj9jLqBvIet31VD1v79l3WaWT+WMX7fH8O4wA==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.1.0.tgz",
+      "integrity": "sha512-3CTelLNADK6sIxGHCQmKlT3ezcIp8O3Iimmg+ybS78RHy+HAUkkoBaW/YuHGdYkfEDMBlrqD3u+CQ4vLsrmyFA==",
       "license": "Apache-2.0"
     },
     "node_modules/keygrip": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@terrestris/react-geo": "^26.2.1",
     "@terrestris/react-util": "^10.0.1",
     "@terrestris/shogun-e2e-tests": "^1.0.8",
-    "@terrestris/shogun-util": "^10.2.0",
+    "@terrestris/shogun-util": "^10.4.0",
     "@types/color": "^4.2.0",
     "@types/js-md5": "^0.7.2",
     "@types/react": "^18.3.17",

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -695,7 +695,10 @@ const renderApp = async () => {
     }
 
     const applicationIdString = UrlUtil.getQueryParam(window.location.href, 'applicationId');
-    const applicationName = UrlUtil.getQueryParam(window.location.href, 'applicationName');
+
+    const url = new URL(window.location.href);
+    const pathSegments = url.pathname.split('/');
+    const applicationName = pathSegments[2];
 
     const applicationId = applicationIdString ? parseInt(applicationIdString, 10) : undefined;
 
@@ -705,7 +708,9 @@ const renderApp = async () => {
     let appConfig;
     if (applicationName && client) {
       appConfig = await getApplicationConfigurationByName(client, applicationName);
-      setLoadingImage(applicationName, appConfig?.clientConfig?.theme?.logoPath);
+      if (appConfig?.id) {
+        setLoadingImage(appConfig.id, appConfig?.clientConfig?.theme?.logoPath);
+      }
     } else if (applicationId && client) {
       appConfig = await getApplicationConfiguration(client, applicationId);
       setLoadingImage(applicationId, appConfig?.clientConfig?.theme?.logoPath);

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -158,12 +158,14 @@ export default {
       Index: {
         applicationLoadErrorMessage: 'Fehler beim Laden der Applikation',
         applicationLoadErrorDescription:
-          'Die Applikation mit der ID {{applicationId}} konnte nicht geladen werden. ' +
-          'Die Standardkonfiguration wird stattdessen geladen.',
+          'Die Applikation mit der ID {{applicationId}} konnte nicht geladen werden.',
+        applicationLoadByNameErrorMessage:
+          'Die Applikation mit dem Namen {{applicationName}} konnte nicht geladen werden.',
         errorMessage: 'Fehler beim Laden der Applikation',
         errorDescription: 'Aufgrund eines unerwarteten Fehlers konnte die Applikation nicht geladen werden.',
         errorDescriptionAppIdNotSet: 'Keine Applikations-ID angegeben. Bitte geben Sie die ID als Abfrageparameter an, z.B. ?applicationId=1909',
         errorDescriptionAppConfigNotFound: 'Die Applikation mit der ID {{applicationId}} konnte nicht geladen werden.',
+        errorDescriptionAppConfigByNameNotFound: 'Die Applikation mit dem Namen {{applicationName}} konnte nicht geladen werden.',
         errorDescriptionAppConfigStaticNotFound: 'Die Konfiguration der Applikation konnte nicht geladen werden.',
         permissionDeniedUnauthorized: 'Dies ist keine öffentliche Applikation. Anmeldung erforderlich.',
         rerouteToLoginPage: 'Zur Anmeldeseite.'
@@ -456,12 +458,14 @@ export default {
       Index: {
         applicationLoadErrorMessage: 'Error while loading the application',
         applicationLoadErrorDescription:
-          'The application with ID {{applicationId}} could not be loaded correctly. ' +
-          'You\'re seeing the default application configuration.',
+          'The application with ID {{applicationId}} could not be loaded correctly.',
+        applicationLoadByNameErrorMessage:
+          'The application with the name {{applicationName}} could not be loaded correctly.',
         errorMessage: 'Error while loading the application',
         errorDescription: 'An unexpected error occurred while loading the application.',
         errorDescriptionAppIdNotSet: 'No application ID given. Please provide the ID as query parameter, e.g. ?applicationId=1909',
         errorDescriptionAppConfigNotFound: 'The application with ID {{applicationId}} could not be loaded correctly.',
+        errorDescriptionAppConfigByNameNotFound: 'The application with the name {{applicationName}} could not be loaded correctly.',
         errorDescriptionAppConfigStaticNotFound: 'The configuration of the application could not be loaded correctly.',
         permissionDeniedUnauthorized: 'This application is not public. Authentication required.',
         rerouteToLoginPage: 'To login page.'


### PR DESCRIPTION
This MR makes use of the new api endpoint `/name/applicationName`.

But for this to work, the new SHOGun-Util Version featuring the following [MR](https://github.com/terrestris/shogun-util/pull/867) needs to be used.

This MR will remain as a Draft until the new shogun-util is deployed and used within this MR.

Please note:
the property `historyApiFallback` within the rspack.dev.js mostlikely needs to be set true.