### PR TITLE
Pass plugin config to plugin component

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -626,19 +626,18 @@ const loadPlugins = async (map: OlMap, toolConfig?: DefaultApplicationToolConfig
     for (const module of clientPluginModules) {
       const clientPluginDefault: ClientPluginInternal = module as ClientPluginInternal;
       const PluginComponent = clientPluginDefault.component;
+      const pluginApplicationConfig = toolConfig?.find((tc) => tc.name === clientPluginDefault.key);
 
-      if (toolConfig) {
-        const pluginApplicationConfig = toolConfig.find((tc) => tc.name === clientPluginDefault.key);
-        if (pluginApplicationConfig?.config?.disabled) {
-          Logger.info(`"${clientPluginDefault.key}" is disabled by the application config`);
-          continue;
-        }
+      if (pluginApplicationConfig?.config?.disabled) {
+        Logger.info(`"${clientPluginDefault.key}" is disabled by the application config`);
+        continue;
       }
 
       const WrappedPluginComponent = () => (
         <PluginComponent
           map={map}
           client={client}
+          config={pluginApplicationConfig?.config}
         />
       );
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -11,12 +11,17 @@ import type OlMap from 'ol/Map';
 import { SHOGunAPIClient } from '@terrestris/shogun-util/dist/service/SHOGunAPIClient';
 
 export type ClientPluginLocale = Record<string, {
-    translation: Record<string, any>;
-  }>;
+  translation: Record<string, any>;
+}>;
 
-export type ClientPluginComponentProps = {
+export type PluginConfig = {
+  disabled?: boolean;
+};
+
+export type ClientPluginComponentProps<T extends PluginConfig = PluginConfig> = {
   map?: OlMap;
   client?: SHOGunAPIClient;
+  config?: T;
 };
 
 export type ClientPluginIntegration = {


### PR DESCRIPTION
This suggests to pass the plugin configuration (if any) to the plugin component. This enables the plugin to read the configuration without requesting it again.

The newly introduced type `PluginConfig` can be extended in plugins to match any given model, e.g.:

```tsx
import {
  ClientPluginComponentProps,
  PluginConfig
} from '@terrestris/shogun-gis-client/dist/plugin';

export type MyPluginConfig = PluginConfig & {
  myStringConfig?: string;
  myNumberConfig?: number;
};

export type MyPluginProps = ClientPluginComponentProps<MyPluginConfig>;

export const MyPlugin: React.FC<MyPluginProps> = ({
  config
}): JSX.Element => {
  return (<span>{config.myStringConfig}</span>);
};
```

Please review @terrestris/devs.