### PR TITLE
feat: add proj4 to module federation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "keycloak-js": "^26.1.0",
         "normalize.css": "^8.0.1",
         "ol": "^10.3.1",
+        "proj4": "^2.15.0",
         "react": "^18.3.1",
         "react-cookie-consent": "^9.0.0",
         "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "keycloak-js": "^26.1.0",
     "normalize.css": "^8.0.1",
     "ol": "^10.3.1",
+    "proj4": "^2.15.0",
     "react": "^18.3.1",
     "react-cookie-consent": "^9.0.0",
     "react-dom": "^18.3.1",
@@ -149,6 +150,7 @@
     "relativePaths": "true"
   },
   "overrides": {
-    "ol": "$ol"
+    "ol": "$ol",
+    "proj4": "$proj4"
   }
 }

--- a/rspack.common.js
+++ b/rspack.common.js
@@ -143,6 +143,10 @@ module.exports = {
         'ol/': {
           singleton: true,
           requiredVersion: deps.ol
+        },
+        'proj4': {
+          singleton: true,
+          requiredVersion: deps.proj4
         }
       }
     })


### PR DESCRIPTION
This adds proj4 as a singleton to the module federation plugin. This is needed when custom projections are registered to proj4 and proj4 is called directly.