### PR TITLE
test: add unittests for searchEngines

### DIFF
--- a/src/hooks/searchEngines/useNominatimSearchEngine.spec.ts
+++ b/src/hooks/searchEngines/useNominatimSearchEngine.spec.ts
@@ -1,0 +1,131 @@
+import { renderHook } from '@testing-library/react';
+
+import { Map } from 'ol';
+
+import { createNominatimSearchFunction } from '@terrestris/react-util/dist/Hooks/search/createNominatimSearchFunction';
+import { useMap } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
+
+import { useNominatimSearchEngine } from './useNominatimSearchEngine';
+
+jest.mock('@terrestris/react-util/dist/Hooks/useMap/useMap', () => ({
+  useMap: jest.fn()
+}));
+
+jest.mock('@terrestris/react-util/dist/Hooks/search/createNominatimSearchFunction', () => ({
+  createNominatimSearchFunction: jest.fn()
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: jest.fn(key => key)
+  })
+}));
+
+describe('useNominatimSearchEngine', () => {
+  let mockMap: Map;
+  let mockProjection: any;
+
+  beforeEach(() => {
+    mockProjection = 'EPSG:3857';
+    mockMap = {
+      getView: jest.fn().mockReturnValue({
+        getProjection: jest.fn().mockReturnValue(mockProjection)
+      })
+    } as unknown as Map;
+
+    (useMap as jest.Mock).mockReturnValue(mockMap);
+  });
+
+  it('returns undefined if map is not available', async () => {
+    (useMap as jest.Mock).mockReturnValue(null);
+    const { result } = renderHook(() => useNominatimSearchEngine());
+    const performNominatimSearch = result.current;
+
+    const resultData = await performNominatimSearch('test');
+    expect(resultData).toBeUndefined();
+  });
+
+  it('executes search with valid data', async () => {
+    const mockExecuteSearch = jest.fn().mockResolvedValue({
+      features: [
+        {
+          properties: {
+            geojson: {
+              type: 'Point',
+              coordinates: [0, 0]
+            },
+            // eslint-disable-next-line camelcase
+            display_name: 'Test Location'
+          },
+          geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+          }
+        }
+      ]
+    });
+    (createNominatimSearchFunction as jest.Mock).mockReturnValue(mockExecuteSearch);
+
+    const { result } = renderHook(() => useNominatimSearchEngine());
+    const performNominatimSearch = result.current;
+
+    const response = await performNominatimSearch('test');
+
+    expect(mockExecuteSearch).toHaveBeenCalledWith('test');
+
+    expect(response).toEqual([
+      {
+        title: 'useNominatimSearchEngine.title',
+        features: [
+          expect.objectContaining({
+            getProperties: expect.any(Function),
+            get: expect.any(Function)
+          })
+        ]
+      }
+    ]);
+  });
+
+  it('handles empty response', async () => {
+    (createNominatimSearchFunction as jest.Mock).mockReturnValue(jest.fn().mockResolvedValue({ features: [] }));
+
+    const { result } = renderHook(() => useNominatimSearchEngine());
+    const performNominatimSearch = result.current;
+
+    const response = await performNominatimSearch('test');
+
+    expect(response).toEqual([
+      {
+        title: 'useNominatimSearchEngine.title',
+        features: []
+      }
+    ]);
+  });
+
+  it('handles edge case where feature array contains no geojson', async () => {
+    (createNominatimSearchFunction as jest.Mock).mockReturnValue(jest.fn().mockResolvedValue({
+      features: [
+        {
+          properties: {
+            // eslint-disable-next-line camelcase
+            display_name: 'Location Without GeoJSON'
+          },
+          geometry: {}
+        }
+      ]
+    }));
+
+    const { result } = renderHook(() => useNominatimSearchEngine());
+    const performNominatimSearch = result.current;
+
+    const response = await performNominatimSearch('test');
+
+    expect(response).toEqual([
+      {
+        title: 'useNominatimSearchEngine.title',
+        features: []
+      }
+    ]);
+  });
+});
+

--- a/src/hooks/searchEngines/useSolrSearchEngine.spec.ts
+++ b/src/hooks/searchEngines/useSolrSearchEngine.spec.ts
@@ -1,0 +1,432 @@
+import { renderHook } from '@testing-library/react';
+
+import {
+  Map as OlMap,
+  View as OlView
+} from 'ol';
+import OlLayerTile from 'ol/layer/Tile';
+import { get as getProjection } from 'ol/proj';
+import OlSourceTileWMS from 'ol/source/TileWMS';
+
+import Logger from '@terrestris/base-util/dist/Logger';
+import { MapUtil } from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+import { WmsLayer } from '@terrestris/ol-util/dist/typeUtils/typeUtils';
+import { useMap } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
+
+import generateSolrQuery from '../../utils/generateSolrQuery';
+import useExecuteSolrQuery from '../useExecuteSolrQuery';
+
+import { useSolrSearchEngine } from './useSolrSearchEngine';
+
+jest.mock('@terrestris/react-util/dist/Hooks/useMap/useMap', () => ({
+  useMap: jest.fn()
+}));
+
+jest.mock('../useExecuteSolrQuery');
+jest.mock('../../utils/generateSolrQuery');
+jest.mock('clientConfig', () => ({
+  search: {
+    solrBasePath: '/search/query',
+    solrQueryConfig: {
+      rowsPerQuery: 10,
+      queryParser: 'edismax',
+      tagPre: '<em>',
+      tagPost: '</em>',
+      requireFieldMatch: true
+    },
+    coreName: 'testCore',
+    useSolrHighlighting: true,
+    groupByCategory: false
+  }
+}));
+
+jest.mock('@terrestris/ol-util/dist/MapUtil/MapUtil', () => ({
+  MapUtil: {
+    getLayerByNameParam: jest.fn()
+  }
+}));
+
+jest.mock('@terrestris/base-util/dist/Logger', () => ({
+  error: jest.fn()
+}));
+
+describe('useSolrSearchEngine', () => {
+  let mockMap: OlMap;
+  let mockLayer: WmsLayer;
+  let mockExecuteSolrQuery: jest.Mock;
+  let mockGenerateSolrQuery: jest.Mock;
+
+  beforeEach(() => {
+    mockMap = new OlMap({
+      view: new OlView({
+        center: [0, 0],
+        zoom: 10,
+        projection: getProjection('EPSG:3857')!
+      })
+    });
+
+    mockExecuteSolrQuery = jest.fn();
+    mockGenerateSolrQuery = jest.fn();
+
+    (useMap as jest.Mock).mockReturnValue(mockMap);
+    (useExecuteSolrQuery as jest.Mock).mockReturnValue(mockExecuteSolrQuery);
+    (generateSolrQuery as jest.Mock).mockImplementation(mockGenerateSolrQuery);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('performSolrSearch', () => {
+    it('returns undefined if map is not available', async () => {
+      (useMap as jest.Mock).mockReturnValue(null);
+      const { result } = renderHook(() => useSolrSearchEngine());
+
+      const searchResult = await result.current('test');
+
+      expect(searchResult).toBeUndefined();
+      expect(mockExecuteSolrQuery).not.toHaveBeenCalled();
+    });
+
+    it('executes solr queries for each layer', async () => {
+      const mockQueryPerLayer = [
+        {
+          query: 'query1',
+          fieldList: ['field1', 'field2']
+        },
+        {
+          query: 'query2',
+          fieldList: ['field3', 'field4']
+        }
+      ];
+
+      mockGenerateSolrQuery.mockReturnValue(mockQueryPerLayer);
+      mockExecuteSolrQuery.mockResolvedValue({
+        response: { docs: [] },
+        highlighting: {}
+      });
+
+      const { result } = renderHook(() => useSolrSearchEngine());
+
+      await result.current('test search');
+
+      expect(mockGenerateSolrQuery).toHaveBeenCalledWith({
+        searchValue: 'test search',
+        map: mockMap
+      });
+      expect(mockExecuteSolrQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('processes fulfilled responses and creates features', async () => {
+      const wktGeometry = 'POINT(1000000 6000000)';
+      const mockDocs = [
+        {
+          id: 'feature1',
+          featureType: ['testLayer'],
+          geometry: [wktGeometry],
+          name: 'Test Feature',
+          category: ['Test Category']
+        }
+      ];
+
+      mockGenerateSolrQuery.mockReturnValue([
+        {
+          query: 'query1',
+          fieldList: ['field1']
+        }
+      ]);
+
+      mockExecuteSolrQuery.mockResolvedValue({
+        response: { docs: mockDocs },
+        highlighting: {
+          feature1: { name: '<em>Test</em> Feature' }
+        }
+      });
+
+      mockLayer = new OlLayerTile({
+        source: new OlSourceTileWMS({
+          url: 'http://test.com',
+          params: { LAYERS: 'testLayer' }
+        })
+      });
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchable', true);
+      mockLayer.set('searchConfig', { displayTemplate: '{name}' });
+
+      mockMap.addLayer(mockLayer);
+      (MapUtil.getLayerByNameParam as jest.Mock).mockReturnValue(mockLayer);
+
+      const { result } = renderHook(() => useSolrSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(searchResults).toBeDefined();
+      expect(searchResults).toHaveLength(1);
+      expect(searchResults![0].title).toBe('Test Layer');
+      expect(searchResults![0].features).toHaveLength(1);
+      expect(searchResults![0].features[0].get('title')).toBe('Test Feature');
+    });
+
+    it('handles rejected promises and log errors', async () => {
+      mockGenerateSolrQuery.mockReturnValue([
+        {
+          query: 'query1',
+          fieldList: ['field1']
+        }
+      ]);
+
+      mockExecuteSolrQuery.mockRejectedValue(new Error('Solr error'));
+
+      const { result } = renderHook(() => useSolrSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        'Error while fetching the solr results for layer ',
+        new Error('Solr error')
+      );
+      expect(searchResults).toEqual([]);
+    });
+
+    it('uses displayTemplate from searchConfig when available', async () => {
+      const wktGeometry = 'POINT(1000000 6000000)';
+      const mockDocs = [
+        {
+          id: 'feature1',
+          featureType: ['testLayer'],
+          geometry: [wktGeometry],
+          name: 'Test',
+          city: 'Bonn',
+          category: ['Test Category']
+        }
+      ];
+
+      mockGenerateSolrQuery.mockReturnValue([
+        {
+          query: 'query1',
+          fieldList: ['field1']
+        }
+      ]);
+
+      mockExecuteSolrQuery.mockResolvedValue({
+        response: { docs: mockDocs },
+        highlighting: {}
+      });
+
+      mockLayer = new OlLayerTile({
+        source: new OlSourceTileWMS({
+          url: 'http://test.com',
+          params: { LAYERS: 'testLayer' }
+        })
+      });
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchable', true);
+      mockLayer.set('searchConfig', {
+        displayTemplate: '{name} - {city}'
+      });
+
+      mockMap.addLayer(mockLayer);
+      (MapUtil.getLayerByNameParam as jest.Mock).mockReturnValue(mockLayer);
+
+      const { result } = renderHook(() => useSolrSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(searchResults![0].features[0].get('title')).toBe('Test - Bonn');
+    });
+
+    it('skips features without geometry', async () => {
+      const mockDocs = [
+        {
+          id: 'feature1',
+          featureType: ['testLayer'],
+          name: 'Feature without geometry',
+          category: ['Test Category']
+        }
+      ];
+
+      mockGenerateSolrQuery.mockReturnValue([
+        {
+          query: 'query1',
+          fieldList: ['field1']
+        }
+      ]);
+
+      mockExecuteSolrQuery.mockResolvedValue({
+        response: { docs: mockDocs },
+        highlighting: {}
+      });
+
+      const { result } = renderHook(() => useSolrSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(searchResults).toHaveLength(1);
+      expect(searchResults![0].features).toHaveLength(0);
+    });
+
+    it('applies attributes to features excluding blacklisted ones', async () => {
+      const wktGeometry = 'POINT(1000000 6000000)';
+      const mockDocs = [
+        {
+          id: 'feature1',
+          featureType: ['testLayer'],
+          geometry: [wktGeometry],
+          name: 'Test Feature',
+          city: 'Berlin',
+          category: ['Test Category'],
+          _version_: 123
+        }
+      ];
+
+      mockGenerateSolrQuery.mockReturnValue([
+        {
+          query: 'query1',
+          fieldList: ['field1']
+        }
+      ]);
+
+      mockExecuteSolrQuery.mockResolvedValue({
+        response: { docs: mockDocs },
+        highlighting: {}
+      });
+
+      mockLayer = new OlLayerTile({
+        source: new OlSourceTileWMS({
+          url: 'http://test.com',
+          params: { LAYERS: 'testLayer' }
+        })
+      });
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchable', true);
+
+      mockMap.addLayer(mockLayer);
+      (MapUtil.getLayerByNameParam as jest.Mock).mockReturnValue(mockLayer);
+
+      const { result } = renderHook(() => useSolrSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      const feature = searchResults![0].features[0];
+      expect(feature.get('name')).toBe('Test Feature');
+      expect(feature.get('city')).toBe('Berlin');
+      expect(feature.get('category')).toBeUndefined();
+      expect(feature.get('_version_')).toBeUndefined();
+    });
+
+    it('handles viewBox parameter', async () => {
+      const viewBox: [number, number, number, number] = [0, 0, 1000, 1000];
+
+      mockGenerateSolrQuery.mockReturnValue([
+        {
+          query: 'query1',
+          fieldList: ['field1']
+        }
+      ]);
+
+      mockExecuteSolrQuery.mockResolvedValue({
+        response: { docs: [] },
+        highlighting: {}
+      });
+
+      const { result } = renderHook(() => useSolrSearchEngine());
+
+      await result.current('test', viewBox);
+
+      expect(mockExecuteSolrQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          viewBox
+        })
+      );
+    });
+
+    it('uses highlighted values in feature titles', async () => {
+      const wktGeometry = 'POINT(1000000 6000000)';
+      const mockDocs = [
+        {
+          id: 'feature1',
+          featureType: ['testLayer'],
+          geometry: [wktGeometry],
+          name: 'Test Feature',
+          category: ['Test Category']
+        }
+      ];
+
+      mockGenerateSolrQuery.mockReturnValue([
+        {
+          query: 'query1',
+          fieldList: ['field1']
+        }
+      ]);
+
+      mockExecuteSolrQuery.mockResolvedValue({
+        response: { docs: mockDocs },
+        highlighting: {
+          feature1: { name: '<em>Test</em> Feature' }
+        }
+      });
+
+      mockLayer = new OlLayerTile({
+        source: new OlSourceTileWMS({
+          url: 'http://test.com',
+          params: { LAYERS: 'testLayer' }
+        })
+      });
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchable', true);
+
+      mockMap.addLayer(mockLayer);
+      (MapUtil.getLayerByNameParam as jest.Mock).mockReturnValue(mockLayer);
+
+      const { result } = renderHook(() => useSolrSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(searchResults![0].features[0].get('title')).toBe('<em>Test</em> Feature [name]');
+    });
+
+    it('falls back to id when no matching value is found', async () => {
+      const wktGeometry = 'POINT(1000000 6000000)';
+      const mockDocs = [
+        {
+          id: 'feature1',
+          featureType: ['testLayer'],
+          geometry: [wktGeometry],
+          description: 'Some description',
+          category: ['Test Category']
+        }
+      ];
+
+      mockGenerateSolrQuery.mockReturnValue([
+        {
+          query: 'query1',
+          fieldList: ['field1']
+        }
+      ]);
+
+      mockExecuteSolrQuery.mockResolvedValue({
+        response: { docs: mockDocs },
+        highlighting: {}
+      });
+
+      mockLayer = new OlLayerTile({
+        source: new OlSourceTileWMS({
+          url: 'http://test.com',
+          params: { LAYERS: 'testLayer' }
+        })
+      });
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchable', true);
+
+      mockMap.addLayer(mockLayer);
+      (MapUtil.getLayerByNameParam as jest.Mock).mockReturnValue(mockLayer);
+
+      const { result } = renderHook(() => useSolrSearchEngine());
+
+      const searchResults = await result.current('xyz');
+
+      expect(searchResults![0].features[0].get('title')).toBe('feature1');
+    });
+  });
+});
+

--- a/src/hooks/searchEngines/useWfsSearchEngine.spec.ts
+++ b/src/hooks/searchEngines/useWfsSearchEngine.spec.ts
@@ -1,0 +1,731 @@
+import { renderHook } from '@testing-library/react';
+import {
+  Map as OlMap,
+  View as OlView
+} from 'ol';
+import ImageLayer from 'ol/layer/Image';
+import OlLayerTile from 'ol/layer/Tile';
+import { get as getProjection } from 'ol/proj';
+import OlSourceTileWMS from 'ol/source/TileWMS';
+
+import Logger from '@terrestris/base-util/dist/Logger';
+import { WmsLayer } from '@terrestris/ol-util/dist/typeUtils/typeUtils';
+import { useMap } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
+
+import useExecuteGetFeature from '../useExecuteGetFeature';
+import useExecuteWfsDescribeFeatureType from '../useExecuteWfsDescribeFeatureType';
+
+import { useWfsSearchEngine } from './useWfsSearchEngine';
+
+jest.mock('@terrestris/react-util/dist/Hooks/useMap/useMap', () => ({
+  useMap: jest.fn()
+}));
+
+jest.mock('../useExecuteGetFeature');
+jest.mock('../useExecuteWfsDescribeFeatureType');
+jest.mock('clientConfig', () => ({
+  search: {
+    showSearchResultDrawer: true
+  }
+}));
+
+jest.mock('@terrestris/base-util/dist/Logger', () => ({
+  error: jest.fn(),
+  warn: jest.fn()
+}));
+
+describe('useWfsSearchEngine', () => {
+  let mockMap: OlMap;
+  let mockLayer: WmsLayer;
+  let mockExecuteGetFeature: jest.Mock;
+  let mockExecuteWfsDescribeFeatureType: jest.Mock;
+
+  beforeEach(() => {
+    mockMap = new OlMap({
+      view: new OlView({
+        center: [0, 0],
+        zoom: 10,
+        projection: getProjection('EPSG:3857')!
+      })
+    });
+
+    mockLayer = new OlLayerTile({
+      source: new OlSourceTileWMS({
+        url: 'http://test.com',
+        params: { LAYERS: 'testLayer' }
+      })
+    });
+
+    mockExecuteGetFeature = jest.fn();
+    mockExecuteWfsDescribeFeatureType = jest.fn();
+
+    (useMap as jest.Mock).mockReturnValue(mockMap);
+    (useExecuteGetFeature as jest.Mock).mockReturnValue(mockExecuteGetFeature);
+    (useExecuteWfsDescribeFeatureType as jest.Mock).mockReturnValue(mockExecuteWfsDescribeFeatureType);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('performWfsSearch', () => {
+    it('returns undefined if map is not available', async () => {
+      (useMap as jest.Mock).mockReturnValue(null);
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      const searchResult = await result.current('test');
+
+      expect(searchResult).toBeUndefined();
+      expect(mockExecuteGetFeature).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined and warn if no searchable layers are found', async () => {
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      const searchResult = await result.current('test');
+
+      expect(searchResult).toBeUndefined();
+      expect(Logger.warn).toHaveBeenCalledWith('No queryable layer found.');
+    });
+
+    it('skips non-WMS layers with a warning', async () => {
+      const nonWmsLayer = new ImageLayer();
+      nonWmsLayer.set('searchable', true);
+      mockMap.addLayer(nonWmsLayer);
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('test');
+
+      expect(Logger.warn).toHaveBeenCalledWith('Layer type not supported in search: ', nonWmsLayer);
+    });
+
+    it('skips layers without search configuration', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockMap.addLayer(mockLayer);
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('test');
+
+      expect(Logger.warn).toHaveBeenCalledWith('No search configuration given for layer: ', mockLayer);
+    });
+
+    it('skips layers with failed DescribeFeatureType', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('test');
+
+      expect(Logger.warn).toHaveBeenCalledWith('No successful DescribeFeatureType for layer: ', mockLayer);
+    });
+
+    it('skips layers without layer name', async () => {
+      mockLayer = new OlLayerTile({
+        source: new OlSourceTileWMS({
+          url: 'http://test.com',
+          params: {}
+        })
+      });
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: []
+      });
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('test');
+
+      expect(Logger.warn).toHaveBeenCalledWith('No layer name available for layer: ', mockLayer);
+    });
+
+    it('executes GetFeature for valid searchable layers', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name', 'city'],
+        displayTemplate: '{name} - {city}'
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            },
+            {
+              name: 'city',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      const mockGeoJson = {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+          },
+          properties: {
+            name: 'Test Feature',
+            city: 'Bonn'
+          },
+          id: 'feature1'
+        }]
+      };
+
+      mockExecuteGetFeature.mockResolvedValue(mockGeoJson);
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(mockExecuteGetFeature).toHaveBeenCalledTimes(1);
+      expect(searchResults).toHaveLength(1);
+      expect(searchResults![0].title).toBe('Test Layer');
+      expect(searchResults![0].features).toHaveLength(1);
+    });
+
+    it('creates string filters with LIKE operator', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      mockExecuteGetFeature.mockResolvedValue({
+        type: 'FeatureCollection',
+        features: []
+      });
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('test');
+
+      expect(mockExecuteGetFeature).toHaveBeenCalledWith(
+        expect.objectContaining({
+          layer: mockLayer,
+          filter: expect.anything()
+        })
+      );
+    });
+
+    it('creates numeric filters with EQUAL operator', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['population']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'population',
+              localType: 'number'
+            }
+          ]
+        }]
+      });
+
+      mockExecuteGetFeature.mockResolvedValue({
+        type: 'FeatureCollection',
+        features: []
+      });
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('12345');
+
+      expect(mockExecuteGetFeature).toHaveBeenCalled();
+    });
+
+    it('skips numeric filters when search value is not a number', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['population']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'population',
+              localType: 'number'
+            }
+          ]
+        }]
+      });
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('not-a-number');
+
+      expect(Logger.warn).toHaveBeenCalledWith('No valid filter available for layer: ', mockLayer);
+      expect(mockExecuteGetFeature).not.toHaveBeenCalled();
+    });
+
+    it('warns about unsupported attribute types', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['dateField']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'dateField',
+              localType: 'date'
+            }
+          ]
+        }]
+      });
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('test');
+
+      expect(Logger.warn).toHaveBeenCalledWith(
+        'Attribute "dateField" with type "date" not supported for search in layer "Test Layer".'
+      );
+    });
+
+    it('warns when attribute is not found in feature type', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['nonExistentField']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('test');
+
+      expect(Logger.warn).toHaveBeenCalledWith(
+        'Attribute "nonExistentField" not found in feature type "testLayer" for layer "Test Layer".'
+      );
+    });
+
+    it('uses displayTemplate for feature title', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name', 'city'],
+        displayTemplate: '{name} - {city}'
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            },
+            {
+              name: 'city',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      const mockGeoJson = {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+          },
+          properties: {
+            name: 'Test Feature',
+            city: 'Berlin'
+          },
+          id: 'feature1'
+        }]
+      };
+
+      mockExecuteGetFeature.mockResolvedValue(mockGeoJson);
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(searchResults![0].features[0].get('title')).toBe('Test Feature - Berlin');
+    });
+
+    it('uses matched property for feature title when no displayTemplate', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      const mockGeoJson = {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+          },
+          properties: { name: 'Test Feature' },
+          id: 'feature1'
+        }]
+      };
+
+      mockExecuteGetFeature.mockResolvedValue(mockGeoJson);
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(searchResults![0].features[0].get('title')).toBe('Test Feature [name]');
+    });
+
+    it('falls back to feature ID when no matching property found', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      const mockGeoJson = {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+          },
+          properties: { name: 'Other Value' },
+          id: 'feature1'
+        }]
+      };
+
+      mockExecuteGetFeature.mockResolvedValue(mockGeoJson);
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(searchResults![0].features[0].get('title')).toBe('feature1');
+    });
+
+    it('handles viewBox parameter', async () => {
+      const viewBox: [number, number, number, number] = [0, 0, 10, 10];
+
+      mockLayer = new OlLayerTile({
+        source: new OlSourceTileWMS({
+          url: 'http://test.com',
+          params: { LAYERS: 'testLayer' }
+        })
+      });
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      mockExecuteGetFeature.mockResolvedValue({
+        type: 'FeatureCollection',
+        features: []
+      });
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('test', viewBox);
+
+      expect(mockExecuteGetFeature).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bbox: expect.any(Array)
+        })
+      );
+    });
+
+    it('handles rejected GetFeature promises and log errors', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      mockExecuteGetFeature.mockRejectedValue(new Error('WFS error'));
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        'Error while fetching the layer search results for layer "Test Layer": ',
+        new Error('WFS error')
+      );
+      expect(searchResults).toEqual([]);
+    });
+
+    it('handles namespaced layer names', async () => {
+      mockLayer = new OlLayerTile({
+        source: new OlSourceTileWMS({
+          url: 'http://test.com',
+          params: { LAYERS: 'namespace:testLayer' }
+        })
+      });
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      mockExecuteGetFeature.mockResolvedValue({
+        type: 'FeatureCollection',
+        features: []
+      });
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('test');
+
+      expect(mockExecuteGetFeature).toHaveBeenCalled();
+    });
+
+    it('includes propertyNames when resultDrawerConfig is provided', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name'],
+        displayTemplate: '{name}',
+        resultDrawerConfig: {
+          children: [
+            { propertyName: 'name' },
+            { propertyName: 'city' }
+          ]
+        }
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      mockExecuteGetFeature.mockResolvedValue({
+        type: 'FeatureCollection',
+        features: []
+      });
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('test');
+
+      expect(mockExecuteGetFeature).toHaveBeenCalledWith(
+        expect.objectContaining({
+          propertyNames: expect.arrayContaining(['name', 'city'])
+        })
+      );
+    });
+
+    it('handles int localType as numeric', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['id']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'id',
+              localType: 'int'
+            }
+          ]
+        }]
+      });
+
+      mockExecuteGetFeature.mockResolvedValue({
+        type: 'FeatureCollection',
+        features: []
+      });
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      await result.current('123');
+
+      expect(mockExecuteGetFeature).toHaveBeenCalled();
+    });
+
+    it('sets layer reference on features', async () => {
+      mockLayer.set('searchable', true);
+      mockLayer.set('name', 'Test Layer');
+      mockLayer.set('searchConfig', {
+        attributes: ['name']
+      });
+      mockMap.addLayer(mockLayer);
+
+      mockExecuteWfsDescribeFeatureType.mockResolvedValue({
+        featureTypes: [{
+          typeName: 'testLayer',
+          properties: [
+            {
+              name: 'name',
+              localType: 'string'
+            }
+          ]
+        }]
+      });
+
+      const mockGeoJson = {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+          },
+          properties: { name: 'Test Feature' },
+          id: 'feature1'
+        }]
+      };
+
+      mockExecuteGetFeature.mockResolvedValue(mockGeoJson);
+
+      const { result } = renderHook(() => useWfsSearchEngine());
+
+      const searchResults = await result.current('test');
+
+      expect(searchResults![0].features[0].get('layer')).toBe(mockLayer);
+    });
+  });
+});


### PR DESCRIPTION
This adds unittests for the search engine hooks:

- NominatimeSearchEngine
- SolrSearchEngine
- WfsSearchEngine