### PR TITLE
Fix pipeline for `next` branch without any new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      last_release_version: ${{ steps.semantic.outputs.last_release_version }}
     steps:
       - name: Checkout 🔰
         uses: actions/checkout@v4
@@ -42,6 +43,7 @@ jobs:
     with:
       release_is_published: ${{ needs.release-npm.outputs.new_release_published }}
       release_version: ${{ needs.release-npm.outputs.new_release_version }}
+      last_release_version: ${{ needs.release-npm.outputs.last_release_version }}
     secrets:
       nexus_user: ${{ secrets.NEXUS_USERNAME }}
       nexus_pass: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -9,6 +9,9 @@ on:
       release_version:
         required: true
         type: string
+      last_release_version:
+        required: true
+        type: string
     secrets:
       nexus_user:
         required: true
@@ -26,7 +29,7 @@ jobs:
       - name: Checkout sources 🔰
         uses: actions/checkout@v4
         with:
-          ref: v${{ inputs.release_version }}
+          ref: v${{ inputs.release_version || inputs.last_release_version }}
 
       - name: Login to Nexus
         uses: docker/login-action@v3


### PR DESCRIPTION
This attempts to fix the currently failing pipeline in the #1976 branch.

Explanation: As there is currently no release performed for the branch, the variable `release_version` is not defined and the checkout can't be performed. As fallback the previous version/tag is used now.

Please review @terrestris/devs.