### PR TITLE
Move toolbar when drawer opens/closes

### DIFF
--- a/src/components/MapDrawer/index.tsx
+++ b/src/components/MapDrawer/index.tsx
@@ -38,7 +38,7 @@ export const MapDrawer: React.FC<MapDrawerProps> = ({
       mask={false}
       open={open}
       placement="right"
-      width={getComputedStyle(document.documentElement).getPropertyValue('--editDrawerWidth')}
+      width={getComputedStyle(document.documentElement).getPropertyValue('--drawerWidth')}
       afterOpenChange={onAfterDrawerOpenChange}
       {...passThroughProps}
     >

--- a/src/components/MapToolbar/index.less
+++ b/src/components/MapToolbar/index.less
@@ -6,6 +6,10 @@
   flex-direction: column;
   z-index: 1;
 
+  &.drawer-open {
+    right: calc(var(--drawerWidth) + 10px);
+  }
+
   .ant-btn {
     margin: 5px;
     display: block;

--- a/src/components/MapToolbar/index.tsx
+++ b/src/components/MapToolbar/index.tsx
@@ -44,6 +44,11 @@ export const MapToolbar: React.FC = (): JSX.Element => {
 
   const mapToolbarVisible = useAppSelector(state => state.mapToolbarVisible.visible);
 
+  const stylingDrawerVisibility = useAppSelector(state => state.stylingDrawerVisibility);
+  const editFeatureDrawerOpen = useAppSelector(state => state.editFeatureDrawerOpen);
+  const drawerOpen = stylingDrawerVisibility || editFeatureDrawerOpen;
+  const className = drawerOpen ? 'drawer-open' : '';
+
   const btnTooltipProps = {
     tooltipPlacement: 'left' as TooltipPlacement,
     tooltipProps: {
@@ -56,10 +61,10 @@ export const MapToolbar: React.FC = (): JSX.Element => {
       {mapToolbarVisible &&
         <Toolbar
           id='map-toolbar'
+          className={className}
           alignment="vertical"
           role="toolbar"
         >
-
           {map &&
             <ZoomButton
               aria-label='zoom-in'

--- a/src/components/StylingDrawer/index.tsx
+++ b/src/components/StylingDrawer/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {
-  Drawer,
   DrawerProps
 } from 'antd';
 
@@ -14,6 +13,7 @@ import './index.less';
 import useAppDispatch from '../../hooks/useAppDispatch';
 import useAppSelector from '../../hooks/useAppSelector';
 import { setStylingDrawerVisibility } from '../../store/stylingDrawerVisibility';
+import MapDrawer from '../MapDrawer';
 import StylingComponent from '../ToolMenu/Draw/StylingDrawerButton/StylingComponent';
 
 export type StylingDrawerProps = DrawerProps;
@@ -34,7 +34,7 @@ export const StylingDrawer: React.FC<StylingDrawerProps> = ({
   };
 
   return (
-    <Drawer
+    <MapDrawer
       title={t('StylingDrawer.title')}
       placement="right"
       onClose={onClose}
@@ -45,7 +45,7 @@ export const StylingDrawer: React.FC<StylingDrawerProps> = ({
       {...passThroughProps}
     >
       <StylingComponent />
-    </Drawer>
+    </MapDrawer>
   );
 };
 

--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -112,7 +112,7 @@
   }
 
   button {
-    color: #000000;
+    --ant-color-link: #000000;
 
     &.collapse-btn {
       width: 100%;

--- a/src/index.less
+++ b/src/index.less
@@ -4,7 +4,7 @@
 :root {
   --headerHeight: 50px;
   --footerHeight: 40px;
-  --editDrawerWidth: 450px;
+  --drawerWidth: 450px;
   --componentShadow: 0 6px 12px rgb(0 0 0 / 18%), 0 -6px 12px rgb(0 0 0 / 18%);
 }
 


### PR DESCRIPTION
This adjusts the position of the map toolbar when a drawer is shown.

## Preview:

![shogun-maptools-drawer](https://github.com/user-attachments/assets/067d7b99-5c00-4737-b67b-e2d098ab0dea)
