### PR TITLE
Update `Header` style

### DIFF
--- a/src/components/Header/index.less
+++ b/src/components/Header/index.less
@@ -17,12 +17,14 @@
     align-items: center;
 
     &.left-items {
-      flex: 0 1 0;
+      flex: 1 1 0;
       justify-content: flex-start;
 
       .logo {
         height: 100%;
-        padding: 10px;
+        object-fit: contain;
+        padding: 5px;
+        box-sizing: border-box;
       }
 
       .title {
@@ -30,11 +32,12 @@
         text-align: center;
         font-size: 1.1rem;
         font-weight: bold;
-        margin-left: 2rem;
+        margin: 0 2rem;
         text-overflow: ellipsis;
         overflow: hidden;
 
         display: -webkit-box;
+        -webkit-box-orient: vertical;
         -webkit-line-clamp: 2;
         line-clamp: 2;
       }
@@ -44,12 +47,17 @@
       flex: 1 1 0;
       display: flex;
       justify-content: center;
+
+      .search {
+        width: 100%;
+        max-width: 800px;
+      }
     }
 
     &.right-items {
-      flex: 0 1 0;
+      flex: 1 1 0;
       justify-content: flex-end;
-      padding-right: 5px;
+      margin-right: 5px;
     }
   }
 

--- a/src/components/SearchField/index.less
+++ b/src/components/SearchField/index.less
@@ -1,3 +1,0 @@
-.search {
-  width: 60%;
-}

--- a/src/components/SearchField/index.tsx
+++ b/src/components/SearchField/index.tsx
@@ -13,8 +13,6 @@ import useAppSelector from '../../hooks/useAppSelector';
 
 import MultiSearch from '../MultiSearch';
 
-import './index.less';
-
 export type SearchFieldProps = InputProps;
 
 export const SearchField: React.FC<SearchFieldProps> = ({


### PR DESCRIPTION
This updates the style of the `Header` to:

- readd some padding to the logo image
- making the ellipsis for long titles work
- giving each section (left, center, right) the same width

![image](https://github.com/user-attachments/assets/5e342453-0a68-4183-b15a-de53b8c71c47)

![image](https://github.com/user-attachments/assets/0ee72b4d-ae8a-4534-ae0c-13b02234dee5)

Please review @terrestris/devs.
