### PR TITLE
Update header layout

### DIFF
--- a/src/components/Header/index.less
+++ b/src/components/Header/index.less
@@ -17,6 +17,7 @@
     align-items: center;
 
     &.left-items {
+      flex: 0 1 0;
       justify-content: flex-start;
 
       .logo {
@@ -40,12 +41,13 @@
     }
 
     &.center-items {
-      flex: 1;
+      flex: 1 1 0;
       display: flex;
       justify-content: center;
     }
 
     &.right-items {
+      flex: 0 1 0;
       justify-content: flex-end;
       padding-right: 5px;
     }


### PR DESCRIPTION
This fixes a layout bug in Firefox where the left-items took all the space when containing a logo.