### PR TITLE
Adds ZoomFullExtent button

### DIFF
--- a/rspack.dev.js
+++ b/rspack.dev.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
-const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
+const reactRefresh = require('@rspack/plugin-react-refresh');
+const ReactRefreshPlugin = reactRefresh.ReactRefreshRspackPlugin || reactRefresh.default || reactRefresh;
 const { merge } = require('webpack-merge');
 
 const common = require('./rspack.common.js');

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -123,6 +123,7 @@ import {
 } from './store/logoPath';
 import {
   setGeoLocationVisible,
+  setZoomFullExtentVisible,
   setMapToolbarVisible
 } from './store/mapToolbar';
 import {
@@ -345,6 +346,7 @@ export const setApplicationToStore = async (application?: Application) => {
       map_toolbar: (config) => {
         store.dispatch(setMapToolbarVisible(config?.visible));
         store.dispatch(setGeoLocationVisible(config?.showGeolocation));
+        store.dispatch(setZoomFullExtentVisible(config?.showZoomFullExtent));
       },
       // eslint-disable-next-line camelcase
       measure_tools: (config) => {

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -123,6 +123,7 @@ import {
 } from './store/logoPath';
 import {
   setGeoLocationVisible,
+  setZoomFullExtentTarget,
   setZoomFullExtentVisible,
   setMapToolbarVisible
 } from './store/mapToolbar';
@@ -310,6 +311,11 @@ export const setApplicationToStore = async (application?: Application) => {
   if (application?.clientConfig?.newsTextIds) {
     store.dispatch(setNewsText(application.clientConfig.newsTextIds));
   }
+
+  store.dispatch(setZoomFullExtentTarget({
+    center: application.clientConfig?.mapView?.center,
+    zoom: application.clientConfig?.mapView?.zoom
+  }));
 
   // nominatim search is active by default
   store.dispatch(setSearchEngines(['nominatim']));

--- a/src/components/MapToolbar/index.tsx
+++ b/src/components/MapToolbar/index.tsx
@@ -8,6 +8,7 @@ import {
   faPlus,
   faMinus,
   faLocation,
+  faGlobe,
   faLocationPin
 } from '@fortawesome/free-solid-svg-icons';
 
@@ -26,6 +27,7 @@ import {
   GeoLocationButton
 } from '@terrestris/react-geo/dist/Button/GeoLocationButton/GeoLocationButton';
 import ZoomButton from '@terrestris/react-geo/dist/Button/ZoomButton/ZoomButton';
+import ZoomToExtentButton from '@terrestris/react-geo/dist/Button/ZoomToExtentButton/ZoomToExtentButton';
 
 import {
   useMap
@@ -49,6 +51,7 @@ export const MapToolbar: FC<MapToolbarProps> = (): JSX.Element => {
   const [geolocationButtonPressed, setGeolocationButtonPressed] = useState(false);
 
   const showGeolocation = useAppSelector(state => state.mapToolbar.showGeolocation);
+  const showZoomFullExtent = useAppSelector(state => state.mapToolbar.showZoomFullExtent);
 
   const btnTooltipProps = {
     tooltipPlacement: 'left' as TooltipPlacement,
@@ -57,12 +60,28 @@ export const MapToolbar: FC<MapToolbarProps> = (): JSX.Element => {
     }
   };
 
+  const initialCenter = map?.getView().getCenter();
+  const initialZoom = map?.getView().getZoom();
+
   return (
     <Toolbar
       id="map-toolbar"
       alignment="vertical"
       role="toolbar"
     >
+      {map && showZoomFullExtent && initialCenter && Number.isFinite(initialZoom) &&
+        <ZoomToExtentButton
+          aria-label="zoom-to-full-extent"
+          tooltip={t('MapToolbar.zoomToExtentTooltip')}
+          center={initialCenter}
+          zoom={initialZoom as number}
+          icon={
+            <FontAwesomeIcon
+              icon={faGlobe}
+            />
+          }
+          {...btnTooltipProps}
+        />}
       {map &&
         <ZoomButton
           aria-label="zoom-in"

--- a/src/components/MapToolbar/index.tsx
+++ b/src/components/MapToolbar/index.tsx
@@ -22,6 +22,7 @@ import {
 import {
   useTranslation
 } from 'react-i18next';
+import { fromLonLat } from 'ol/proj';
 
 import {
   GeoLocationButton
@@ -52,6 +53,8 @@ export const MapToolbar: FC<MapToolbarProps> = (): JSX.Element => {
 
   const showGeolocation = useAppSelector(state => state.mapToolbar.showGeolocation);
   const showZoomFullExtent = useAppSelector(state => state.mapToolbar.showZoomFullExtent);
+  const zoomFullExtentCenter = useAppSelector(state => state.mapToolbar.zoomFullExtentCenter);
+  const zoomFullExtentLevel = useAppSelector(state => state.mapToolbar.zoomFullExtentLevel);
 
   const btnTooltipProps = {
     tooltipPlacement: 'left' as TooltipPlacement,
@@ -60,8 +63,9 @@ export const MapToolbar: FC<MapToolbarProps> = (): JSX.Element => {
     }
   };
 
-  const initialCenter = map?.getView().getCenter();
-  const initialZoom = map?.getView().getZoom();
+  const zoomToExtentCenter = map && zoomFullExtentCenter
+    ? fromLonLat(zoomFullExtentCenter, map.getView().getProjection())
+    : undefined;
 
   return (
     <Toolbar
@@ -69,12 +73,12 @@ export const MapToolbar: FC<MapToolbarProps> = (): JSX.Element => {
       alignment="vertical"
       role="toolbar"
     >
-      {map && showZoomFullExtent && initialCenter && Number.isFinite(initialZoom) &&
+      {map && showZoomFullExtent && zoomToExtentCenter && Number.isFinite(zoomFullExtentLevel) &&
         <ZoomToExtentButton
           aria-label="zoom-to-full-extent"
           tooltip={t('MapToolbar.zoomToExtentTooltip')}
-          center={initialCenter}
-          zoom={initialZoom as number}
+          center={zoomToExtentCenter}
+          zoom={zoomFullExtentLevel as number}
           icon={
             <FontAwesomeIcon
               icon={faGlobe}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -139,6 +139,7 @@ export default {
       MapToolbar: {
         zoomInTooltip: 'Hereinzoomen',
         zoomOutTooltip: 'Herauszoomen',
+        zoomToExtentTooltip: 'Auf Startansicht zoomen',
         geoLocation: 'Geolokalisierung'
       },
       PrintForm: {
@@ -507,6 +508,7 @@ export default {
       MapToolbar: {
         zoomInTooltip: 'Zoom-in',
         zoomOutTooltip: 'Zoom-out',
+        zoomToExtentTooltip: 'Zoom to initial view',
         geoLocation: 'Geolocation'
       },
       PrintForm: {

--- a/src/store/mapToolbar/index.tsx
+++ b/src/store/mapToolbar/index.tsx
@@ -6,7 +6,9 @@ import {
 const initialState = {
   visible: false,
   showGeolocation: true,
-  showZoomFullExtent: true
+  showZoomFullExtent: false,
+  zoomFullExtentCenter: undefined as [number, number] | undefined,
+  zoomFullExtentLevel: undefined as number | undefined
 };
 
 export const slice = createSlice({
@@ -21,12 +23,20 @@ export const slice = createSlice({
     },
     setZoomFullExtentVisible(state, action: PayloadAction<boolean>) {
       state.showZoomFullExtent = action.payload;
+    },
+    setZoomFullExtentTarget(state, action: PayloadAction<{
+      center?: [number, number];
+      zoom?: number;
+    }>) {
+      state.zoomFullExtentCenter = action.payload.center;
+      state.zoomFullExtentLevel = action.payload.zoom;
     }
   }
 });
 
 export const {
   setGeoLocationVisible,
+  setZoomFullExtentTarget,
   setZoomFullExtentVisible,
   setMapToolbarVisible
 } = slice.actions;

--- a/src/store/mapToolbar/index.tsx
+++ b/src/store/mapToolbar/index.tsx
@@ -5,7 +5,8 @@ import {
 
 const initialState = {
   visible: false,
-  showGeolocation: true
+  showGeolocation: true,
+  showZoomFullExtent: true
 };
 
 export const slice = createSlice({
@@ -17,12 +18,16 @@ export const slice = createSlice({
     },
     setGeoLocationVisible(state, action: PayloadAction<boolean>) {
       state.showGeolocation = action.payload;
+    },
+    setZoomFullExtentVisible(state, action: PayloadAction<boolean>) {
+      state.showZoomFullExtent = action.payload;
     }
   }
 });
 
 export const {
   setGeoLocationVisible,
+  setZoomFullExtentVisible,
   setMapToolbarVisible
 } = slice.actions;
 


### PR DESCRIPTION
This PR 

- adds support for a configurable `ZoomToExtentButton` in the map_toolbar made via the Tool Configuration of the shogun admin:

  `showZoomFullExtent: true` -> button is visible
  `showZoomFullExtent: false` or omitted -> button is hidden (default)
- fixes rspack dev startup by making React Refresh plugin import compatible with current `@rspack/plugin-react-refresh` exports. This resolves "ReactRefreshPlugin is not a constructor".

@terrestris/devs please review