### PR TITLE
feat: add possibility to deactivate map interaction tools programmatically

### DIFF
--- a/src/components/ToolMenu/Draw/index.tsx
+++ b/src/components/ToolMenu/Draw/index.tsx
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  useEffect,
   useState
 } from 'react';
 
@@ -51,6 +52,12 @@ import {
   DigitizeUtil
 } from '@terrestris/react-util/dist/Util/DigitizeUtil';
 
+import useAppDispatch from '../../../hooks/useAppDispatch';
+import useAppSelector from '../../../hooks/useAppSelector';
+import {
+  removeInteractionStatus, setMapInteractionStatus
+} from '../../../store/mapInteractionStatus';
+
 import AttributionDrawer from './Attributions';
 import DeleteAllButton from './DeleteAllButton';
 import ImportDataModal from './ImportDataModal';
@@ -89,11 +96,29 @@ export const Draw: React.FC<DrawProps> = ({
   const [selectedButton, setSelectedButton] = useState<string>();
   const [isImportDataModalOpen, setIsImportDataModalOpen] = useState<boolean>(false);
 
+  const mapInteractionStatus = useAppSelector(state => state.mapInteractionStatus);
+
+  const dispatch = useAppDispatch();
+
   const {
     t
   } = useTranslation();
 
   const map = useMap();
+
+  useEffect(() => {
+    if (selectedButton !== undefined) {
+      dispatch(setMapInteractionStatus('draw'));
+    } else {
+      dispatch(removeInteractionStatus('draw'));
+    }
+  }, [selectedButton, dispatch]);
+
+  useEffect(() => {
+    if (mapInteractionStatus !== 'draw') {
+      setSelectedButton(undefined);
+    }
+  }, [mapInteractionStatus]);
 
   const onToggleChange: Exclude<ToggleGroupProps['onChange'], undefined> = useCallback((evt, value) => {
     setSelectedButton(value);

--- a/src/components/ToolMenu/Measure/index.tsx
+++ b/src/components/ToolMenu/Measure/index.tsx
@@ -2,7 +2,7 @@ import React, {
   useState,
   useMemo,
   FC,
-  JSX
+  JSX, useEffect
 } from 'react';
 
 import {
@@ -29,6 +29,11 @@ import {
 } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
 
 import './index.less';
+import useAppDispatch from '../../../hooks/useAppDispatch';
+import useAppSelector from '../../../hooks/useAppSelector';
+import {
+  removeInteractionStatus, setMapInteractionStatus
+} from '../../../store/mapInteractionStatus';
 
 interface DefaultMeasureProps {
   showMeasureDistance?: boolean;
@@ -41,6 +46,12 @@ export const Measure: FC<MeasureProps> = ({
   showMeasureDistance,
   showMeasureArea
 }): JSX.Element => {
+  const [selected, setSelected] = useState<string>();
+
+  const mapInteractionStatus = useAppSelector(state => state.mapInteractionStatus);
+
+  const dispatch = useAppDispatch();
+
   const {
     t
   } = useTranslation();
@@ -57,7 +68,19 @@ export const Measure: FC<MeasureProps> = ({
     return _isEmpty(projName) || projName === 'longlat' || projName === 'geocent';
   }, [map]);
 
-  const [selected, setSelected] = useState<string>();
+  useEffect(() => {
+    if (selected !== undefined) {
+      dispatch(setMapInteractionStatus('measure'));
+    } else {
+      dispatch(removeInteractionStatus('measure'));
+    }
+  }, [selected, dispatch]);
+
+  useEffect(() => {
+    if (mapInteractionStatus !== 'measure') {
+      setSelected(undefined);
+    }
+  }, [mapInteractionStatus]);
 
   if (!map) {
     return <></>;

--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -8,15 +8,17 @@
   box-shadow: var(--componentShadow);
   overflow-y: auto;
 
+  .ant-collapse-header:not(.ant-collapse-collapsible-disabled) {
+    .ant-collapse-header-text:hover {
+      color: var(--secondaryColor);
+      font-weight: bold;
+    }
+  }
+
   .ant-collapse-header-text {
     display: flex;
     width: 100%;
     transition: color .3s;
-
-    &:hover {
-      color: var(--secondaryColor);
-      font-weight: bold;
-    }
 
     svg {
       width: 25px;

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -64,6 +64,11 @@ import {
   UploadTools, setLayerTreeEnabled
 } from '../../store/layerTree';
 import {
+  removeInteractionStatus,
+  setMapInteractionStatus
+} from '../../store/mapInteractionStatus';
+import {
+  removeActiveKey,
   setActiveKeys
 } from '../../store/toolMenu';
 import {
@@ -79,6 +84,7 @@ import FeatureInfo from './FeatureInfo';
 import LayerTree from './LayerTree';
 
 import Measure from './Measure';
+
 import './index.less';
 
 export interface TitleEventEntity {
@@ -115,6 +121,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
   const availableTools = useAppSelector(state => state.toolMenu.availableTools);
   const activeKeys = useAppSelector(state => state.toolMenu.activeKeys);
   const maxHeight = useAppSelector(state => state.toolMenu.maxHeight);
+  const mapInteractionStatus = useAppSelector(state => state.mapInteractionStatus);
 
   const client = useSHOGunAPIClient();
   const keycloak = client?.getKeycloak();
@@ -177,15 +184,38 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
 
       if (lastExclusiveTool) {
         dispatch(
-          setActiveKeys(activeKeys.filter(keys => keys !== lastExclusiveTool))
+          removeActiveKey(lastExclusiveTool)
         );
       }
     }
 
-    dispatch(setFeatureInfoEnabled(activeKeys.includes('feature_info')));
-    dispatch(setLayerTreeEnabled(activeKeys.includes('tree')));
+    const featureInfoEnabled = activeKeys.includes('feature_info');
+    dispatch(setFeatureInfoEnabled(featureInfoEnabled));
 
+    if (featureInfoEnabled) {
+      dispatch(setMapInteractionStatus('feature-info'));
+    } else if (!featureInfoEnabled) {
+      dispatch(removeInteractionStatus('feature-info'));
+    }
+
+    dispatch(setLayerTreeEnabled(activeKeys.includes('tree')));
   }, [activeKeys, dispatch]);
+
+  useEffect(() => {
+    if (mapInteractionStatus === 'feature-info') {
+      return () => {
+        dispatch(removeActiveKey('feature_info'));
+      };
+    }
+  }, [mapInteractionStatus, dispatch]);
+
+  useEffect(() => {
+    if (mapInteractionStatus === 'feature-info') {
+      return () => {
+        dispatch(removeActiveKey('feature_info'));
+      };
+    }
+  }, [mapInteractionStatus, dispatch]);
 
   const getToolPanels = (): ItemType[] => {
     const panels: ItemType[] = [];

--- a/src/store/mapInteractionStatus/index.ts
+++ b/src/store/mapInteractionStatus/index.ts
@@ -1,0 +1,24 @@
+import {
+  createSlice, PayloadAction
+} from '@reduxjs/toolkit';
+
+export type MapInteractionStatus = 'feature-info' | 'draw' | 'measure' | 'none';
+
+const mapInteractionStatusSlice = createSlice({
+  name: 'mapInteractionStatus',
+  initialState: 'none' as MapInteractionStatus,
+  reducers: {
+    setMapInteractionStatus: (state, action: PayloadAction<MapInteractionStatus>) =>
+      action.payload,
+    removeInteractionStatus: (state, action: PayloadAction<MapInteractionStatus>) => {
+      return action.payload === state ? 'none' : state;
+    }
+  }
+});
+
+export const {
+  setMapInteractionStatus,
+  removeInteractionStatus
+} = mapInteractionStatusSlice.actions;
+
+export default mapInteractionStatusSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -17,6 +17,7 @@ import layerDetailsModal from './layerDetailsModal';
 import layerTree from './layerTree';
 import legal from './legal';
 import logoPath from './logoPath';
+import mapInteractionStatus from './mapInteractionStatus';
 import mapToolbarVisible from './mapToolbarVisible';
 import print from './print';
 import searchEngines from './searchEngines';
@@ -45,6 +46,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     layerTree,
     legal,
     logoPath,
+    mapInteractionStatus,
     mapToolbarVisible,
     print,
     searchEngines,

--- a/src/store/toolMenu/index.ts
+++ b/src/store/toolMenu/index.ts
@@ -22,6 +22,9 @@ export const slice = createSlice({
     setActiveKeys(state, action: PayloadAction<string[]>) {
       state.activeKeys = [...action.payload];
     },
+    removeActiveKey(state, action: PayloadAction<string>) {
+      state.activeKeys = state.activeKeys.filter(key => key !== action.payload);
+    },
     setAvailableTools(state, action: PayloadAction<string[]>) {
       state.availableTools = [...action.payload];
     },
@@ -34,6 +37,7 @@ export const slice = createSlice({
 export const {
   setActiveKeys,
   setAvailableTools,
+  removeActiveKey,
   setToolMenuMaxHeight
 } = slice.actions;
 


### PR DESCRIPTION
If using a map interaction tool (like a geometry editor) from a plugin, the shogun-gis-clients map interaction tools stayed active and there was no easy way to deactivate them.

To handle this I introduced a `mapInteractionStatus` state variable that will deactivate the corresponding tool if set to a different value.

To test this I included a simple button in the footer of the application:

![Peek 2025-05-26 16-49](https://github.com/user-attachments/assets/dc3c7264-64c2-40b8-a679-d31268d7f437)

The code for the button looks like this:

```tsx
import React, {useMemo} from "react";
import useAppDispatch from "./hooks/useAppDispatch";
import useAppSelector from "./hooks/useAppSelector";
import {MapInteractionStatus, removeInteractionStatus, setMapInteractionStatus} from "./store/mapInteractionStatus";
import {Button} from "antd";

export const TestMapInteraction = () => {
  const mapInteractionStatus = useAppSelector(state => state.mapInteractionStatus);
  const dispatch = useAppDispatch();
  const isActive = useMemo(() => mapInteractionStatus === ('other' as MapInteractionStatus), [mapInteractionStatus]);

  return <div>
    <Button
      type={'primary'}
      style={{
        backgroundColor: isActive ? 'green' : undefined
      }}
      onClick={() => {
        if (!isActive) {
          dispatch(setMapInteractionStatus('other' as MapInteractionStatus))
        }
        else {
          dispatch(removeInteractionStatus('other' as MapInteractionStatus))
        }
      }}>
      turn on other interaction
    </Button>
  </div>;
}
```
