### PR TITLE
feat: refactor handling of shrinked map if drawer is opened

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import EditFeatureDrawer from './components/EditFeatureDrawer';
 import Footer from './components/Footer';
 import Header from './components/Header';
 import LayerDetailsModal from './components/LayerDetailsModal';
-import MapToolbar from './components/MapToolbar';
 import SearchResultDrawer from './components/SearchResultDrawer';
 import StylingDrawer from './components/StylingDrawer';
 import ToolMenu from './components/ToolMenu';
@@ -44,7 +43,6 @@ export const App: React.FC<AppProps> = ({
       <Header />
       <BasicMapComponent />
       <ToolMenu />
-      <MapToolbar />
       <Footer />
       <CookieBanner />
       <AddLayerModal />

--- a/src/components/BasicMapComponent/index.less
+++ b/src/components/BasicMapComponent/index.less
@@ -1,4 +1,17 @@
 .map {
+  .toolbar-control {
+    top: calc(var(--headerHeight) + 10px);
+    right: 10px;
+
+    &.ol-control {
+      background-color: unset;
+
+      button {
+        height: var(--ant-control-height);
+      }
+    }
+  }
+
   .bg-layer-chooser {
     bottom: 95px;
     right: 10px;

--- a/src/components/BasicMapComponent/index.tsx
+++ b/src/components/BasicMapComponent/index.tsx
@@ -2,13 +2,17 @@ import React, {
   useEffect
 } from 'react';
 
-import { ObjectEvent as OlObjectEvent } from 'ol/Object';
+import {
+  ObjectEvent as OlObjectEvent
+} from 'ol/Object';
 
 import {
   useTranslation
 } from 'react-i18next';
 
-import { MapUtil } from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+import {
+  MapUtil
+} from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 import {
   BackgroundLayerChooser
@@ -18,7 +22,9 @@ import {
   MapComponent,
   MapComponentProps
 } from '@terrestris/react-geo/dist/Map/MapComponent/MapComponent';
-import { useMap } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
+import {
+  useMap
+} from '@terrestris/react-util/dist/Hooks/useMap/useMap';
 
 import useAppSelector from '../../hooks/useAppSelector';
 import usePlugins from '../../hooks/usePlugins';
@@ -26,6 +32,9 @@ import usePlugins from '../../hooks/usePlugins';
 import {
   isMapIntegration
 } from '../../plugin';
+
+import MapControl from '../MapControl';
+import MapToolbar from '../MapToolbar';
 
 import './index.less';
 
@@ -42,6 +51,7 @@ export const BasicMapComponent: React.FC<Partial<MapComponentProps>> = ({
 
   const blcVisible = useAppSelector(state => state.backgroundLayerChooser.visible);
   const allowEmptyBackground = useAppSelector(state => state.backgroundLayerChooser.allowEmptyBackground);
+  const mapToolbarVisible = useAppSelector(state => state.mapToolbarVisible.visible);
 
   /**
    * Updates external layer group name when language changes.
@@ -90,11 +100,22 @@ export const BasicMapComponent: React.FC<Partial<MapComponentProps>> = ({
       map={map}
       {...restProps}
     >
-      {blcVisible &&
-        <BackgroundLayerChooser
-          layers={map.getAllLayers().filter(l => l.get('isBackgroundLayer') === true).reverse()}
-          allowEmptyBackground = {allowEmptyBackground}
-        />
+      {
+        mapToolbarVisible && (
+          <MapControl
+            className="toolbar-control"
+          >
+            <MapToolbar />
+          </MapControl>
+        )
+      }
+      {
+        blcVisible && (
+          <BackgroundLayerChooser
+            layers={map.getAllLayers().filter(l => l.get('isBackgroundLayer') === true).reverse()}
+            allowEmptyBackground = {allowEmptyBackground}
+          />
+        )
       }
       {
         pluginComponents

--- a/src/components/ClassificationDrawer/index.tsx
+++ b/src/components/ClassificationDrawer/index.tsx
@@ -85,6 +85,7 @@ export const ClassificationDrawer: FC<ClassificationDrawerProps> = ({
       open={isOpen}
       maskClosable={false}
       destroyOnHidden={true}
+      shrinkMapOnOpen={false}
       mask={false}
       {...passThroughProps}
     >

--- a/src/components/EditFeatureDrawer/index.tsx
+++ b/src/components/EditFeatureDrawer/index.tsx
@@ -157,6 +157,7 @@ export const EditFeatureDrawer: React.FC<EditFeatureDrawerProps> = ({
       className="map-drawer edit-feature-drawer"
       onClose={onDrawerClose}
       open={isDrawerOpen}
+      shrinkMapOnOpen={false}
       title={drawerTitle}
       {...passThroughProps}
     >

--- a/src/components/MapControl/index.tsx
+++ b/src/components/MapControl/index.tsx
@@ -1,0 +1,48 @@
+import React, {
+  useState,
+  useEffect
+} from 'react';
+
+import {
+  Control as OlControl
+} from 'ol/control';
+
+import {
+  createPortal
+} from 'react-dom';
+
+import {
+  useMap
+} from '@terrestris/react-util/dist/Hooks/useMap/useMap';
+
+interface MapControlProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const MapControl = ({
+  className = '',
+  children
+}: MapControlProps) => {
+  const [element] = useState(() => document.createElement('div'));
+
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    element.className = `${className} ol-unselectable ol-control`.trim();
+    const control = new OlControl({ element });
+    map.addControl(control);
+
+    return () => {
+      map.removeControl(control);
+    };
+  }, [map, element, className]);
+
+  return createPortal(children, element);
+};
+
+export default MapControl;

--- a/src/components/MapDrawer/index.less
+++ b/src/components/MapDrawer/index.less
@@ -1,3 +1,19 @@
+#map {
+  transition: width 0.3s;
+
+  &.bisected {
+    width: calc(100vw - var(--drawerWidth));
+  }
+
+  .ol-control {
+    transition: right 0.3s;
+
+    &.bisected {
+      right: calc(10px + var(--drawerWidth));
+    }
+  }
+}
+
 .ant-drawer.map-drawer {
   position: absolute;
   top: var(--headerHeight);

--- a/src/components/MapDrawer/index.tsx
+++ b/src/components/MapDrawer/index.tsx
@@ -14,19 +14,30 @@ import { useMap } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
 
 import './index.less';
 
-export type MapDrawerProps = DrawerProps;
+export type MapDrawerProps = {
+  shrinkMapOnOpen?: boolean;
+  additionalMapElementClassName?: string;
+} & DrawerProps;
 
 export const MapDrawer: React.FC<MapDrawerProps> = ({
   open,
   children,
+  shrinkMapOnOpen = true,
+  additionalMapElementClassName = 'bisected',
   ...passThroughProps
 }) => {
 
   const map = useMap();
 
   useEffect(() => {
-    document.querySelectorAll('#map')[0]?.classList.toggle('bisected', !!open);
-  }, [open]);
+    if (!shrinkMapOnOpen) {
+      document.querySelectorAll('#map .ol-control')?.forEach(element => {
+        element.classList.toggle(additionalMapElementClassName, !!open);
+      });
+    } else {
+      document.querySelectorAll('#map')[0]?.classList.toggle(additionalMapElementClassName, !!open);
+    }
+  }, [open, additionalMapElementClassName, shrinkMapOnOpen]);
 
   const onAfterDrawerOpenChange = () => {
     map?.updateSize();

--- a/src/components/MapToolbar/index.less
+++ b/src/components/MapToolbar/index.less
@@ -1,14 +1,6 @@
 #map-toolbar {
-  position: absolute;
-  top: calc(var(--headerHeight) + 16px);
-  right: 10px;
-  transition: 0.3s;
   flex-direction: column;
   z-index: 1;
-
-  &.drawer-open {
-    right: calc(var(--drawerWidth) + 10px);
-  }
 
   .ant-btn {
     margin: 5px;

--- a/src/components/MapToolbar/index.tsx
+++ b/src/components/MapToolbar/index.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React, {
+  useState
+} from 'react';
 
 import {
   faPlus,
@@ -27,8 +29,9 @@ import {
   useMap
 } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
 
-import useAppSelector from '../../hooks/useAppSelector';
-import Toolbar, { ToolbarProps } from '../Toolbar';
+import Toolbar, {
+  ToolbarProps
+} from '../Toolbar';
 
 import './index.less';
 
@@ -42,14 +45,6 @@ export const MapToolbar: React.FC = (): JSX.Element => {
 
   const [geolocationButtonPressed, setGeolocationButtonPressed] = useState(false);
 
-  const mapToolbarVisible = useAppSelector(state => state.mapToolbarVisible.visible);
-
-  const stylingDrawerVisibility = useAppSelector(state => state.stylingDrawerVisibility);
-  const editFeatureDrawerOpen = useAppSelector(state => state.editFeatureDrawerOpen);
-  const searchResultDrawerOpen = useAppSelector(state => state.searchResult.drawerVisibility);
-  const drawerOpen = stylingDrawerVisibility || editFeatureDrawerOpen || searchResultDrawerOpen;
-  const className = drawerOpen ? 'drawer-open' : '';
-
   const btnTooltipProps = {
     tooltipPlacement: 'left' as TooltipPlacement,
     tooltipProps: {
@@ -58,60 +53,55 @@ export const MapToolbar: React.FC = (): JSX.Element => {
   };
 
   return (
-    <>
-      {mapToolbarVisible &&
-        <Toolbar
-          id='map-toolbar'
-          className={className}
-          alignment="vertical"
-          role="toolbar"
-        >
-          {map &&
-            <ZoomButton
-              aria-label='zoom-in'
-              tooltip={t('MapToolbar.zoomInTooltip')}
-              icon={
-                <FontAwesomeIcon
-                  icon={faPlus}
-                />
-              }
-              {...btnTooltipProps}
-            />}
-          {map &&
-            <ZoomButton
-              aria-label='zoom-out'
-              tooltip={t('MapToolbar.zoomOutTooltip')}
-              delta={-1}
-              icon={
-                <FontAwesomeIcon
-                  icon={faMinus}
-                />
-              }
-              {...btnTooltipProps}
-            />}
-          {map &&
-            <GeoLocationButton
-              aria-label='geolocation'
-              showMarker={true}
-              follow={true}
-              pressed={geolocationButtonPressed}
-              onChange={() => setGeolocationButtonPressed(!geolocationButtonPressed)}
-              tooltip={t('MapToolbar.geoLocation')}
-              icon={
-                <FontAwesomeIcon
-                  icon={faLocation}
-                />
-              }
-              pressedIcon={
-                <FontAwesomeIcon
-                  icon={faLocationPin}
-                />
-              }
-              {...btnTooltipProps}
-            />}
-        </Toolbar>
-      }
-    </>
+    <Toolbar
+      id="map-toolbar"
+      alignment="vertical"
+      role="toolbar"
+    >
+      {map &&
+        <ZoomButton
+          aria-label="zoom-in"
+          tooltip={t('MapToolbar.zoomInTooltip')}
+          icon={
+            <FontAwesomeIcon
+              icon={faPlus}
+            />
+          }
+          {...btnTooltipProps}
+        />}
+      {map &&
+        <ZoomButton
+          aria-label="zoom-out"
+          tooltip={t('MapToolbar.zoomOutTooltip')}
+          delta={-1}
+          icon={
+            <FontAwesomeIcon
+              icon={faMinus}
+            />
+          }
+          {...btnTooltipProps}
+        />}
+      {map &&
+        <GeoLocationButton
+          aria-label="geolocation"
+          showMarker={true}
+          follow={true}
+          pressed={geolocationButtonPressed}
+          onChange={() => setGeolocationButtonPressed(!geolocationButtonPressed)}
+          tooltip={t('MapToolbar.geoLocation')}
+          icon={
+            <FontAwesomeIcon
+              icon={faLocation}
+            />
+          }
+          pressedIcon={
+            <FontAwesomeIcon
+              icon={faLocationPin}
+            />
+          }
+          {...btnTooltipProps}
+        />}
+    </Toolbar>
   );
 };
 

--- a/src/components/SearchResultDrawer/index.tsx
+++ b/src/components/SearchResultDrawer/index.tsx
@@ -219,6 +219,7 @@ export const SearchResultDrawer: React.FC<SearchResultDrawerProps> = ({
       placement="right"
       onClose={onClose}
       open={isSearchResultDrawerVisible}
+      shrinkMapOnOpen={false}
       maskClosable={false}
       mask={false}
       {...passThroughProps}

--- a/src/components/StylingDrawer/index.tsx
+++ b/src/components/StylingDrawer/index.tsx
@@ -39,6 +39,7 @@ export const StylingDrawer: FC<StylingDrawerProps> = ({
       placement="right"
       onClose={onClose}
       open={isStylingDrawerVisible}
+      shrinkMapOnOpen={false}
       maskClosable={false}
       mask={false}
       {...passThroughProps}


### PR DESCRIPTION
This suggests to update the handling of an opened `MapDrawer` and how this state is applied to the map and the map controls in size of width and position respectively:

- Add a new component `MapControl` to add react components as an OpenLayers control (and thus inside the `ol-overlaycontainer-stopevent` element). 
- Wrap the existing `MapToolbar` into the `MapControl`.
- Introduce a new prop `shrinkMapOnOpen` to the `MapDrawer` deciding if the map should be shrinked the remaining application size if the drawer is being opened
  - if `true` the map div will be shrinked and all controls inside the div will be moved accordingly
  - if `false` all `ol-controls` will be positioned accordingly

This makes the behaviour a bit more predictable and easier to override in plugins.

Please review @terrestris/devs.