### PR TITLE
feat: make GeoLocation tool configurable

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -114,8 +114,9 @@ import {
   setLogoPath
 } from './store/logoPath';
 import {
+  setGeoLocationVisible,
   setMapToolbarVisible
-} from './store/mapToolbarVisible';
+} from './store/mapToolbar';
 import { setPrintApp } from './store/print';
 import {
   setSearchEngines
@@ -326,6 +327,7 @@ export const setApplicationToStore = async (application?: Application) => {
       // eslint-disable-next-line camelcase
       map_toolbar: (config) => {
         store.dispatch(setMapToolbarVisible(config?.visible));
+        store.dispatch(setGeoLocationVisible(config?.showGeolocation));
       },
       // eslint-disable-next-line camelcase
       user_menu: (config) => {

--- a/src/components/BasicMapComponent/index.tsx
+++ b/src/components/BasicMapComponent/index.tsx
@@ -1,5 +1,7 @@
 import React, {
-  useEffect
+  useEffect,
+  FC,
+  JSX
 } from 'react';
 
 import {
@@ -38,7 +40,7 @@ import MapToolbar from '../MapToolbar';
 
 import './index.less';
 
-export const BasicMapComponent: React.FC<Partial<MapComponentProps>> = ({
+export const BasicMapComponent: FC<Partial<MapComponentProps>> = ({
   ...restProps
 }): JSX.Element => {
   const map = useMap();
@@ -51,7 +53,7 @@ export const BasicMapComponent: React.FC<Partial<MapComponentProps>> = ({
 
   const blcVisible = useAppSelector(state => state.backgroundLayerChooser.visible);
   const allowEmptyBackground = useAppSelector(state => state.backgroundLayerChooser.allowEmptyBackground);
-  const mapToolbarVisible = useAppSelector(state => state.mapToolbarVisible.visible);
+  const mapToolbarVisible = useAppSelector(state => state.mapToolbar.visible);
 
   /**
    * Updates external layer group name when language changes.

--- a/src/components/MapToolbar/index.tsx
+++ b/src/components/MapToolbar/index.tsx
@@ -1,5 +1,7 @@
 import React, {
-  useState
+  useState,
+  FC,
+  JSX
 } from 'react';
 
 import {
@@ -29,6 +31,7 @@ import {
   useMap
 } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
 
+import useAppSelector from '../../hooks/useAppSelector';
 import Toolbar, {
   ToolbarProps
 } from '../Toolbar';
@@ -37,13 +40,15 @@ import './index.less';
 
 export type MapToolbarProps = React.HTMLAttributes<HTMLDivElement> & ToolbarProps;
 
-export const MapToolbar: React.FC = (): JSX.Element => {
+export const MapToolbar: FC<MapToolbarProps> = (): JSX.Element => {
   const {
     t
   } = useTranslation();
   const map = useMap();
 
   const [geolocationButtonPressed, setGeolocationButtonPressed] = useState(false);
+
+  const showGeolocation = useAppSelector(state => state.mapToolbar.showGeolocation);
 
   const btnTooltipProps = {
     tooltipPlacement: 'left' as TooltipPlacement,
@@ -81,27 +86,31 @@ export const MapToolbar: React.FC = (): JSX.Element => {
           }
           {...btnTooltipProps}
         />}
-      {map &&
-        <GeoLocationButton
-          aria-label="geolocation"
-          showMarker={true}
-          follow={true}
-          pressed={geolocationButtonPressed}
-          onChange={() => setGeolocationButtonPressed(!geolocationButtonPressed)}
-          tooltip={t('MapToolbar.geoLocation')}
-          icon={
-            <FontAwesomeIcon
-              icon={faLocation}
-            />
-          }
-          pressedIcon={
-            <FontAwesomeIcon
-              icon={faLocationPin}
-            />
-          }
-          {...btnTooltipProps}
-        />}
+      {
+        map && showGeolocation && (
+          <GeoLocationButton
+            aria-label="geolocation"
+            follow={true}
+            icon={
+              <FontAwesomeIcon
+                icon={faLocation}
+              />
+            }
+            onChange={() => setGeolocationButtonPressed(!geolocationButtonPressed)}
+            pressed={geolocationButtonPressed}
+            pressedIcon={
+              <FontAwesomeIcon
+                icon={faLocationPin}
+              />
+            }
+            showMarker={true}
+            tooltip={t('MapToolbar.geoLocation')}
+            {...btnTooltipProps}
+          />
+        )
+      }
     </Toolbar>
+
   );
 };
 

--- a/src/store/mapToolbar/index.tsx
+++ b/src/store/mapToolbar/index.tsx
@@ -4,7 +4,8 @@ import {
 } from '@reduxjs/toolkit';
 
 const initialState = {
-  visible: false
+  visible: false,
+  showGeolocation: true
 };
 
 export const slice = createSlice({
@@ -13,11 +14,15 @@ export const slice = createSlice({
   reducers: {
     setMapToolbarVisible(state, action: PayloadAction<boolean>) {
       state.visible = action.payload;
+    },
+    setGeoLocationVisible(state, action: PayloadAction<boolean>) {
+      state.showGeolocation = action.payload;
     }
   }
 });
 
 export const {
+  setGeoLocationVisible,
   setMapToolbarVisible
 } = slice.actions;
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -19,7 +19,7 @@ import layerDetailsModal from './layerDetailsModal';
 import layerTree from './layerTree';
 import legal from './legal';
 import logoPath from './logoPath';
-import mapToolbarVisible from './mapToolbarVisible';
+import mapToolbar from './mapToolbar';
 import print from './print';
 import searchEngines from './searchEngines';
 import searchResult from './searchResult';
@@ -49,7 +49,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     layerTree,
     legal,
     logoPath,
-    mapToolbarVisible,
+    mapToolbar,
     print,
     searchEngines,
     searchResult,


### PR DESCRIPTION
See title.

In `toolConfig` of app, geolocation button may be removed as follows:

```
...,
{
  "name": "map_toolbar",
  "config": {
    "visible": true,
    "showGeolocation": false
  }
},
```

**BREAKING CHANGE:** rename `mapToolbarVisible` store to `mapToolbar`

Plz review @terrestris/devs 