### PR TITLE
Minor style fix for the `BackgroundLayerChooser`

### DIFF
--- a/src/components/BasicMapComponent/index.less
+++ b/src/components/BasicMapComponent/index.less
@@ -1,7 +1,6 @@
 .map {
   .bg-layer-chooser {
     bottom: 95px;
-    width: 99%;
     right: 10px;
 
     .layer-cards {


### PR DESCRIPTION
Since the hardcoded width of the `.bg-layer-chooser` overlaps the map (and blocks mouse interactions on it), this suggests to remove it.

Please review @terrestris/devs.