### PR TITLE
fix: style time slider modal

### DIFF
--- a/src/components/TimeLayerModal/index.less
+++ b/src/components/TimeLayerModal/index.less
@@ -24,6 +24,7 @@
     background-color: var(--primaryColor);
     border-top-left-radius: 8px;
     border-top-right-radius: 8px;
+    color: var(--complementaryColor);
 
     h3 {
       margin: 0;
@@ -47,9 +48,10 @@
       justify-content: center;
       width: 24px;
       height: 24px;
+      color: var(--complementaryColor);
 
       &:hover {
-        background-color: #f0f0f0;
+        background-color: var(--secondaryColor);
       }
 
       &.close-button {
@@ -84,5 +86,20 @@
 
   .time-layer-slider {
     width: 100%;
+
+    .change-datarange-button {
+      background-color: var(--primaryColor);
+      color: var(--complementaryColor);
+    }
+
+    .sync-button {
+      background-color: var(--primaryColor);
+      color: var(--complementaryColor);
+    }
+
+    .playback {
+      background-color: var(--primaryColor);
+      color: var(--complementaryColor);
+    }
   }
 }


### PR DESCRIPTION
This PR adjsuts the header and button style of the time slider modal by introducing the theme colors.
<img width="1905" height="557" alt="Shogun_Styling_TimeSlider" src="https://github.com/user-attachments/assets/e0d39fa0-7f9f-472d-a688-5d7bb61f123d" />



Please review @terrestris/devs 