### PR TITLE
fix: wms version upper case

### DIFF
--- a/src/components/AddLayerModal/index.tsx
+++ b/src/components/AddLayerModal/index.tsx
@@ -75,7 +75,8 @@ export const AddLayerModal: React.FC<AddLayerModalProps> = ({
     if (!isModalVisible) {
       return;
     }
-    setSanitizedUrl(UrlUtil.createValidGetCapabilitiesRequest(url, 'WMS', version));
+    const validRequestUrl = UrlUtil.createValidGetCapabilitiesRequest(url, 'WMS', version);
+    setSanitizedUrl(validRequestUrl.replace('Version', 'VERSION'));
   }, [version, isModalVisible, url]);
 
   const onUrlChange = (evt: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
This PR changes the writting of `Version` to `VERSION` in the entered url in the `AddLayerModal`, as it is required by the [CapabilitiesUtil](https://github.com/terrestris/ol-util/blob/main/src/CapabilitiesUtil/CapabilitiesUtil.ts#L34) later on.

Please review