### PR TITLE
Bump print-manager to 16.1.3 to fix tileSize problem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ngageoint/geopackage": "^4.2.6",
         "@reduxjs/toolkit": "^2.5.0",
         "@terrestris/base-util": "^4.0.2",
-        "@terrestris/mapfish-print-manager": "^16.0.2",
+        "@terrestris/mapfish-print-manager": "^16.1.3",
         "@terrestris/ol-util": "^21.3.0",
         "@terrestris/react-geo": "^32.5.0",
         "@terrestris/react-util": "^12.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ngageoint/geopackage": "^4.2.6",
     "@reduxjs/toolkit": "^2.5.0",
     "@terrestris/base-util": "^4.0.2",
-    "@terrestris/mapfish-print-manager": "^16.0.2",
+    "@terrestris/mapfish-print-manager": "^16.1.3",
     "@terrestris/ol-util": "^21.3.0",
     "@terrestris/react-geo": "^32.5.0",
     "@terrestris/react-util": "^12.3.0",


### PR DESCRIPTION
See title. This should include this bugfix: https://github.com/terrestris/mapfish-print-manager/pull/1201

@terrestris/devs Please review