### PR TITLE
feat: add showSegmentLengths option to measure tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@terrestris/base-util": "^3.0.0",
         "@terrestris/mapfish-print-manager": "^16.0.2",
         "@terrestris/ol-util": "^21.3.0",
-        "@terrestris/react-geo": "^32.1.1",
+        "@terrestris/react-geo": "^32.5.0",
         "@terrestris/react-util": "^12.1.1",
         "@terrestris/shogun-e2e-tests": "^1.0.8",
         "@terrestris/shogun-util": "^10.8.1",
@@ -7373,10 +7373,9 @@
       }
     },
     "node_modules/@terrestris/react-geo": {
-      "version": "32.3.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/react-geo/-/react-geo-32.3.0.tgz",
-      "integrity": "sha512-wtonl2CzHiq/Al7Wkb4/YdkqK/OwNaDQY36sb5WxTlExIEXaknjRsW+aN7oAPSAhOzhdZqo7nj+Iknj1IA3ryA==",
-      "license": "BSD-2-Clause",
+      "version": "32.5.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/react-geo/-/react-geo-32.5.0.tgz",
+      "integrity": "sha512-CMKME8yyyYvkJpQBEOx9dW/SjLKZnZDaoUxKF37fg61X+OH3D9/6EvYg1G5S8OsM2Y685l3hodbyCd3Z+KKEEg==",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/modifiers": "^8.0.0",
@@ -7387,7 +7386,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@terrestris/base-util": "^3.0.0",
-        "@terrestris/react-util": "^12.1.1",
+        "@terrestris/react-util": "^12.3.0",
         "@types/lodash": "^4.17.4",
         "ag-grid-react": "^33.0.4",
         "dayjs": "^1.11.13",
@@ -7413,10 +7412,9 @@
       }
     },
     "node_modules/@terrestris/react-util": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/react-util/-/react-util-12.1.1.tgz",
-      "integrity": "sha512-C+ycWYHaX6qwFm0mDhXqWMkheFyLVl6zoLn0+3jGiJbItMdK/ljp/1TUAffJxWwGA6XdYkOkNhv0P838dHQWMg==",
-      "license": "BSD-2-Clause",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/react-util/-/react-util-12.3.0.tgz",
+      "integrity": "sha512-o1KDIr73XWFB1jQfoWRIudtB7v4ekS3+Fzo6bcdCJ0iHYR6Gao65hFQL+djBE/yK63rgHWgVPND+bulWHDdMNA==",
       "dependencies": {
         "@camptocamp/inkmap": "^1.4.0",
         "@terrestris/base-util": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@terrestris/base-util": "^3.0.0",
     "@terrestris/mapfish-print-manager": "^16.0.2",
     "@terrestris/ol-util": "^21.3.0",
-    "@terrestris/react-geo": "^32.1.1",
+    "@terrestris/react-geo": "^32.5.0",
     "@terrestris/react-util": "^12.1.1",
     "@terrestris/shogun-e2e-tests": "^1.0.8",
     "@terrestris/shogun-util": "^10.8.1",

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -117,6 +117,9 @@ import {
   setGeoLocationVisible,
   setMapToolbarVisible
 } from './store/mapToolbar';
+import {
+  setShowSegmentLengths
+} from './store/measure';
 import { setPrintApp } from './store/print';
 import {
   setSearchEngines
@@ -328,6 +331,9 @@ export const setApplicationToStore = async (application?: Application) => {
       map_toolbar: (config) => {
         store.dispatch(setMapToolbarVisible(config?.visible));
         store.dispatch(setGeoLocationVisible(config?.showGeolocation));
+      },
+      measure: (config) => {
+        store.dispatch(setShowSegmentLengths(config?.showSegmentLengths ?? false));
       },
       // eslint-disable-next-line camelcase
       user_menu: (config) => {

--- a/src/components/ToolMenu/Measure/index.tsx
+++ b/src/components/ToolMenu/Measure/index.tsx
@@ -29,6 +29,7 @@ import {
 } from '@terrestris/react-util/dist/Hooks/useMap/useMap';
 
 import './index.less';
+import useAppSelector from "../../../hooks/useAppSelector";
 
 interface DefaultMeasureProps {
   showMeasureDistance?: boolean;
@@ -46,6 +47,8 @@ export const Measure: FC<MeasureProps> = ({
   } = useTranslation();
 
   const map = useMap();
+
+  const showSegmentLengths = useAppSelector(state => state.measure.showSegmentLengths);
 
   const isGeodesicMeasurement = useMemo(() => {
     if (_isNil(map)) {
@@ -78,6 +81,7 @@ export const Measure: FC<MeasureProps> = ({
           measureType="line"
           type="link"
           continueLineMsg={t('Measure.clicktodrawline')}
+          showSegmentLengths={showSegmentLengths}
         >
           <FontAwesomeIcon icon={faPenRuler} />
           <span className="measure-text">{t('Measure.line')}</span>
@@ -93,6 +97,7 @@ export const Measure: FC<MeasureProps> = ({
           measureType="polygon"
           type="link"
           continuePolygonMsg={t('Measure.clicktodrawarea')}
+          showSegmentLengths={showSegmentLengths}
         >
           <FontAwesomeIcon icon={faDrawPolygon} />
           <span className="measure-text">{t('Measure.area')}</span>

--- a/src/store/measure/index.ts
+++ b/src/store/measure/index.ts
@@ -1,0 +1,28 @@
+import {
+  createSlice,
+  PayloadAction
+} from '@reduxjs/toolkit';
+
+export type MeasureState = {
+  showSegmentLengths: boolean;
+};
+
+const initialState: MeasureState = {
+  showSegmentLengths: false
+};
+
+export const measureSlice = createSlice({
+  name: 'measure',
+  initialState,
+  reducers: {
+    setShowSegmentLengths: (state, action: PayloadAction<boolean>) => {
+      state.showSegmentLengths = action.payload;
+    }
+  }
+});
+
+export const {
+  setShowSegmentLengths
+} = measureSlice.actions;
+
+export default measureSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -30,6 +30,7 @@ import toolMenu from './toolMenu';
 import uploadDataModal from './uploadDataModal';
 import user from './user';
 import userMenu from './userMenu';
+import measure from "./measure";
 
 export type AsyncReducer = Record<string, Reducer>;
 
@@ -50,6 +51,7 @@ export const createReducer = (asyncReducers?: AsyncReducer) => {
     legal,
     logoPath,
     mapToolbar,
+    measure,
     print,
     searchEngines,
     searchResult,


### PR DESCRIPTION
This adds config options for the measure tools to activate the `showSegmentLengths` mode of the measure buttons.