### PR TITLE
Introduces SearchResultDrawer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@terrestris/react-geo": "^30.2.1",
         "@terrestris/react-util": "^12.1.0",
         "@terrestris/shogun-e2e-tests": "^1.0.8",
-        "@terrestris/shogun-util": "^10.5.2",
+        "@terrestris/shogun-util": "^10.6.0",
         "@types/color": "^4.2.0",
         "@types/js-md5": "^0.7.2",
         "@types/proj4": "^2.5.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@terrestris/react-geo": "^30.2.1",
     "@terrestris/react-util": "^12.1.0",
     "@terrestris/shogun-e2e-tests": "^1.0.8",
-    "@terrestris/shogun-util": "^10.5.2",
+    "@terrestris/shogun-util": "^10.6.0",
     "@types/color": "^4.2.0",
     "@types/js-md5": "^0.7.2",
     "@types/proj4": "^2.5.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Footer from './components/Footer';
 import Header from './components/Header';
 import LayerDetailsModal from './components/LayerDetailsModal';
 import MapToolbar from './components/MapToolbar';
+import SearchResultDrawer from './components/SearchResultDrawer';
 import StylingDrawer from './components/StylingDrawer';
 import ToolMenu from './components/ToolMenu';
 import UploadDataModal from './components/UploadDataModal';
@@ -50,6 +51,7 @@ export const App: React.FC<AppProps> = ({
       <EditFeatureDrawer />
       <LayerDetailsModal />
       <StylingDrawer />
+      <SearchResultDrawer />
     </div>
   );
 };

--- a/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
+++ b/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
@@ -120,7 +120,12 @@ export const EditFeatureGeometryToolbar: React.FC<EditFeatureGeometryToolbarProp
         return;
       }
 
-      const source = editLayer.getSource() as OlSourceVector;
+      const source = editLayer.getSource();
+
+      if (!source) {
+        return;
+      }
+
       source.addFeature(olFeat);
       setRevision(r => r + 1);
 

--- a/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
+++ b/src/components/EditFeatureDrawer/EditFeatureGeometryToolbar/index.tsx
@@ -43,6 +43,7 @@ import {
 
 import useAppDispatch from '../../../hooks/useAppDispatch';
 import useAppSelector from '../../../hooks/useAppSelector';
+import useGetFitPadding from '../../../hooks/useGetFitPadding';
 
 import {
   setFormDirty
@@ -74,6 +75,7 @@ export const EditFeatureGeometryToolbar: React.FC<EditFeatureGeometryToolbarProp
 
   const map = useMap();
   const dispatch = useAppDispatch();
+  const getFitPadding = useGetFitPadding();
 
   const [editLayer, setEditLayer] = useState<OlLayerVector<OlSourceVector>>();
   const [, setRevision] = useState<number>(0);
@@ -124,11 +126,11 @@ export const EditFeatureGeometryToolbar: React.FC<EditFeatureGeometryToolbarProp
 
       if (!isEmptyOlExtent(source.getExtent())) {
         map?.getView().fit(source.getExtent(), {
-          padding: [50, 50, 50, 50]
+          padding: getFitPadding(true)
         });
       }
     }
-  }, [feature, editLayer, gjFormat, map]);
+  }, [feature, editLayer, gjFormat, map, getFitPadding]);
 
   const undoEdit = () => {
 

--- a/src/components/MapToolbar/index.tsx
+++ b/src/components/MapToolbar/index.tsx
@@ -46,7 +46,8 @@ export const MapToolbar: React.FC = (): JSX.Element => {
 
   const stylingDrawerVisibility = useAppSelector(state => state.stylingDrawerVisibility);
   const editFeatureDrawerOpen = useAppSelector(state => state.editFeatureDrawerOpen);
-  const drawerOpen = stylingDrawerVisibility || editFeatureDrawerOpen;
+  const searchResultDrawerOpen = useAppSelector(state => state.searchResult.drawerVisibility);
+  const drawerOpen = stylingDrawerVisibility || editFeatureDrawerOpen || searchResultDrawerOpen;
   const className = drawerOpen ? 'drawer-open' : '';
 
   const btnTooltipProps = {

--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -56,6 +56,7 @@ import {
 
 import './index.less';
 import useAppDispatch from '../../hooks/useAppDispatch';
+import useGetFitPadding from '../../hooks/useGetFitPadding';
 import { setSearchResultState } from '../../store/searchResult';
 
 export type SearchEngineFunction = (value: string, viewBox?: OlExtent) => Promise<ResultCategory[] | undefined>;
@@ -99,6 +100,7 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
   const [resultsVisible, setResultsVisible] = useState<boolean>(false);
   const [settingsVisible, setSettingsVisible] = useState<boolean>(false);
   const [searchResults, setSearchResults] = useState<ResultCategory[]>([]);
+  const getFitPadding = useGetFitPadding();
 
   useEffect(() => {
     window.addEventListener('mousedown', handleClickAway);
@@ -334,22 +336,11 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
 
     const zoomOffsetOnClick = (item: Item) => {
       const extent = item.feature.getGeometry()?.getExtent();
-      const toolMenuElement = document.querySelector('.tool-menu');
-      const toolMenuWidth = toolMenuElement?.clientWidth ?? 0;
-
-      let drawerWidth = 0;
-      if (ClientConfiguration.search?.searchResultDrawer) {
-        drawerWidth = Number(
-          getComputedStyle(document.body).getPropertyValue('--drawerWidth').replace('px', '')
-        ) || 450;
-      }
-
-      const padding = [0, drawerWidth, 0, toolMenuWidth];
 
       if (extent) {
         map?.getView().fit(extent, {
           size: map.getSize(),
-          padding
+          padding: getFitPadding(ClientConfiguration.search?.searchResultDrawer)
         });
       }
     };

--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -311,7 +311,7 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
         activateLayer(item);
       }
 
-      if (ClientConfiguration.search?.searchResultDrawer) {
+      if (ClientConfiguration.search?.showSearchResultDrawer) {
         dispatch(setSearchResultState({
           geoJSONFeature: geoJSONFormat.writeFeatureObject(item.feature),
           drawerVisibility: true
@@ -340,7 +340,7 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
       if (extent) {
         map?.getView().fit(extent, {
           size: map.getSize(),
-          padding: getFitPadding(ClientConfiguration.search?.searchResultDrawer)
+          padding: getFitPadding(ClientConfiguration.search?.showSearchResultDrawer)
         });
       }
     };

--- a/src/components/SearchResultDrawer/AttributeValueCell/index.spec.tsx
+++ b/src/components/SearchResultDrawer/AttributeValueCell/index.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import {
+  render, screen
+} from '@testing-library/react';
+
+import { AttributeValueCell } from './index';
+
+describe('AttributeValueCell', () => {
+  it('renders a simple string value', () => {
+    render(
+      <AttributeValueCell
+        value="Mall"
+        attributeName="name"
+      />
+    );
+    expect(screen.getByText('Mall')).toBeInTheDocument();
+  });
+
+  it('renders a clickable link if value is a URL and config matches', () => {
+    render(
+      <AttributeValueCell
+        value="https://www.terrestris.de"
+        attributeName="Details"
+        resultDrawerConfig={{
+          children: [
+            {
+              displayName: 'Details',
+              fieldProps: { urlDisplayValue: 'terrestris' }
+            }
+          ]
+        }}
+      />
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://www.terrestris.de');
+    expect(link).toHaveTextContent('terrestris');
+  });
+
+  it('normalizes single-item string arrays', () => {
+    render(
+      <AttributeValueCell
+        value={['single value']}
+        attributeName="name"
+      />
+    );
+    expect(screen.getByText('single value')).toBeInTheDocument();
+  });
+});

--- a/src/components/SearchResultDrawer/AttributeValueCell/index.tsx
+++ b/src/components/SearchResultDrawer/AttributeValueCell/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+export interface AttributeValueCellProps {
+  value: any;
+  attributeName: string;
+  resultDrawerConfig?: {
+    children?: {
+      displayName?: string;
+      fieldProps?: {
+        urlDisplayValue?: string;
+      };
+    }[];
+  } | null;
+}
+
+export const AttributeValueCell: React.FC<AttributeValueCellProps> = ({
+  value,
+  attributeName,
+  resultDrawerConfig
+}) => {
+  let normalized = value;
+
+  const isUrl = (val: string) => {
+    return /^(?:\w+:)?\/\/([^\s.]+\.\S{2}|localhost[:?\d]*)\S*$/.test(val);
+  };
+
+  if (
+    Array.isArray(value) &&
+    value.length === 1 &&
+    typeof value[0] === 'string'
+  ) {
+    normalized = value[0];
+  }
+
+  if (
+    typeof normalized === 'string' &&
+    isUrl(normalized) &&
+    resultDrawerConfig
+  ) {
+    const fieldConfig = resultDrawerConfig.children?.find(
+      c => c.displayName === attributeName
+    );
+    const displayText = fieldConfig?.fieldProps?.urlDisplayValue || normalized;
+
+    return (
+      <a
+        href={normalized}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {displayText}
+      </a>
+    );
+  }
+
+  return (
+    <>
+      {normalized == null || typeof normalized === 'object'
+        ? ''
+        : normalized}
+    </>
+  );
+};

--- a/src/components/SearchResultDrawer/index.spec.tsx
+++ b/src/components/SearchResultDrawer/index.spec.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import {
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react';
+
+import {
+  Provider
+} from 'react-redux';
+
+import { setDrawerVisibility } from '../../store/searchResult';
+import {
+  store
+} from '../../store/store';
+
+import SearchResultDrawer from '../SearchResultDrawer';
+
+import SearchResultDrawerButton from './index';
+
+const createWrapper = () => {
+  return ({
+    children
+  }: any) => (
+    <Provider store={store}>
+      {children}
+    </Provider>
+  );
+};
+
+describe('SearchResultDrawer', () => {
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(<SearchResultDrawer />, {
+      wrapper: createWrapper()
+    });
+
+    expect(container).toBeVisible();
+  });
+
+  it('renders the correct title', async () => {
+    render(<SearchResultDrawerButton />, {
+      wrapper: createWrapper()
+    });
+
+    store.dispatch(setDrawerVisibility(true));
+    await waitFor(() => {
+      expect(screen.getByText('SearchResultDrawer.title')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/SearchResultDrawer/index.tsx
+++ b/src/components/SearchResultDrawer/index.tsx
@@ -1,0 +1,157 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+
+import {
+  DrawerProps
+} from 'antd';
+
+import OlFeature from 'ol/Feature';
+import GeoJSONParser from 'ol/format/GeoJSON';
+import OlLayerVector from 'ol/layer/Vector';
+import OlSourceVector from 'ol/source/Vector';
+import OlStyleCircle from 'ol/style/Circle';
+import OlStyleFill from 'ol/style/Fill';
+import OlStyleStroke from 'ol/style/Stroke';
+import OlStyle from 'ol/style/Style';
+
+import {
+  useTranslation
+} from 'react-i18next';
+
+import PropertyGrid from '@terrestris/react-geo/dist/Grid/PropertyGrid/PropertyGrid';
+import { useMap } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
+
+import useAppDispatch from '../../hooks/useAppDispatch';
+import useAppSelector from '../../hooks/useAppSelector';
+import {
+  setSearchResultState
+} from '../../store/searchResult';
+import MapDrawer from '../MapDrawer';
+
+export type SearchResultDrawerProps = DrawerProps;
+
+export const SearchResultDrawer: React.FC<SearchResultDrawerProps> = ({
+  ...passThroughProps
+}): JSX.Element => {
+
+  const dispatch = useAppDispatch();
+  const map = useMap();
+  const isSearchResultDrawerVisible = useAppSelector(state => state.searchResult.drawerVisibility);
+  const geoJSONFeature = useAppSelector(state => state.searchResult.geoJSONFeature);
+  const [highlightLayer, setHighlightLayer] = useState<OlLayerVector<OlSourceVector> | null>(null);
+  const olFeature: OlFeature | null = useMemo(() => {
+    if (!geoJSONFeature) {
+      return null;
+    }
+    return new GeoJSONParser().readFeature(geoJSONFeature) as OlFeature;
+  }, [geoJSONFeature]);
+
+  useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    const layer = new OlLayerVector({
+      source: new OlSourceVector(),
+      style: new OlStyle({
+        stroke: new OlStyleStroke({
+          color: 'rgb(255,0,0)',
+          width: 2
+        }),
+        fill: new OlStyleFill({
+          color: 'rgba(255,255,255, 0.5)'
+        }),
+        image: new OlStyleCircle({
+          radius: 10,
+          fill: new OlStyleFill({
+            color: 'rgba(255,255,255, 0.5)'
+          }),
+          stroke: new OlStyleStroke({
+            color: 'rgb(255,0,0)',
+            width: 3
+          })
+        })
+      })
+    });
+
+    setHighlightLayer(layer);
+    map.addLayer(layer);
+  }, [map]);
+
+  const highlightFeature = useCallback((feature?: OlFeature) => {
+    if (!highlightLayer || !highlightLayer.getSource() || !feature) {
+      return;
+    }
+    highlightLayer.getSource()!.clear();
+    highlightLayer.getSource()!.addFeature(feature);
+  }, [highlightLayer]);
+
+  useEffect(() => {
+    if (olFeature && map) {
+      highlightFeature(olFeature);
+    }
+  }, [olFeature, map, highlightFeature]);
+
+  const {
+    t
+  } = useTranslation();
+
+  const onClose = () => {
+    dispatch(setSearchResultState({
+      drawerVisibility: false,
+      geoJSONFeature: null
+    }));
+    highlightLayer?.getSource()!.clear();
+  };
+
+  return (
+    <MapDrawer
+      title={t('SearchResultDrawer.title')}
+      placement="right"
+      onClose={onClose}
+      open={isSearchResultDrawerVisible}
+      maskClosable={false}
+      mask={false}
+      {...passThroughProps}
+    >
+      <div>
+        {olFeature &&<h3>{olFeature.get('title')}</h3>}
+        {
+          olFeature && Object.keys(olFeature.getProperties()).length > 1 &&
+          <PropertyGrid
+            className="property-grid"
+            feature={olFeature}
+            // attributeFilter={attributeFilter}
+            size="small"
+            sticky={true}
+            columns={[{
+              title: t('FeaturePropertyGrid.key'),
+              dataIndex: 'attributeName',
+              key: 'attributeName',
+              width: '50%',
+              ellipsis: true,
+              defaultSortOrder: 'ascend',
+              sorter: (a, b) => a.key.localeCompare(b.key)
+            }, {
+              title: t('FeaturePropertyGrid.value'),
+              dataIndex: 'attributeValue',
+              key: 'attributeValue',
+              width: '50%',
+              ellipsis: true
+            }]}
+            scroll={{
+              scrollToFirstRowOnChange: true,
+              y: 'calc(100% - 90px)'
+            }}
+          />
+        }
+      </div>
+    </MapDrawer>
+  );
+};
+
+export default SearchResultDrawer;

--- a/src/components/StylingDrawer/index.less
+++ b/src/components/StylingDrawer/index.less
@@ -1,6 +1,0 @@
-.color-pick-drawer {
-  position: absolute;
-  top: var(--headerHeight);
-  bottom: var(--footerHeight);
-  z-index: 499;
-}

--- a/src/components/StylingDrawer/index.tsx
+++ b/src/components/StylingDrawer/index.tsx
@@ -8,8 +8,6 @@ import {
   useTranslation
 } from 'react-i18next';
 
-import './index.less';
-
 import useAppDispatch from '../../hooks/useAppDispatch';
 import useAppSelector from '../../hooks/useAppSelector';
 import { setStylingDrawerVisibility } from '../../store/stylingDrawerVisibility';
@@ -39,7 +37,6 @@ export const StylingDrawer: React.FC<StylingDrawerProps> = ({
       placement="right"
       onClose={onClose}
       open={isStylingDrawerVisible}
-      rootClassName="color-pick-drawer"
       maskClosable={false}
       mask={false}
       {...passThroughProps}

--- a/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/PaginationToolbar/index.tsx
@@ -45,6 +45,7 @@ import { DigitizeUtil } from '@terrestris/react-util/dist/Util/DigitizeUtil';
 
 import useAppDispatch from '../../../../hooks/useAppDispatch';
 import useAppSelector from '../../../../hooks/useAppSelector';
+import useGetFitPadding from '../../../../hooks/useGetFitPadding';
 import {
   setLayerId,
   setFeature
@@ -76,6 +77,7 @@ export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
   } = useTranslation();
   const dispatch = useAppDispatch();
   const map = useMap();
+  const getFitPadding = useGetFitPadding();
 
   const activeCopyTools = useAppSelector(state => state.featureInfo.activeCopyTools);
 
@@ -152,7 +154,7 @@ export const PaginationToolbar: React.FC<PaginationToolbarProps> = ({
       }
 
       map.getView().fit(source.getExtent(), {
-        padding: [150, 150, 150, 150]
+        padding: getFitPadding()
       });
       dispatch(setLayerId(getUid(layer)));
       dispatch(setFeature(geojsonFeature));

--- a/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
+++ b/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
@@ -62,6 +62,7 @@ import {
 
 import useAppDispatch from '../../../../hooks/useAppDispatch';
 import useAppSelector from '../../../../hooks/useAppSelector';
+import useGetFitPadding from '../../../../hooks/useGetFitPadding';
 import useSHOGunAPIClient from '../../../../hooks/useSHOGunAPIClient';
 
 import {
@@ -96,6 +97,7 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
   const dispatch = useAppDispatch();
   const client = useSHOGunAPIClient();
   const map = useMap();
+  const getFitPadding = useGetFitPadding();
   const {
     t
   } = useTranslation();
@@ -158,7 +160,9 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
         } : {}
       });
       extent = transformExtent(extent, 'EPSG:4326', map.getView().getProjection());
-      map.getView().fit(extent);
+      map.getView().fit(extent, {
+        padding: getFitPadding()
+      });
     } catch (error) {
       Logger.error(error);
       notification.error({

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -35,7 +35,7 @@ declare module 'clientConfig' {
     coreName?: string;
     solrQueryConfig?: SolrQueryConfig;
     activateLayerOnClick?: boolean;
-    searchResultDrawer?: boolean;
+    showSearchResultDrawer?: boolean;
   };
   type ClientConfiguration = {
     shogunBase?: string | false;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -35,6 +35,7 @@ declare module 'clientConfig' {
     coreName?: string;
     solrQueryConfig?: SolrQueryConfig;
     activateLayerOnClick?: boolean;
+    searchResultDrawer?: boolean;
   };
   type ClientConfiguration = {
     shogunBase?: string | false;

--- a/src/hooks/searchEngines/useNominatimSearchEngine.ts
+++ b/src/hooks/searchEngines/useNominatimSearchEngine.ts
@@ -51,7 +51,7 @@ export const useNominatimSearchEngine = () => {
     const nFeats = response?.features
       .filter(f => !_isNil(f?.properties.geojson))
       .map(f => {
-        const olFeat = geoJsonFormat.readFeature(f.properties.geojson, {
+        const olFeat = geoJsonFormat.readFeature(f.geometry, {
           dataProjection: 'EPSG:4326',
           featureProjection: map.getView().getProjection()
         });
@@ -59,6 +59,8 @@ export const useNominatimSearchEngine = () => {
         if (Array.isArray(olFeat)) {
           return;
         }
+
+        olFeat.setProperties(f.properties);
 
         olFeat.set('title', f.properties.display_name);
 

--- a/src/hooks/searchEngines/useSolrSearchEngine.ts
+++ b/src/hooks/searchEngines/useSolrSearchEngine.ts
@@ -105,6 +105,34 @@ export const useSolrSearchEngine = () => {
     return title;
   }, [map, replaceTemplates]);
 
+  const applyAttributesToFeature = (
+    olFeature: OlFeature,
+    dsResult: DataSearchResult
+  ): void => {
+
+    if (!map) {
+      return;
+    }
+
+    const blacklistedAttributes = [
+      'category',
+      'id',
+      'featureType',
+      'geometry',
+      'search',
+      '_version_'
+    ];
+
+    Object.keys(dsResult)
+      .filter(key => !blacklistedAttributes.includes(key))
+      .forEach(key => {
+        const value = dsResult[key];
+        if (value !== undefined) {
+          olFeature.set(key, value);
+        }
+      });
+  };
+
   const performSolrSearch = useCallback(async (value: string, viewBox?: OlExtent) => {
     if (!map) {
       return;
@@ -191,7 +219,9 @@ export const useSolrSearchEngine = () => {
         const olFeat = new OlFeature({
           geometry
         });
-        // TODO: get all properties from search result
+
+        applyAttributesToFeature(olFeat, dsResult);
+
         olFeat.set('title', getFeatureTitle(value, dsResult, hlResults?.[id]));
         let ftName;
         if (dsResult.featureType?.[0]) {

--- a/src/hooks/searchEngines/useSolrSearchEngine.ts
+++ b/src/hooks/searchEngines/useSolrSearchEngine.ts
@@ -66,11 +66,7 @@ export const useSolrSearchEngine = () => {
     const searchConfig = layer?.get('searchConfig') as SearchConfig;
 
     const blacklistedAttributes = [
-      'category',
-      'id',
-      'featureType',
-      'geometry',
-      'search'
+      'geometry'
     ];
 
     let title = '';
@@ -105,15 +101,10 @@ export const useSolrSearchEngine = () => {
     return title;
   }, [map, replaceTemplates]);
 
-  const applyAttributesToFeature = (
+  const applyAttributesToFeature = useCallback((
     olFeature: OlFeature,
     dsResult: DataSearchResult
   ): void => {
-
-    if (!map) {
-      return;
-    }
-
     const blacklistedAttributes = [
       'category',
       'id',
@@ -131,7 +122,7 @@ export const useSolrSearchEngine = () => {
           olFeature.set(key, value);
         }
       });
-  };
+  }, []);
 
   const performSolrSearch = useCallback(async (value: string, viewBox?: OlExtent) => {
     if (!map) {
@@ -244,7 +235,7 @@ export const useSolrSearchEngine = () => {
     });
 
     return solrResults;
-  }, [executeSolrQuery, getFeatureTitle, map]);
+  }, [applyAttributesToFeature, executeSolrQuery, getFeatureTitle, map]);
 
   return performSolrSearch;
 };

--- a/src/hooks/searchEngines/useSolrSearchEngine.ts
+++ b/src/hooks/searchEngines/useSolrSearchEngine.ts
@@ -191,6 +191,7 @@ export const useSolrSearchEngine = () => {
         const olFeat = new OlFeature({
           geometry
         });
+        // TODO: get all properties from search result
         olFeat.set('title', getFeatureTitle(value, dsResult, hlResults?.[id]));
         let ftName;
         if (dsResult.featureType?.[0]) {

--- a/src/hooks/searchEngines/useWfsSearchEngine.ts
+++ b/src/hooks/searchEngines/useWfsSearchEngine.ts
@@ -81,6 +81,26 @@ export const useWfsSearchEngine = () => {
     return feature.getId();
   }, [replaceTemplates]);
 
+  const applyAttributesToFeature = (
+    feature: OlFeature
+  ): void => {
+    const blacklistedAttributes = [
+      'category',
+      'id',
+      'featureType',
+      'geometry',
+      'search'
+    ];
+
+    const properties = feature.getProperties();
+
+    Object.entries(properties).forEach(([key, value]) => {
+      if (!blacklistedAttributes.includes(key) && value !== undefined) {
+        feature.set(key, value);
+      }
+    });
+  };
+
   const performWfsSearch = useCallback(async (value: string, viewBox?: OlExtent) => {
     if (!map) {
       return;
@@ -152,10 +172,9 @@ export const useWfsSearchEngine = () => {
         featureProjection: map.getView().getProjection()
       });
 
-      // TODO: check if feature has all properties
-
       features.forEach(feature => {
         feature.set('title', getFeatureTitle(value, feature, fulfilledResponse.layer));
+        applyAttributesToFeature(feature);
         feature.set('layer', fulfilledResponse.layer);
       });
 

--- a/src/hooks/searchEngines/useWfsSearchEngine.ts
+++ b/src/hooks/searchEngines/useWfsSearchEngine.ts
@@ -85,11 +85,7 @@ export const useWfsSearchEngine = () => {
     feature: OlFeature
   ): void => {
     const blacklistedAttributes = [
-      'category',
-      'id',
-      'featureType',
-      'geometry',
-      'search'
+      'geometry'
     ];
 
     const properties = feature.getProperties();

--- a/src/hooks/searchEngines/useWfsSearchEngine.ts
+++ b/src/hooks/searchEngines/useWfsSearchEngine.ts
@@ -152,6 +152,8 @@ export const useWfsSearchEngine = () => {
         featureProjection: map.getView().getProjection()
       });
 
+      // TODO: check if feature has all properties
+
       features.forEach(feature => {
         feature.set('title', getFeatureTitle(value, feature, fulfilledResponse.layer));
         feature.set('layer', fulfilledResponse.layer);

--- a/src/hooks/useGetFitPadding.ts
+++ b/src/hooks/useGetFitPadding.ts
@@ -1,0 +1,48 @@
+/**
+ * This hook returns a function to calculate padding for the fit method
+ * of an ol.View. It considers the menu width, header height, footer height
+ * and drawer width if drawerOpen is set to true.
+ *
+ * It takes a boolean to determine if the drawer is open.
+ *
+ * The returned function (getFitPadding) computes an array consisting of:
+ *   - header height (using the '--headerHeight' CSS property, defaults to 50px if undefined)
+ *   - drawer width (using the '--drawerWidth' CSS property, defaults to 450px if undefined and if the drawer is open)
+ *   - footer height (using the '--footerHeight' CSS property, defaults to 40px if undefined)
+ *   - tool menu width (derived from the width of the element with the 'tool-menu' class)
+ *
+ * @returns (drawerOpen: boolean) => [number, number, number, number]
+ */
+export const useGetFitPadding = () => {
+
+  const getCssPropertyValue = (value: string, fallback: number) => {
+    return Number(
+      getComputedStyle(document.body).getPropertyValue(value).replace('px', '')
+    ) || fallback;
+  };
+
+  /**
+   * This function calculates the padding for the fit method of an ol.View.
+   *
+   * @param drawerOpen Include the drawer width in the calculation
+   * @returns [topPadding, rightPadding, bottomPadding, leftPadding]
+   */
+  function getFitPadding(drawerOpen = false) {
+    const toolMenuElement = document.querySelector('.tool-menu');
+    const toolMenuWidth = toolMenuElement?.clientWidth ?? 0;
+
+    const headerHeight = getCssPropertyValue('--headerHeight', 50);
+    const footerHeight = getCssPropertyValue('--footerHeight', 40);
+
+    let drawerWidth = 0;
+    if (drawerOpen) {
+      drawerWidth = getCssPropertyValue('--drawerWidth', 450);
+    }
+
+    return [headerHeight, drawerWidth, footerHeight, toolMenuWidth];
+  };
+
+  return getFitPadding;
+};
+
+export default useGetFitPadding;

--- a/src/hooks/useGetFitPadding.ts
+++ b/src/hooks/useGetFitPadding.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 /**
  * This hook returns a function to calculate padding for the fit method
  * of an ol.View. It considers the menu width, header height, footer height
@@ -15,11 +17,11 @@
  */
 export const useGetFitPadding = () => {
 
-  const getCssPropertyValue = (value: string, fallback: number) => {
+  const getCssPropertyValue = useCallback((value: string, fallback: number) => {
     return Number(
       getComputedStyle(document.body).getPropertyValue(value).replace('px', '')
     ) || fallback;
-  };
+  }, []);
 
   /**
    * This function calculates the padding for the fit method of an ol.View.
@@ -27,7 +29,7 @@ export const useGetFitPadding = () => {
    * @param drawerOpen Include the drawer width in the calculation
    * @returns [topPadding, rightPadding, bottomPadding, leftPadding]
    */
-  function getFitPadding(drawerOpen = false) {
+  const getFitPadding = useCallback((drawerOpen = false) => {
     const toolMenuElement = document.querySelector('.tool-menu');
     const toolMenuWidth = toolMenuElement?.clientWidth ?? 0;
 
@@ -40,7 +42,7 @@ export const useGetFitPadding = () => {
     }
 
     return [headerHeight, drawerWidth, footerHeight, toolMenuWidth];
-  };
+  }, [getCssPropertyValue]);
 
   return getFitPadding;
 };

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -268,6 +268,9 @@ export default {
         title: 'Speichern',
         errorNoGeometry: 'Objekt kann ohne Geometrie nicht gespeichert werden.'
       },
+      SearchResultDrawer: {
+        title: 'Suchergebnisse'
+      },
       DeleteButton: {
         title: 'Objekt löschen',
         confirm: 'Das Objekt wird vollständig gelöscht. Fortfahren?'
@@ -575,6 +578,9 @@ export default {
       SaveButton: {
         title: 'Save',
         errorNoGeometry: 'Cannot save feature without geometry.'
+      },
+      SearchResultDrawer: {
+        title: 'Search results'
       },
       DeleteButton: {
         title: 'Delete feature',

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -280,7 +280,8 @@ export default {
       },
       FeaturePropertyGrid: {
         key: 'Name',
-        value: 'Wert'
+        value: 'Wert',
+        linkText: 'Link'
       },
       PaginationToolbar: {
         copyAsGeoJson: 'Als GeoJSON kopieren (inkl. Geometrie)',
@@ -591,7 +592,8 @@ export default {
       },
       FeaturePropertyGrid: {
         key: 'Name',
-        value: 'Value'
+        value: 'Value',
+        linkText: 'Link'
       },
       PaginationToolbar: {
         copyAsGeoJson: 'Copy as GeoJSON (incl. geometry)',

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -280,8 +280,7 @@ export default {
       },
       FeaturePropertyGrid: {
         key: 'Name',
-        value: 'Wert',
-        linkText: 'Link'
+        value: 'Wert'
       },
       PaginationToolbar: {
         copyAsGeoJson: 'Als GeoJSON kopieren (inkl. Geometrie)',
@@ -592,8 +591,7 @@ export default {
       },
       FeaturePropertyGrid: {
         key: 'Name',
-        value: 'Value',
-        linkText: 'Link'
+        value: 'Value'
       },
       PaginationToolbar: {
         copyAsGeoJson: 'Copy as GeoJSON (incl. geometry)',

--- a/src/store/searchResult/index.tsx
+++ b/src/store/searchResult/index.tsx
@@ -1,0 +1,49 @@
+import {
+  createSlice,
+  PayloadAction
+} from '@reduxjs/toolkit';
+
+import { Feature } from 'geojson';
+
+export interface SearchResultState {
+  geoJSONFeature: Feature | null;
+  drawerVisibility: boolean;
+}
+
+const initialState: SearchResultState = {
+  drawerVisibility: false,
+  geoJSONFeature: null
+};
+
+export const slice = createSlice({
+  name: 'stylingDrawerVisibility',
+  initialState,
+  reducers: {
+    setSearchResultState: (state, action: PayloadAction<SearchResultState>) => {
+      return {
+        ...state,
+        ...action.payload
+      };
+    },
+    setDrawerVisibility: (state, action: PayloadAction<boolean>) => {
+      return {
+        ...state,
+        drawerVisibility: action.payload
+      };
+    },
+    setGeoJSONFeature: (state, action: PayloadAction<Feature>) => {
+      return {
+        ...state,
+        geoJSONFeature: action.payload
+      };
+    }
+  }
+});
+
+export const {
+  setGeoJSONFeature: setFeature,
+  setSearchResultState,
+  setDrawerVisibility
+} = slice.actions;
+
+export default slice.reducer;

--- a/src/store/searchResult/index.tsx
+++ b/src/store/searchResult/index.tsx
@@ -16,7 +16,7 @@ const initialState: SearchResultState = {
 };
 
 export const slice = createSlice({
-  name: 'stylingDrawerVisibility',
+  name: 'searchResultDrawer',
   initialState,
   reducers: {
     setSearchResultState: (state, action: PayloadAction<SearchResultState>) => {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -20,6 +20,7 @@ import logoPath from './logoPath';
 import mapToolbarVisible from './mapToolbarVisible';
 import print from './print';
 import searchEngines from './searchEngines';
+import searchResult from './searchResult';
 import selectedFeatures from './selectedFeatures';
 import stylingDrawerVisibility from './stylingDrawerVisibility';
 import title from './title';
@@ -44,15 +45,16 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     layerTree,
     legal,
     logoPath,
+    mapToolbarVisible,
     print,
+    searchEngines,
+    searchResult,
     selectedFeatures,
+    stylingDrawerVisibility,
     title,
     toolMenu,
     uploadDataModal,
-    searchEngines,
     user,
-    stylingDrawerVisibility,
-    mapToolbarVisible,
     userMenu,
     ...asyncReducers
   });


### PR DESCRIPTION
This introduces the SearchResultDrawer.

The feature can be enabled when setting [searchResultDrawer](https://github.com/terrestris/shogun-gis-client/compare/search-result-drawer?expand=1#diff-858566d2d4cf06579a908cb85f587c5752fa0fa6a47d579277749006e86f0834R38) to true in the `SearchConfig` of the gis-client-config.js.

When set to true the search result wil be displayed in a drawer on the right side.

It contains the "title" property of the selected feature of the `SearchResultList`.

When the passed feature has other properties then title a `PropertyGrid` with its features is shown.

TODO:

- [x] Adapt `useSolrSearchEngine` to add all properties of the selected item to the created ol feature
- [x] Adapt `useWfsSearchEngine` to add all properties of the selected item to the created ol feature
- [x] Make PropertyGrid configurable
  - [x] attributesFilter (maybe reusable from layer config)
  - [x] Check if we want a more versatile configuration here


## Preview

![shogun-client-search-result-drawer](https://github.com/user-attachments/assets/f80c8429-f367-464f-be76-146d74cfb530)

