### PR TITLE
Unify ol import paths for rspack

### DIFF
--- a/OlImportRewritePlugin.js
+++ b/OlImportRewritePlugin.js
@@ -1,0 +1,25 @@
+/**
+ * This plugin rewrite all OpenLayers import paths by removing the '.js'
+ * extension from the import paths (e.g. 'ol/Map.js' to 'ol/Map').
+ * This is necessary because usually the import paths are written without the '.js'
+ * extension and having the '.js' extension in the import paths can cause issues
+ * with module federation since it would share both modules (with and without the
+ * extension) thus resulting in sharing the modules twice.
+ */
+class OlImportRewritePlugin {
+  apply(compiler) {
+    compiler.hooks.normalModuleFactory.tap('OlImportRewritePlugin', nmf => {
+      nmf.hooks.beforeResolve.tap('OlImportRewritePlugin', resolveData => {
+        if (resolveData &&
+          typeof resolveData.request === 'string' &&
+          resolveData.request.startsWith('ol/') &&
+          resolveData.request.endsWith('.js')) {
+            const newRequest = resolveData.request.slice(0, -3);
+            resolveData.request = newRequest;
+        }
+      });
+    });
+  }
+}
+
+module.exports = OlImportRewritePlugin;

--- a/rspack.common.js
+++ b/rspack.common.js
@@ -5,6 +5,8 @@ const rspack = require('@rspack/core');
 
 const deps = require('./package.json').dependencies;
 
+const OlImportRewritePlugin = require('./OlImportRewritePlugin');
+
 module.exports = {
   entry: './src/index.tsx',
   externals: {
@@ -116,6 +118,7 @@ module.exports = {
         'Buffer'
       ]
     }),
+    new OlImportRewritePlugin(),
     new ModuleFederationPlugin({
       name: 'SHOGunGISClient',
       dev: false,


### PR DESCRIPTION
This pull request introduces a custom rspack plugin, `OlImportRewritePlugin`, to address issues with OpenLayers import paths and integrates it into the build configuration. The plugin ensures consistent import paths by removing the `.js` extension, preventing module duplication in module federation setups. Without unified import paths, the module federation is actually providing shared modules for the same module twice, e.g. sharing the module `ol/Map` and `ol/Map.js`. This is actually leading to potential scope (and e.g. resulting in `instanceof` check) issues during runtime.

Please review @terrestris/devs.