### PR TITLE
Move application info opener to footer

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -129,6 +129,9 @@ import {
 import {
   setUser
 } from './store/user';
+import {
+  setVisible as setUserMenuVisible
+} from './store/userMenu';
 
 import './index.less';
 
@@ -289,7 +292,7 @@ const setApplicationToStore = async (application?: Application) => {
     const availableTools: string[] = [];
     application.toolConfig
       .forEach((tool: DefaultApplicationToolConfig) => {
-        if (tool.config?.visible && tool.name !== 'search') {
+        if (tool.config?.visible && !['search', 'user_menu', 'map_toolbar'].includes(tool.name)) {
           availableTools.push(tool.name);
         }
         if (tool.name === 'search' && tool.config.engines.length > 0) {
@@ -312,6 +315,9 @@ const setApplicationToStore = async (application?: Application) => {
         }
         if (tool.name === 'map_toolbar') {
           store.dispatch(setMapToolbarVisible(tool.config?.visible));
+        }
+        if (tool.name === 'user_menu') {
+          store.dispatch(setUserMenuVisible(tool.config?.visible ?? true));
         }
       });
     store.dispatch(setAvailableTools(availableTools));

--- a/src/components/DocumentationButton/index.tsx
+++ b/src/components/DocumentationButton/index.tsx
@@ -7,31 +7,43 @@ import {
   FontAwesomeIcon
 } from '@fortawesome/react-fontawesome';
 
-import SimpleButton, { SimpleButtonProps } from '@terrestris/react-geo/dist/Button/SimpleButton/SimpleButton';
+import {
+  Button,
+  Tooltip
+} from 'antd';
+import { ButtonProps } from 'antd/lib';
 
-export type DocumentationButtonProps = SimpleButtonProps;
+import { useTranslation } from 'react-i18next';
+
+export type DocumentationButtonProps = ButtonProps;
 
 const defaultClassName = 'documentationbutton';
 export const DocumentationButton: React.FC<DocumentationButtonProps> = ({
   className
 }) => {
 
+  const { t } = useTranslation();
+
   const finalClassName = className
     ? `${defaultClassName} ${className}`
     : defaultClassName;
 
   return (
-    <SimpleButton
-      type='link'
-      onClick={() => window.open('/gis-docs', '_blank')}
-      className={finalClassName}
-      icon={
-        <FontAwesomeIcon
-          icon={faCircleQuestion}
-        />
-      }
+    <Tooltip
+      title={t('DocumentationButton.tooltip')}
     >
-    </SimpleButton>
+      <Button
+        type="link"
+        aria-label="documentation-button"
+        onClick={() => window.open('/gis-docs', '_blank')}
+        className={finalClassName}
+        icon={
+          <FontAwesomeIcon
+            icon={faCircleQuestion}
+          />
+        }
+      />
+    </Tooltip>
   );
 };
 

--- a/src/components/Footer/index.less
+++ b/src/components/Footer/index.less
@@ -92,7 +92,7 @@
     &.right-items {
       width: 50%;
       justify-content: flex-end;
-      padding-right: 5px;
+      padding-right: 10px;
 
       button {
         padding: 0 10px;

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,7 +1,11 @@
-import React, { useEffect } from 'react';
+import React, {
+  useEffect
+} from 'react';
 
 import {
-  Button, Divider
+  Button,
+  Divider,
+  Tooltip
 } from 'antd';
 
 import OlControlMousePosition from 'ol/control/MousePosition';
@@ -13,7 +17,6 @@ import { useTranslation } from 'react-i18next';
 import ScaleCombo from '@terrestris/react-geo/dist/Field/ScaleCombo/ScaleCombo';
 import { useMap } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
 
-import './index.less';
 import useAppSelector from '../../hooks/useAppSelector';
 import { usePlugins } from '../../hooks/usePlugins';
 
@@ -21,7 +24,12 @@ import {
   FooterPlacementOrientation,
   isFooterIntegration
 } from '../../plugin';
+
 import { Legal } from '../../store/legal';
+
+import { ApplicationInfo } from '../ApplicationInfo';
+
+import './index.less';
 
 export type FooterProps = React.ComponentProps<'div'>;
 
@@ -173,7 +181,22 @@ export const Footer: React.FC<FooterProps> = ({
         type="link"
       >
         {t('Footer.privacypolicy')}
-      </Button>
+      </Button>,
+      <ApplicationInfo
+        key="application-info"
+        opener={
+          <Tooltip
+            title={t('Footer.aboutTooltip')}
+          >
+            <Button
+              type="link"
+              aria-label="info-opener"
+            >
+              {t('Footer.about')}
+            </Button>
+          </Tooltip>
+        }
+      />
     ];
 
     if (plugins.length > 0) {

--- a/src/components/Header/index.spec.tsx
+++ b/src/components/Header/index.spec.tsx
@@ -12,6 +12,12 @@ import { createReduxWrapper } from '../../utils/testUtils';
 
 import Header from './index';
 
+jest.mock('clientConfig', () => ({
+  keycloak: {
+    enabled: true
+  }
+}));
+
 describe('<Header />', () => {
 
   it('is defined', () => {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -25,8 +25,10 @@ export type HeaderProps = React.ComponentProps<'div'>;
 export const Header: React.FC<HeaderProps> = ({
   ...restProps
 }): JSX.Element => {
-  const title = useAppSelector((state) => state.title);
-  const logoPath = useAppSelector((state) => state.logoPath);
+  const title = useAppSelector(state => state.title);
+  const logoPath = useAppSelector(state => state.logoPath);
+  const userMenuVisible = useAppSelector(state => state.userMenu.visible);
+
   const plugins = usePlugins();
 
   const insertPlugins = (itemPosition: HeaderPlacementOrientation, items: JSX.Element[]) => {
@@ -85,24 +87,20 @@ export const Header: React.FC<HeaderProps> = ({
   };
 
   const getDocsButton = () => {
-    if (ClientConfiguration.documentationButtonVisible) {
-      return (
-        <div
-          key="documentation-button"
-          aria-label="documentation-button"
-        >
-          <DocumentationButton
-            key="documentation-button"
-            type="link"
-          >
-          </DocumentationButton>
-
-        </div>
-      );
+    if (!ClientConfiguration.documentationButtonVisible) {
+      return;
     }
+
+    return (
+      <DocumentationButton />
+    );
   };
 
   const getUserMenu = () => {
+    if (!userMenuVisible || !ClientConfiguration.keycloak?.enabled) {
+      return;
+    }
+
     return (
       <div
         key="user-menu"

--- a/src/components/UserMenu/index.less
+++ b/src/components/UserMenu/index.less
@@ -1,58 +1,49 @@
-.userchip {
+.user-menu {
   padding: 6px;
 
-  .ant-avatar {
-    border: 1px solid var(--complementaryColor);
-    height: 30px;
-    width: 30px;
-    transition: border .3s;
+  .userchip {
+    .ant-avatar {
+      border: 1px solid var(--complementaryColor);
+      height: 30px;
+      width: 30px;
+      transition: border .3s;
 
-    &:hover {
-      border-color: var(--secondaryColor);
-    }
-  }
-
-  .username {
-    span {
-      font-size: 0.6em;
+      &:hover {
+        border-color: var(--secondaryColor);
+      }
     }
 
-    transition: color .3s;
+    .username {
+      span {
+        font-size: 0.6em;
+      }
 
-    &:hover {
-      color: var(--secondaryColor);
+      transition: color .3s;
+
+      &:hover {
+        color: var(--secondaryColor);
+      }
+    }
+
+    .ant-dropdown {
+      svg {
+        width: 20px;
+        padding-right: 10px;
+      }
+
+      .username-menu-item {
+        margin: 13px;
+        cursor: default;
+        text-align: right;
+
+        .item-username {
+          font-weight: bold;
+        }
+
+        .item-fullname {
+          font-size: small;
+        }
+      }
     }
   }
-}
-
-.user-chip-menu {
-  svg {
-    width: 20px;
-    padding-right: 10px;
-  }
-
-  div.user-name {
-    margin: 13px;
-    cursor: default;
-
-    span {
-      font-weight: bold;
-    }
-  }
-
-  .ant-dropdown-menu-title-content {
-    display: flex;
-
-    .info-opener {
-      width: 100%;
-    }
-  }
-}
-
-.ant-dropdown-menu-item {
-  height: 32px;
-}
-
-.user-documentation {
-  padding: 0;
 }

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -158,7 +158,9 @@ export default {
         mousePosition: 'Mausposition',
         imprint: 'Impressum',
         contact: 'Kontakt',
-        privacypolicy: 'Datenschutz'
+        privacypolicy: 'Datenschutz',
+        about: 'Über',
+        aboutTooltip: 'Zeige die Beschreibung und Versionsinformationen'
       },
       Index: {
         applicationLoadErrorMessage: 'Fehler beim Laden der Applikation',
@@ -177,10 +179,12 @@ export default {
       },
       UserMenu: {
         settingsMenuTitle: 'Profil bearbeiten',
-        infoMenuTitle: 'Über',
-        helpMenuTitle: 'Dokumentation',
         logoutMenuTitle: 'Ausloggen',
-        loginMenuTitle: 'Anmelden'
+        loginMenuTitle: 'Anmelden',
+        loginTooltip: 'Zur Anmeldung'
+      },
+      DocumentationButton: {
+        tooltip: 'Öffne die Dokumentation'
       },
       WmsTimeSlider: {
         title: 'Zeitlicher Bezug',
@@ -463,7 +467,9 @@ export default {
         mousePosition: 'Mouse position',
         imprint: 'Imprint',
         contact: 'Contact',
-        privacypolicy: 'Privacy'
+        privacypolicy: 'Privacy',
+        about: 'About',
+        aboutTooltip: 'Show description and version information'
       },
       Index: {
         applicationLoadErrorMessage: 'Error while loading the application',
@@ -482,10 +488,12 @@ export default {
       },
       UserMenu: {
         settingsMenuTitle: 'Edit profile',
-        infoMenuTitle: 'About',
-        helpMenuTitle: 'Documentation',
         logoutMenuTitle: 'Logout',
-        loginMenuTitle: 'Login'
+        loginMenuTitle: 'Login',
+        loginTooltip: 'Go to login'
+      },
+      DocumentationButton: {
+        tooltip: 'Open the documentation'
       },
       WmsTimeSlider: {
         title: 'Time reference',

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -26,6 +26,7 @@ import title from './title';
 import toolMenu from './toolMenu';
 import uploadDataModal from './uploadDataModal';
 import user from './user';
+import userMenu from './userMenu';
 
 type AsyncReducer = Record<string, Reducer>;
 
@@ -52,6 +53,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     user,
     stylingDrawerVisibility,
     mapToolbarVisible,
+    userMenu,
     ...asyncReducers
   });
 };

--- a/src/store/userMenu/index.tsx
+++ b/src/store/userMenu/index.tsx
@@ -1,0 +1,24 @@
+import {
+  createSlice,
+  PayloadAction
+} from '@reduxjs/toolkit';
+
+const initialState = {
+  visible: true
+};
+
+export const slice = createSlice({
+  name: 'user_menu',
+  initialState,
+  reducers: {
+    setVisible(state, action: PayloadAction<boolean>) {
+      state.visible = action.payload;
+    }
+  }
+});
+
+export const {
+  setVisible
+} = slice.actions;
+
+export default slice.reducer;


### PR DESCRIPTION
This suggests to move the application info opener ("About") from the user menu to the footer. This allows users to open it regardless from the presence of the user menu which visible state is defined as follows now:

- visible by default always, except (possibly required for public instances):
  - not visible if Keycloak is disabled globally (see `keycloak.enabled`) -> no change in behaviour
  - not visible if explicitly disabled for the given application configuration -> new configuration:
  ```
  {
    "name": "user_menu",
    "config": {
      "visible": false
    }
  }
  ```

The menu itself is slightly refactored to show a login button only if a user is not logged in already and to show the users full name as well. Previously the username was shown only.

![login](https://github.com/user-attachments/assets/7952efcd-bd20-4bf1-b03a-0af93bd35e74)

![image](https://github.com/user-attachments/assets/ff776818-994f-4551-8654-f2ad167a2e60)

In addition the `DocumentationButton` is slightly simplified.

Please review @terrestris/devs.