### PR TITLE
fix: add missing translations

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -376,6 +376,9 @@ export default {
       Draw: {
         point: 'Point',
         line: 'Line',
+        modalPromptCancelButtonText: 'Cancel',
+        modalPromptOkButtonText: 'Ok',
+        modalPromptTitle: 'Enter text',
         polygon: 'Polygon',
         circle: 'Circle',
         rectangle: 'Rectangle',


### PR DESCRIPTION
Minor fix to add missing translations for the Draw modal.

<img width="553" height="221" alt="image" src="https://github.com/user-attachments/assets/5f7154d0-f882-4b2a-b8f6-c383988bd696" />
