### PR TITLE
Request all required layer properties in search

### DIFF
--- a/src/components/MultiSearch/index.tsx
+++ b/src/components/MultiSearch/index.tsx
@@ -24,7 +24,9 @@ import {
 
 import ClientConfiguration from 'clientConfig';
 
-import { getUid } from 'ol';
+import {
+  getUid
+} from 'ol';
 import {
   Extent as OlExtent
 } from 'ol/extent';
@@ -312,10 +314,17 @@ export const MultiSearch: React.FC<MultiSearchProps> = ({
       }
 
       if (ClientConfiguration.search?.showSearchResultDrawer) {
+        const featureObject = geoJSONFormat.writeFeatureObject(item.feature);
+
+        // Remove layer from properties, as it is not serializable
+        delete featureObject.properties?.layer;
+
         dispatch(setSearchResultState({
-          geoJSONFeature: geoJSONFormat.writeFeatureObject(item.feature),
+          geoJSONFeature: featureObject,
+          layerId: getUid(item.feature.get('layer')),
           drawerVisibility: true
         }));
+
         setSearchValue('');
       }
     };

--- a/src/store/searchResult/index.tsx
+++ b/src/store/searchResult/index.tsx
@@ -3,15 +3,19 @@ import {
   PayloadAction
 } from '@reduxjs/toolkit';
 
-import { Feature } from 'geojson';
+import {
+  Feature
+} from 'geojson';
 
 export interface SearchResultState {
   geoJSONFeature: Feature | null;
+  layerId: string | null;
   drawerVisibility: boolean;
 }
 
 const initialState: SearchResultState = {
   drawerVisibility: false,
+  layerId: null,
   geoJSONFeature: null
 };
 


### PR DESCRIPTION
Previously only the given `attributes` of the layer's search configuration were requested from the WFS. This might resulted in unwanted behaviours e.g. while making the attribues `name` and `description` searchable, but making the attribute `owner` visible in the search result drawer as well. The latter wouldn't be available.

This fixes this issue by requesting all needed attributes from the WFS target layer.

In addition it removes the layer instance from the store since it's not serializable (well).

Please review @terrestris/devs.