### PR TITLE
feat: allow vector layers in layer tree if they have a shogunId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@terrestris/react-geo": "^31.0.1",
         "@terrestris/react-util": "^12.1.1",
         "@terrestris/shogun-e2e-tests": "^1.0.8",
-        "@terrestris/shogun-util": "^10.6.0",
+        "@terrestris/shogun-util": "^10.7.0",
         "@types/color": "^4.2.0",
         "@types/js-md5": "^0.7.2",
         "@types/proj4": "^2.5.6",
@@ -6944,10 +6944,9 @@
       }
     },
     "node_modules/@terrestris/shogun-util": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-10.6.0.tgz",
-      "integrity": "sha512-Bo+ZzmboUWKSlHPaNOIChERxpmK+qfYS2qZDl6pd0qcwuRCGLp8tBFCZLjut7Ash6xdVb9Mnb36loEneJTRFYg==",
-      "license": "BSD-2-Clause",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-10.7.0.tgz",
+      "integrity": "sha512-yolBKMVSy5apcSmrnGtmu96O1dr+1FDDTAeOXyg5fRLL52NkfZsMEEUxTlzG0qRiqDN8lLjGjo6/yznTbDTqTQ==",
       "dependencies": {
         "@terrestris/base-util": "^3.0.0",
         "geojson": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@terrestris/react-geo": "^31.0.1",
     "@terrestris/react-util": "^12.1.1",
     "@terrestris/shogun-e2e-tests": "^1.0.8",
-    "@terrestris/shogun-util": "^10.6.0",
+    "@terrestris/shogun-util": "^10.7.0",
     "@types/color": "^4.2.0",
     "@types/js-md5": "^0.7.2",
     "@types/proj4": "^2.5.6",

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -28,13 +28,15 @@ import OlLayerGroup from 'ol/layer/Group';
 import OlLayerImage from 'ol/layer/Image';
 import OlLayer from 'ol/layer/Layer';
 import OlLayerTile from 'ol/layer/Tile';
+import OlVectorLayer from "ol/layer/Vector";
 import OlSourceImageWMS from 'ol/source/ImageWMS';
 import OlSourceTileWMS from 'ol/source/TileWMS';
-import OlSourceVector from 'ol/source/Vector';
 
 import {
   useTranslation
 } from 'react-i18next';
+
+import _isNil from "lodash/isNil";
 
 import { MapUtil } from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 import { isWmsLayer } from '@terrestris/ol-util/dist/typeUtils/typeUtils';
@@ -246,11 +248,11 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
   };
 
   const treeFilterFunction = (layer: OlBaseLayer | OlLayerGroup) => {
-    if ((layer as OlLayerGroup).getLayers) {
-      return !layer.get('hideInLayerTree');
+    if (layer instanceof OlLayerGroup) {
+      return true;
     }
 
-    return !((layer as OlLayer).getSource && ((layer as OlLayer).getSource() as OlSourceVector)?.forEachFeature);
+    return !(layer instanceof OlVectorLayer) || !_isNil(layer.get('shogunId'));
   };
 
   const treeNodeTitleRenderer = (layer: OlBaseLayer) => {


### PR DESCRIPTION
This allows vector layers in the layer tree so `WFS` and `OGC_FEATURES` will appear.