### PR TITLE
Make exclusiveTools configurable

### DIFF
--- a/resources/config/gis-client-config.js
+++ b/resources/config/gis-client-config.js
@@ -40,5 +40,12 @@ var clientConfig = {
   },
   wfsLockFeatureEnabled: false,
   documentationButtonVisible: true,
-  enableFallbackConfig: true
+  enableFallbackConfig: true,
+  exclusiveTools: [
+    'print',
+    'measure_tools',
+    'draw_tools',
+    'feature_info',
+    'tree'
+  ]
 };

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -161,7 +161,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
   }, [menuTools, availableTools]);
 
   useEffect(() => {
-    const exclusiveTools = [
+    const exclusiveTools = ClientConfiguration.exclusiveTools ?? [
       'print',
       'measure_tools',
       'draw_tools',

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -59,6 +59,7 @@ declare module 'clientConfig' {
     staticAppConfigUrl?: string;
     layerConfigUrl?: string;
     logoLinkUrl?: string;
+    exclusiveTools?: string[];
   };
   const config: ClientConfiguration;
 


### PR DESCRIPTION
This allows to configure `exclusiveTools` via `ClientConfiguration`. That's useful if you want some tools to be active simultaneously.

@terrestris/devs Please review.