### PR TITLE
feat: add TimeLayerSliderPanel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import LayerDetailsModal from './components/LayerDetailsModal';
 import NewsModal from './components/NewsModal';
 import SearchResultDrawer from './components/SearchResultDrawer';
 import StylingDrawer from './components/StylingDrawer';
+import TimeLayerModal from './components/TimeLayerModal';
 import ToolMenu from './components/ToolMenu';
 import UploadDataModal from './components/UploadDataModal';
 
@@ -54,6 +55,7 @@ export const App: React.FC<AppProps> = ({
       <SearchResultDrawer />
       <ClassificationDrawer />
       <NewsModal/>
+      <TimeLayerModal />
     </div>
   );
 };

--- a/src/components/TimeLayerModal/index.less
+++ b/src/components/TimeLayerModal/index.less
@@ -1,0 +1,88 @@
+.time-layer-modal {
+  z-index: 1000;
+  width: 100%;
+  min-width: 600px;
+  max-width: 95vw;
+
+  .time-layer-modal-container {
+    background-color: white;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .time-layer-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 20px;
+    border-bottom: 1px solid #f0f0f0;
+    cursor: move;
+    background-color: var(--primaryColor);
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+
+    h3 {
+      margin: 0;
+      flex: 1;
+    }
+
+    .header-controls {
+      display: flex;
+      gap: 8px;
+    }
+
+    .header-button {
+      background: none;
+      border: none;
+      font-size: 16px;
+      cursor: pointer;
+      padding: 4px 8px;
+      border-radius: 4px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+
+      &:hover {
+        background-color: #f0f0f0;
+      }
+
+      &.close-button {
+        font-size: 18px;
+      }
+
+      &.collapse-button {
+        font-size: 14px;
+      }
+    }
+  }
+
+  .time-layer-modal-content {
+    padding: 10px;
+
+    &.collapsed {
+      display: none;
+    }
+  }
+
+  &.collapsed {
+    .time-layer-modal-container {
+      height: 60px !important;
+      min-height: 60px;
+      max-height: 60px;
+    }
+
+    .time-layer-modal-content {
+      display: none !important;
+    }
+  }
+
+  .time-layer-slider {
+    width: 100%;
+  }
+}

--- a/src/components/TimeLayerModal/index.spec.tsx
+++ b/src/components/TimeLayerModal/index.spec.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+
+import { act, render, waitFor } from '@testing-library/react';
+
+import dayjs from 'dayjs';
+
+import { MapUtil } from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+import { useMap } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
+
+import useAppDispatch from '../../hooks/useAppDispatch';
+import useAppSelector from '../../hooks/useAppSelector';
+import { useTimeLayerData } from '../../hooks/useTimeLayerData';
+import appDayjs from '../../utils/dayjs';
+
+import TimeLayerModal from './index';
+
+jest.mock('react-rnd', () => ({
+  Rnd: ({ children }: any) => <div>{children}</div>
+}));
+
+let latestTimeLayerSliderPanelProps: any;
+
+jest.mock(
+  '@terrestris/react-geo/dist/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel',
+  () => ({
+    TimeLayerSliderPanel: (props: any) => {
+      latestTimeLayerSliderPanelProps = props;
+      return <div data-testid="time-layer-slider-panel" />;
+    }
+  })
+);
+
+jest.mock('@terrestris/react-util/dist/Hooks/useMap/useMap', () => ({
+  useMap: jest.fn()
+}));
+
+jest.mock('@terrestris/ol-util/dist/MapUtil/MapUtil', () => ({
+  MapUtil: {
+    getLayerByOlUid: jest.fn()
+  }
+}));
+
+jest.mock('../../hooks/useAppDispatch', () => jest.fn());
+jest.mock('../../hooks/useAppSelector', () => jest.fn());
+jest.mock('../../hooks/useTimeLayerData', () => ({
+  useTimeLayerData: jest.fn()
+}));
+
+describe('<TimeLayerModal />', () => {
+  const dispatchMock = jest.fn();
+  const fakeLayer = {
+    get: jest.fn((key: string) => {
+      if (key === 'name') {
+        return 'Test time layer';
+      }
+      return undefined;
+    })
+  };
+
+  beforeEach(() => {
+    latestTimeLayerSliderPanelProps = undefined;
+    dispatchMock.mockReset();
+
+    (useAppDispatch as jest.Mock).mockReturnValue(dispatchMock);
+    (useMap as jest.Mock).mockReturnValue({});
+    (MapUtil.getLayerByOlUid as jest.Mock).mockReturnValue(fakeLayer);
+
+    (useAppSelector as jest.Mock).mockImplementation((selector: any) =>
+      selector({
+        timeLayerModal: {
+          layerId: '123',
+          visible: true
+        }
+      })
+    );
+
+    (useTimeLayerData as jest.Mock).mockReturnValue({
+      timeAwareLayers: [
+        {
+          get: jest.fn(),
+          getSource: jest.fn()
+        }
+      ],
+      initialTime: appDayjs.utc('2026-01-03T00:00:00.000Z'),
+      minTime: appDayjs.utc('2026-01-01T00:00:00.000Z'),
+      maxTime: appDayjs.utc('2026-01-03T00:00:00.000Z'),
+      availableTimePoints: [],
+      isValidTimeLayer: true
+    });
+  });
+
+  it('converts slider values to UTC before saving in state', async () => {
+    render(<TimeLayerModal />);
+
+    await waitFor(() => {
+      expect(latestTimeLayerSliderPanelProps).toBeDefined();
+    });
+
+    const sliderLocalValue = dayjs('2026-01-02T12:30:00.000');
+
+    act(() => {
+      latestTimeLayerSliderPanelProps.onChangeComplete(sliderLocalValue);
+    });
+
+    await waitFor(() => {
+      expect(latestTimeLayerSliderPanelProps.value.valueOf()).toBe(
+        sliderLocalValue.valueOf()
+      );
+      expect((latestTimeLayerSliderPanelProps.value as any).isUTC()).toBe(true);
+    });
+  });
+});

--- a/src/components/TimeLayerModal/index.tsx
+++ b/src/components/TimeLayerModal/index.tsx
@@ -22,7 +22,7 @@ import useAppDispatch from '../../hooks/useAppDispatch';
 import useAppSelector from '../../hooks/useAppSelector';
 import { useTimeLayerData } from '../../hooks/useTimeLayerData';
 
-import { closeTimeLayerModal } from '../../store/timeLayerModal';
+import { setModalVisible } from '../../store/timeLayerModal';
 
 import './index.less';
 
@@ -38,6 +38,9 @@ export const TimeLayerModal: React.FC<
   const map = useMap();
   const timeModalLayerId = useAppSelector(
     state => state.timeLayerModal.layerId
+  );
+  const timeModalVisible = useAppSelector(
+    state => state.timeLayerModal.visible
   );
 
   const layer = useMemo(() => {
@@ -60,7 +63,7 @@ export const TimeLayerModal: React.FC<
     isValidTimeLayer
   } = timeLayerData;
 
-  const visible = !!layer && isValidTimeLayer;
+  const visible = timeModalVisible && !!layer && isValidTimeLayer;
 
   const tooltips = useMemo(
     () => ({
@@ -146,7 +149,7 @@ export const TimeLayerModal: React.FC<
   }, []);
 
   const handleClose = useCallback(() => {
-    dispatch(closeTimeLayerModal());
+    dispatch(setModalVisible(false));
   }, [dispatch]);
 
   const modalWidth = window.innerWidth * 0.8;

--- a/src/components/TimeLayerModal/index.tsx
+++ b/src/components/TimeLayerModal/index.tsx
@@ -1,0 +1,219 @@
+import React, {
+  useMemo,
+  useState,
+  useCallback
+} from 'react';
+
+import dayjs, { Dayjs } from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import OlLayer from 'ol/layer/Layer';
+
+import { useTranslation } from 'react-i18next';
+
+import { Rnd } from 'react-rnd';
+
+import { MapUtil } from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+
+import { TimeLayerSliderPanel } from '@terrestris/react-geo/dist/Panel/TimeLayerSliderPanel/TimeLayerSliderPanel';
+
+import { useMap } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
+
+import useAppDispatch from '../../hooks/useAppDispatch';
+import useAppSelector from '../../hooks/useAppSelector';
+import { useTimeLayerData } from '../../hooks/useTimeLayerData';
+
+import { closeTimeLayerModal } from '../../store/timeLayerModal';
+
+import './index.less';
+
+export type TimeLayerModalProps = Record<string, never>;
+
+dayjs.extend(utc);
+
+export const TimeLayerModal: React.FC<
+  TimeLayerModalProps
+> = (): JSX.Element => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+  const map = useMap();
+  const timeModalLayerId = useAppSelector(
+    state => state.timeLayerModal.layerId
+  );
+
+  const layer = useMemo(() => {
+    if (!map || !timeModalLayerId) {
+      return null;
+    }
+    return MapUtil.getLayerByOlUid(map, timeModalLayerId) as OlLayer | null;
+  }, [map, timeModalLayerId]);
+
+  const [currentTime, setCurrentTime] = useState<Dayjs | undefined>();
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const timeLayerData = useTimeLayerData(layer);
+  const {
+    timeAwareLayers,
+    initialTime,
+    minTime,
+    maxTime,
+    availableTimePoints,
+    isValidTimeLayer
+  } = timeLayerData;
+
+  const visible = !!layer && isValidTimeLayer;
+
+  const tooltips = useMemo(
+    () => ({
+      dataRange: t('TimeLayerModal.tooltips.dataRange', 'Set date range'),
+      days: t('TimeLayerModal.tooltips.days', 'Days'),
+      hours: t('TimeLayerModal.tooltips.hours', 'Hours'),
+      minutes: t('TimeLayerModal.tooltips.minutes', 'Minutes'),
+      months: t('TimeLayerModal.tooltips.months', 'Months'),
+      setToMostRecent: t(
+        'TimeLayerModal.tooltips.setToMostRecent',
+        'Set to most recent date'
+      ),
+      weeks: t('TimeLayerModal.tooltips.weeks', 'Weeks'),
+      years: t('TimeLayerModal.tooltips.years', 'Years')
+    }),
+    [t]
+  );
+
+  const layerName = useMemo(() => {
+    return layer?.get('name') || t('TimeLayerModal.unknownLayer');
+  }, [layer, t]);
+
+  React.useEffect(() => {
+    if (initialTime && initialTime.isValid() && !currentTime) {
+      setCurrentTime(initialTime);
+    }
+  }, [initialTime, currentTime]);
+
+  const handleTimeChange = useCallback(
+    (newTime: Dayjs | [Dayjs, Dayjs]) => {
+      if (!Array.isArray(newTime)) {
+        let timeToSet = newTime;
+
+        if (availableTimePoints && availableTimePoints.length > 0) {
+          const firstTimePoint = dayjs.utc(availableTimePoints[0]);
+          if (!firstTimePoint.isValid()) {
+            return;
+          }
+
+          let closestTime = firstTimePoint;
+          let minDiff = Math.abs(newTime.diff(closestTime));
+
+          for (const timePoint of availableTimePoints) {
+            const availableTime = dayjs.utc(timePoint);
+            if (!availableTime.isValid()) {
+              continue;
+            }
+            const diff = Math.abs(newTime.diff(availableTime));
+            if (diff < minDiff) {
+              minDiff = diff;
+              closestTime = availableTime;
+            }
+          }
+          timeToSet = closestTime;
+        }
+
+        if (minTime && maxTime) {
+          if (timeToSet.isBefore(minTime) || timeToSet.isAfter(maxTime)) {
+            const clampedTime = timeToSet.isBefore(minTime) ? minTime : maxTime;
+            setCurrentTime(prev => {
+              if (!prev || !clampedTime.isSame(prev)) {
+                return clampedTime;
+              }
+              return prev;
+            });
+            return;
+          }
+        }
+
+        setCurrentTime(prev => {
+          if (!prev || !timeToSet.isSame(prev)) {
+            return timeToSet;
+          }
+          return prev;
+        });
+      }
+    },
+    [minTime, maxTime, availableTimePoints]
+  );
+
+  const toggleCollapse = useCallback(() => {
+    setIsCollapsed(prev => !prev);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    dispatch(closeTimeLayerModal());
+  }, [dispatch]);
+
+  const modalWidth = window.innerWidth * 0.8;
+  const initialModalHeight = 180;
+  const collapsedHeight = 60;
+
+  if (!visible || !layer) {
+    return <></>;
+  }
+
+  return (
+    <Rnd
+      className={`time-layer-modal ${isCollapsed ? 'collapsed' : ''}`}
+      default={{
+        x: 330,
+        y: 60,
+        width: modalWidth,
+        height: isCollapsed ? collapsedHeight : initialModalHeight
+      }}
+      minWidth={400}
+      minHeight={isCollapsed ? collapsedHeight : initialModalHeight}
+      maxHeight={isCollapsed ? collapsedHeight : undefined}
+      dragHandleClassName="time-layer-modal-header"
+      disableDragging={false}
+      enableResizing={!isCollapsed}
+    >
+      <div className="time-layer-modal-container">
+        <div className="time-layer-modal-header">
+          <h3>{t('TimeLayerModal.title', { layerName })}</h3>
+          <div className="header-controls">
+            <button
+              className="header-button collapse-button"
+              onClick={toggleCollapse}
+              title={isCollapsed ? 'Expand' : 'Collapse'}
+            >
+              {isCollapsed ? '▼' : '▲'}
+            </button>
+            <button
+              className="header-button close-button"
+              onClick={handleClose}
+              title="Close"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+        <div
+          className={`time-layer-modal-content ${
+            isCollapsed ? 'collapsed' : ''
+          }`}
+        >
+          <TimeLayerSliderPanel
+            timeAwareLayers={timeAwareLayers}
+            value={
+              (currentTime && currentTime.isValid() ? currentTime : null) ||
+              (initialTime && initialTime.isValid() ? initialTime : null) ||
+              dayjs.utc()
+            }
+            min={minTime}
+            max={maxTime}
+            onChangeComplete={handleTimeChange}
+            tooltips={tooltips}
+          />
+        </div>
+      </div>
+    </Rnd>
+  );
+};
+
+export default TimeLayerModal;

--- a/src/components/TimeLayerModal/index.tsx
+++ b/src/components/TimeLayerModal/index.tsx
@@ -4,8 +4,6 @@ import React, {
   useCallback
 } from 'react';
 
-import dayjs, { Dayjs } from 'dayjs';
-import utc from 'dayjs/plugin/utc';
 import OlLayer from 'ol/layer/Layer';
 
 import { useTranslation } from 'react-i18next';
@@ -24,11 +22,11 @@ import { useTimeLayerData } from '../../hooks/useTimeLayerData';
 
 import { setModalVisible } from '../../store/timeLayerModal';
 
+import dayjs, { Dayjs } from '../../utils/dayjs';
+
 import './index.less';
 
 export type TimeLayerModalProps = Record<string, never>;
-
-dayjs.extend(utc);
 
 export const TimeLayerModal: React.FC<
   TimeLayerModalProps
@@ -95,7 +93,13 @@ export const TimeLayerModal: React.FC<
   const handleTimeChange = useCallback(
     (newTime: Dayjs | [Dayjs, Dayjs]) => {
       if (!Array.isArray(newTime)) {
-        let timeToSet = newTime;
+        const normalizedTime = dayjs.utc(newTime.valueOf());
+
+        if (!normalizedTime.isValid()) {
+          return;
+        }
+
+        let timeToSet = normalizedTime;
 
         if (availableTimePoints && availableTimePoints.length > 0) {
           const firstTimePoint = dayjs.utc(availableTimePoints[0]);
@@ -104,14 +108,14 @@ export const TimeLayerModal: React.FC<
           }
 
           let closestTime = firstTimePoint;
-          let minDiff = Math.abs(newTime.diff(closestTime));
+          let minDiff = Math.abs(normalizedTime.diff(closestTime));
 
           for (const timePoint of availableTimePoints) {
             const availableTime = dayjs.utc(timePoint);
             if (!availableTime.isValid()) {
               continue;
             }
-            const diff = Math.abs(newTime.diff(availableTime));
+            const diff = Math.abs(normalizedTime.diff(availableTime));
             if (diff < minDiff) {
               minDiff = diff;
               closestTime = availableTime;

--- a/src/components/ToolMenu/LayerTree/index.less
+++ b/src/components/ToolMenu/LayerTree/index.less
@@ -36,6 +36,14 @@
             margin-right: 8px;
           }
 
+          .time-layer-icon {
+            color: #000000;
+
+            &:hover {
+              color: #6d6d6d;
+            }
+          }
+
           .filtered-icon {
             color: #bfbfbf;
           }

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -30,7 +30,12 @@ import {
   useMap
 } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
 
+import useAppDispatch from '../../../hooks/useAppDispatch';
 import useAppSelector from '../../../hooks/useAppSelector';
+
+import {
+  openTimeLayerModal
+} from '../../../store/timeLayerModal';
 
 import TreeNodeRenderer from './TreeNodeRenderer';
 
@@ -49,6 +54,7 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
   ...restProps
 }): JSX.Element => {
   const map = useMap();
+  const dispatch = useAppDispatch();
 
   const initialLayersUid = map?.getAllLayers().map(l => getUid(l));
 
@@ -58,6 +64,11 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
   const [visibleLegendsIds, setVisibleLegendsIds] = useState<string[]>(showLegendsState ? initialLayersUid ?? [] : []);
   const [layerTileLoadCounter, setLayerTileLoadCounter] = useState<LayerTileLoadCounter>({});
   const [mapScale, setMapScale] = useState<number>();
+
+  const handleTimeModalOpen = useCallback((layer: OlLayer) => {
+    const layerId = getUid(layer);
+    dispatch(openTimeLayerModal(layerId));
+  }, [dispatch]);
 
   const registerTileLoadHandler = useCallback(() => {
     if (!map) {
@@ -227,9 +238,10 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
         legendVisible={visibleLegendsIds.includes(getUid(layer))}
         visibleLegendsIds={visibleLegendsIds}
         setVisibleLegendsIds={setVisibleLegendsIds}
+        onTimeModalOpen={handleTimeModalOpen}
       />
     );
-  }, [layerIconsVisible, layerTileLoadCounter, mapScale, visibleLegendsIds]);
+  }, [layerIconsVisible, layerTileLoadCounter, mapScale, visibleLegendsIds, handleTimeModalOpen]);
 
   if (!map) {
     return <></>;

--- a/src/components/ToolMenu/LayerTree/index.tsx
+++ b/src/components/ToolMenu/LayerTree/index.tsx
@@ -34,7 +34,8 @@ import useAppDispatch from '../../../hooks/useAppDispatch';
 import useAppSelector from '../../../hooks/useAppSelector';
 
 import {
-  openTimeLayerModal
+  setLayerId,
+  setModalVisible
 } from '../../../store/timeLayerModal';
 
 import TreeNodeRenderer from './TreeNodeRenderer';
@@ -67,7 +68,8 @@ export const LayerTree: React.FC<LayerTreeProps> = ({
 
   const handleTimeModalOpen = useCallback((layer: OlLayer) => {
     const layerId = getUid(layer);
-    dispatch(openTimeLayerModal(layerId));
+    dispatch(setLayerId(layerId));
+    dispatch(setModalVisible(true));
   }, [dispatch]);
 
   const registerTileLoadHandler = useCallback(() => {

--- a/src/hooks/useTimeLayerData.spec.ts
+++ b/src/hooks/useTimeLayerData.spec.ts
@@ -1,0 +1,163 @@
+import { renderHook } from '@testing-library/react';
+
+import type OlLayer from 'ol/layer/Layer';
+
+import { useTimeLayerData } from './useTimeLayerData';
+
+type MockLayerOptions = {
+  type?: string;
+  dimension?: {
+    name: string;
+    values: string;
+  };
+};
+
+const createMockLayer = (opts: MockLayerOptions = {}): OlLayer => {
+  const store = new Map<string, unknown>();
+
+  store.set('type', opts.type ?? 'WMSTime');
+
+  if (opts.dimension) {
+    store.set('dimension', opts.dimension);
+  }
+
+  const mockLayer = {
+    get: jest.fn((key: string) => store.get(key)),
+    set: jest.fn(),
+    getSource: jest.fn()
+  };
+
+  return mockLayer as unknown as OlLayer;
+};
+
+describe('useTimeLayerData', () => {
+  it('parses WMS time and ensures Z-format (UTC)', () => {
+    const layer = createMockLayer({
+      dimension: {
+        name: 'time',
+        values: '2026-01-01T00:00:00.000Z/2026-01-03T00:00:00.000Z/P1D'
+      }
+    });
+
+    const { result } = renderHook(() => useTimeLayerData(layer));
+
+    expect(result.current.isValidTimeLayer).toBe(true);
+    expect(result.current.minTime?.toISOString()).toBe(
+      '2026-01-01T00:00:00.000Z'
+    );
+    expect(result.current.maxTime?.toISOString()).toBe(
+      '2026-01-03T00:00:00.000Z'
+    );
+    expect(result.current.initialTime?.toISOString()).toBe(
+      '2026-01-03T00:00:00.000Z'
+    );
+
+    expect(result.current.timeAwareLayers).toHaveLength(1);
+    expect(result.current.timeAwareLayers[0].get('startDate')).toBe(
+      '2026-01-01T00:00:00.000Z'
+    );
+    expect(result.current.timeAwareLayers[0].get('endDate')).toBe(
+      '2026-01-03T00:00:00.000Z'
+    );
+    expect(result.current.timeAwareLayers[0].get('duration')).toBe('P1D');
+  });
+
+  it('parses discrete WMS time values and preserves available UTC timestamps', () => {
+    const layer = createMockLayer({
+      dimension: {
+        name: 'time',
+        values:
+          '2026-01-01T00:00:00.000Z, 2026-01-02T00:00:00.000Z, 2026-01-03T00:00:00.000Z'
+      }
+    });
+
+    const { result } = renderHook(() => useTimeLayerData(layer));
+
+    expect(result.current.isValidTimeLayer).toBe(true);
+    expect(result.current.availableTimePoints).toEqual([
+      '2026-01-01T00:00:00.000Z',
+      '2026-01-02T00:00:00.000Z',
+      '2026-01-03T00:00:00.000Z'
+    ]);
+    expect(result.current.minTime?.toISOString()).toBe(
+      '2026-01-01T00:00:00.000Z'
+    );
+    expect(result.current.maxTime?.toISOString()).toBe(
+      '2026-01-03T00:00:00.000Z'
+    );
+    expect(result.current.timeAwareLayers[0].get('duration')).toBe('P1D');
+  });
+
+  it('normalizes non-UTC layer time values to UTC output', () => {
+    const layer = createMockLayer({
+      dimension: {
+        name: 'time',
+        values: '2026-01-01T00:00:00,2026-01-02T00:00:00'
+      }
+    });
+
+    const { result } = renderHook(() => useTimeLayerData(layer));
+
+    expect(result.current.isValidTimeLayer).toBe(true);
+    expect(result.current.minTime?.toISOString()).toBe(
+      '2026-01-01T00:00:00.000Z'
+    );
+    expect(result.current.maxTime?.toISOString()).toBe(
+      '2026-01-02T00:00:00.000Z'
+    );
+    expect(result.current.timeAwareLayers[0].get('startDate')).toBe(
+      '2026-01-01T00:00:00.000Z'
+    );
+    expect(result.current.timeAwareLayers[0].get('endDate')).toBe(
+      '2026-01-02T00:00:00.000Z'
+    );
+  });
+
+  it('converts offset-based layer time values to UTC output', () => {
+    const layer = createMockLayer({
+      dimension: {
+        name: 'time',
+        values: '2026-01-01T00:00:00+01:00,2026-01-02T00:00:00+01:00'
+      }
+    });
+
+    const { result } = renderHook(() => useTimeLayerData(layer));
+
+    expect(result.current.isValidTimeLayer).toBe(true);
+    expect(result.current.minTime?.toISOString()).toBe(
+      '2025-12-31T23:00:00.000Z'
+    );
+    expect(result.current.maxTime?.toISOString()).toBe(
+      '2026-01-01T23:00:00.000Z'
+    );
+    expect(result.current.timeAwareLayers[0].get('startDate')).toBe(
+      '2025-12-31T23:00:00.000Z'
+    );
+    expect(result.current.timeAwareLayers[0].get('endDate')).toBe(
+      '2026-01-01T23:00:00.000Z'
+    );
+  });
+
+  it('returns invalid data for invalid time dimensions', () => {
+    const nonTimeLayer = createMockLayer({ type: 'WMS' });
+    const invalidTimeLayer = createMockLayer({
+      dimension: {
+        name: 'time',
+        values: 'not-a-date'
+      }
+    });
+
+    const { result: nonTimeResult } = renderHook(() =>
+      useTimeLayerData(nonTimeLayer)
+    );
+    const { result: invalidTimeResult } = renderHook(() =>
+      useTimeLayerData(invalidTimeLayer)
+    );
+
+    expect(nonTimeResult.current.isValidTimeLayer).toBe(false);
+    expect(nonTimeResult.current.timeAwareLayers).toEqual([]);
+
+    expect(invalidTimeResult.current.isValidTimeLayer).toBe(false);
+    expect(invalidTimeResult.current.timeAwareLayers).toEqual([]);
+  });
+});

--- a/src/hooks/useTimeLayerData.ts
+++ b/src/hooks/useTimeLayerData.ts
@@ -1,0 +1,220 @@
+import { useMemo } from 'react';
+
+import dayjs, { Dayjs } from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import OlLayer from 'ol/layer/Layer';
+
+import { WmsLayer } from '@terrestris/ol-util/dist/typeUtils/typeUtils';
+
+dayjs.extend(utc);
+
+export interface TimeLayerData {
+  timeAwareLayers: WmsLayer[];
+  initialTime: Dayjs | undefined;
+  minTime: Dayjs | undefined;
+  maxTime: Dayjs | undefined;
+  availableTimePoints: string[];
+  isValidTimeLayer: boolean;
+}
+
+const isTimeLayer = (layer: OlLayer): boolean => {
+  const layerType = layer.get('type');
+  return layerType === 'WMSTIME' || layerType === 'WMSTime';
+};
+
+const calculateDuration = (timeValues: string): string => {
+  const timeArray = timeValues.split(',').map(timeStr => timeStr.trim());
+
+  if (timeArray.length < 2) {
+    return 'P1D';
+  }
+
+  const firstTime = dayjs(timeArray[0]);
+  const secondTime = dayjs(timeArray[1]);
+
+  if (!firstTime.isValid() || !secondTime.isValid()) {
+    return 'P1D';
+  }
+
+  const diffInSeconds = secondTime.diff(firstTime, 'second');
+  const diffInMinutes = secondTime.diff(firstTime, 'minute');
+  const diffInHours = secondTime.diff(firstTime, 'hour');
+  const diffInDays = secondTime.diff(firstTime, 'day');
+  const diffInWeeks = secondTime.diff(firstTime, 'week');
+  const diffInMonths = secondTime.diff(firstTime, 'month');
+  const diffInYears = secondTime.diff(firstTime, 'year');
+
+  if (diffInYears >= 1) {
+    return `P${diffInYears}Y`;
+  } else if (diffInMonths >= 1) {
+    return `P${diffInMonths}M`;
+  } else if (diffInWeeks >= 1) {
+    return `P${diffInWeeks}W`;
+  } else if (diffInDays >= 1) {
+    return `P${diffInDays}D`;
+  } else if (diffInHours >= 1) {
+    return `PT${diffInHours}H`;
+  } else if (diffInMinutes >= 1) {
+    return `PT${diffInMinutes}M`;
+  } else if (diffInSeconds >= 1) {
+    return `PT${diffInSeconds}S`;
+  } else {
+    return 'P1D';
+  }
+};
+
+const parseISOTimeInterval = (timeInterval: string) => {
+  const parts = timeInterval.split('/');
+
+  if (parts.length === 3) {
+    const [startStr, endStr, periodStr] = parts;
+
+    const startTime = dayjs.utc(startStr);
+    const endTime = dayjs.utc(endStr);
+
+    if (startTime.isValid() && endTime.isValid()) {
+      return {
+        startTime,
+        endTime,
+        period: periodStr,
+        isValid: true
+      };
+    }
+  }
+
+  return {
+    startTime: undefined,
+    endTime: undefined,
+    period: undefined,
+    isValid: false
+  };
+};
+
+export const useTimeLayerData = (layer: OlLayer | null): TimeLayerData => {
+  return useMemo(() => {
+    if (!layer || !isTimeLayer(layer)) {
+      return {
+        timeAwareLayers: [],
+        initialTime: undefined,
+        minTime: undefined,
+        maxTime: undefined,
+        availableTimePoints: [],
+        isValidTimeLayer: false
+      };
+    }
+
+    const wmsLayer = layer as WmsLayer;
+    const dimension = wmsLayer.get('dimension');
+
+    let layerInitialTime: Dayjs | undefined;
+    let layerMinTime: Dayjs | undefined;
+    let layerMaxTime: Dayjs | undefined;
+    let calculatedDuration = 'P1D';
+    let timeFormat = 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]';
+    let availableTimePoints: string[] = [];
+
+    if (dimension && dimension.name === 'time' && dimension.values) {
+      const timeValues = dimension.values;
+
+      if (typeof timeValues === 'string') {
+        if (timeValues.includes('/') && timeValues.split('/').length === 3) {
+          const intervalData = parseISOTimeInterval(timeValues);
+
+          if (intervalData.isValid) {
+            layerMinTime = intervalData.startTime;
+            layerMaxTime = intervalData.endTime;
+            layerInitialTime = intervalData.endTime;
+            calculatedDuration = intervalData.period || 'P1D';
+
+            availableTimePoints = [];
+            timeFormat = 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]';
+          } else {
+            return {
+              timeAwareLayers: [],
+              initialTime: undefined,
+              minTime: undefined,
+              maxTime: undefined,
+              availableTimePoints: [],
+              isValidTimeLayer: false
+            };
+          }
+        } else {
+          const timeArray = timeValues
+            .split(',')
+            .map(timeStr => timeStr.trim());
+
+          if (timeArray.length > 0) {
+            const startDate = timeArray[0];
+            const endDate = timeArray[timeArray.length - 1];
+
+            try {
+              const startTime = dayjs.utc(startDate);
+              const endTime = dayjs.utc(endDate);
+
+              if (startTime.isValid() && endTime.isValid()) {
+                calculatedDuration = calculateDuration(timeValues);
+                availableTimePoints = timeArray;
+
+                layerMinTime = startTime;
+                layerMaxTime = endTime;
+                layerInitialTime = endTime;
+                timeFormat = 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]';
+              } else {
+                return {
+                  timeAwareLayers: [],
+                  initialTime: undefined,
+                  minTime: undefined,
+                  maxTime: undefined,
+                  availableTimePoints: [],
+                  isValidTimeLayer: false
+                };
+              }
+            } catch {
+              return {
+                timeAwareLayers: [],
+                initialTime: undefined,
+                minTime: undefined,
+                maxTime: undefined,
+                availableTimePoints: [],
+                isValidTimeLayer: false
+              };
+            }
+          }
+        }
+      }
+    }
+
+    const configuredLayer = {
+      ...wmsLayer,
+      get: (key: string) => {
+        switch (key) {
+          case 'type':
+            return 'WMSTime';
+          case 'isTimeAware':
+            return true;
+          case 'startDate':
+            return layerMinTime?.format(timeFormat);
+          case 'endDate':
+            return layerMaxTime?.format(timeFormat);
+          case 'duration':
+            return calculatedDuration;
+          case 'timeFormat':
+            return timeFormat;
+          default:
+            return wmsLayer.get(key);
+        }
+      },
+      set: wmsLayer.set.bind(wmsLayer),
+      getSource: wmsLayer.getSource.bind(wmsLayer)
+    } as WmsLayer;
+
+    return {
+      timeAwareLayers: [configuredLayer],
+      initialTime: layerInitialTime,
+      minTime: layerMinTime,
+      maxTime: layerMaxTime,
+      availableTimePoints,
+      isValidTimeLayer: true
+    };
+  }, [layer]);
+};

--- a/src/hooks/useTimeLayerData.ts
+++ b/src/hooks/useTimeLayerData.ts
@@ -10,9 +10,9 @@ dayjs.extend(utc);
 
 export interface TimeLayerData {
   timeAwareLayers: WmsLayer[];
-  initialTime: Dayjs | undefined;
-  minTime: Dayjs | undefined;
-  maxTime: Dayjs | undefined;
+  initialTime?: Dayjs;
+  minTime?: Dayjs;
+  maxTime?: Dayjs;
   availableTimePoints: string[];
   isValidTimeLayer: boolean;
 }

--- a/src/hooks/useTimeLayerData.ts
+++ b/src/hooks/useTimeLayerData.ts
@@ -1,12 +1,10 @@
 import { useMemo } from 'react';
 
-import dayjs, { Dayjs } from 'dayjs';
-import utc from 'dayjs/plugin/utc';
 import OlLayer from 'ol/layer/Layer';
 
 import { WmsLayer } from '@terrestris/ol-util/dist/typeUtils/typeUtils';
 
-dayjs.extend(utc);
+import dayjs, { Dayjs } from '../utils/dayjs';
 
 export interface TimeLayerData {
   timeAwareLayers: WmsLayer[];

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -133,7 +133,8 @@ export default {
         searchable: 'Der Inhalt dieses Layers kann im Suchfeld abgefragt werden',
         queryable: 'Der Inhalt dieses Layers kann mit dem Werkzeug \'Karteninhalte abfragen\' abgefragt werden',
         editable: 'Die Features dieses Layers sind editierbar',
-        filtered: 'Die Inhalte des Layers sind gefiltert'
+        filtered: 'Die Inhalte des Layers sind gefiltert',
+        timeLayer: 'Zeitsteuerung für diese Karte öffnen'
       },
       MapToolbar: {
         zoomInTooltip: 'Hereinzoomen',
@@ -198,6 +199,20 @@ export default {
       WmsTimeSlider: {
         title: 'Zeitlicher Bezug',
         default: 'Keine Daten gefunden'
+      },
+      TimeLayerModal: {
+        title: 'Zeitsteuerung für Karte {{layerName}}',
+        unknownLayer: 'Unbekannte Karte',
+        tooltips: {
+          dataRange: 'Zeitspanne festlegen',
+          days: 'Tage',
+          hours: 'Stunden',
+          minutes: 'Minuten',
+          months: 'Monate',
+          weeks: 'Wochen',
+          years: 'Jahre',
+          setToMostRecent: 'Auf neuestes Datum setzen'
+        }
       },
       UploadDataModal: {
         title: 'Daten hochladen',
@@ -483,7 +498,8 @@ export default {
         searchable: 'The contents of this layer can be queried in the search input',
         queryable: 'The contents of this layer can be queried in the query map features tool',
         editable: 'The features of this layer are editable',
-        filtered: 'The layer contents are filtered'
+        filtered: 'The layer contents are filtered',
+        timeLayer: 'Open time controls for this map'
       },
       MapToolbar: {
         zoomInTooltip: 'Zoom-in',
@@ -547,6 +563,20 @@ export default {
       WmsTimeSlider: {
         title: 'Time reference',
         default: 'No data found'
+      },
+      TimeLayerModal: {
+        title: 'Time controls for map {{layerName}}',
+        unknownLayer: 'Unknown map',
+        tooltips: {
+          dataRange: 'Set date range',
+          days: 'Days',
+          hours: 'Hours',
+          minutes: 'Minutes',
+          months: 'Months',
+          weeks: 'Weeks',
+          years: 'Years',
+          setToMostRecent: 'Set to most recent date'
+        }
       },
       UploadDataModal: {
         title: 'Upload data',

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -134,7 +134,7 @@ export default {
         queryable: 'Der Inhalt dieses Layers kann mit dem Werkzeug \'Karteninhalte abfragen\' abgefragt werden',
         editable: 'Die Features dieses Layers sind editierbar',
         filtered: 'Die Inhalte des Layers sind gefiltert',
-        timeLayer: 'Zeitsteuerung für diese Karte öffnen'
+        timeLayer: 'Zeitsteuerung für diesen Layer öffnen'
       },
       MapToolbar: {
         zoomInTooltip: 'Hereinzoomen',
@@ -201,8 +201,8 @@ export default {
         default: 'Keine Daten gefunden'
       },
       TimeLayerModal: {
-        title: 'Zeitsteuerung für Karte {{layerName}}',
-        unknownLayer: 'Unbekannte Karte',
+        title: 'Zeitsteuerung für Layer {{layerName}}',
+        unknownLayer: 'Unbekannter Layer',
         tooltips: {
           dataRange: 'Zeitspanne festlegen',
           days: 'Tage',
@@ -499,7 +499,7 @@ export default {
         queryable: 'The contents of this layer can be queried in the query map features tool',
         editable: 'The features of this layer are editable',
         filtered: 'The layer contents are filtered',
-        timeLayer: 'Open time controls for this map'
+        timeLayer: 'Open time controls for this layer'
       },
       MapToolbar: {
         zoomInTooltip: 'Zoom-in',
@@ -565,8 +565,8 @@ export default {
         default: 'No data found'
       },
       TimeLayerModal: {
-        title: 'Time controls for map {{layerName}}',
-        unknownLayer: 'Unknown map',
+        title: 'Time controls for layer {{layerName}}',
+        unknownLayer: 'Unknown layer',
         tooltips: {
           dataRange: 'Set date range',
           days: 'Days',

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -27,6 +27,7 @@ import searchEngines from './searchEngines';
 import searchResult from './searchResult';
 import selectedFeatures from './selectedFeatures';
 import stylingDrawerVisibility from './stylingDrawerVisibility';
+import timeLayerModal from './timeLayerModal';
 import title from './title';
 import toolMenu from './toolMenu';
 import uploadDataModal from './uploadDataModal';
@@ -59,6 +60,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     searchResult,
     selectedFeatures,
     stylingDrawerVisibility,
+    timeLayerModal,
     title,
     toolMenu,
     uploadDataModal,

--- a/src/store/timeLayerModal/index.ts
+++ b/src/store/timeLayerModal/index.ts
@@ -5,28 +5,30 @@ import {
 
 export interface TimeLayerModalState {
   layerId: string | null;
+  visible: boolean;
 }
 
 const initialState: TimeLayerModalState = {
-  layerId: null
+  layerId: null,
+  visible: false
 };
 
 export const slice = createSlice({
   name: 'timeLayerModal',
   initialState,
   reducers: {
-    openTimeLayerModal(state, action: PayloadAction<string>) {
+    setLayerId(state, action: PayloadAction<string>) {
       state.layerId = action.payload;
     },
-    closeTimeLayerModal(state) {
-      state.layerId = null;
+    setModalVisible(state, action: PayloadAction<boolean>) {
+      state.visible = action.payload;
     }
   }
 });
 
 export const {
-  openTimeLayerModal,
-  closeTimeLayerModal
+  setLayerId,
+  setModalVisible
 } = slice.actions;
 
 export default slice.reducer;

--- a/src/store/timeLayerModal/index.ts
+++ b/src/store/timeLayerModal/index.ts
@@ -1,0 +1,32 @@
+import {
+  createSlice,
+  PayloadAction
+} from '@reduxjs/toolkit';
+
+export interface TimeLayerModalState {
+  layerId: string | null;
+}
+
+const initialState: TimeLayerModalState = {
+  layerId: null
+};
+
+export const slice = createSlice({
+  name: 'timeLayerModal',
+  initialState,
+  reducers: {
+    openTimeLayerModal(state, action: PayloadAction<string>) {
+      state.layerId = action.payload;
+    },
+    closeTimeLayerModal(state) {
+      state.layerId = null;
+    }
+  }
+});
+
+export const {
+  openTimeLayerModal,
+  closeTimeLayerModal
+} = slice.actions;
+
+export default slice.reducer;

--- a/src/utils/dayjs.ts
+++ b/src/utils/dayjs.ts
@@ -1,0 +1,7 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+
+export type { Dayjs } from 'dayjs';
+export default dayjs;


### PR DESCRIPTION
This PR adds a new, collapsible and movable `TimeLayerModal` component that provides interactive time controls for  `WMSTime` layers. The main application in the background remains operable. The modal includes the time slider panel from [react-geo](https://terrestris.github.io/react-geo/docs/latest/#/Components/Panel/TimeLayerSliderPanel) that allows users to navigate through time-aware layers with support for both discrete time points and continuous ISO 8601 time intervals (e.g. `1995-01-01/2025-12-31/PT5M`).

@terrestris/devs please review

<img width="1711" height="530" alt="time_modal" src="https://github.com/user-attachments/assets/c50157f7-31d4-437b-9a81-05166babfc19" />
