### PR TITLE
Legend: Set current map scale on initial render

### DIFF
--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -128,7 +128,7 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
   }, [map, initialLayersUid, registerTileLoadHandler]);
 
   const legendRequestExtraParams = useMemo(() => ({
-    scale: mapScale,
+    SCALE: mapScale,
     LEGEND_OPTIONS: 'fontAntiAliasing:true;forceLabels:on',
     TRANSPARENT: true
   }), [mapScale]);
@@ -151,6 +151,9 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
     if (!map) {
       return;
     }
+
+    // Trigger once on initial render to set the current map scale.
+    onMapMoveEnd(new OlMapEvent('moveend', map));
 
     map.on('moveend', onMapMoveEnd);
 


### PR DESCRIPTION
Enabling the legend (in the layer tree) without having moved the map before might result in an erroneous or inaccurate `GetLegendGraphic` request since the map scale is `undefined`. 

This suggests to fix this issue by setting the default scale value to the current map scale. 

Please review @terrestris/devs.