### PR TITLE
Add active tools management in application store

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -146,6 +146,7 @@ import {
   setTitle
 } from './store/title';
 import {
+  setActiveKeys,
   setAvailableTools,
   setToolMenuWidth
 } from './store/toolMenu';
@@ -322,6 +323,7 @@ export const setApplicationToStore = async (application?: Application) => {
 
   if (application.toolConfig?.length) {
     const availableTools: string[] = [];
+    const activeTools: string[] = [];
     const toolActions: Record<string, (config: any) => void> = {
       search: (config) => {
         if (config.engines?.length) {
@@ -376,10 +378,14 @@ export const setApplicationToStore = async (application?: Application) => {
       if (config?.visible && !['search', 'user_menu', 'map_toolbar'].includes(name)) {
         availableTools.push(name);
       }
+      if (config?.active && config?.visible && !['search', 'user_menu', 'map_toolbar'].includes(name)) {
+        activeTools.push(name);
+      }
       toolActions[name]?.(config);
     });
 
     store.dispatch(setAvailableTools(availableTools));
+    store.dispatch(setActiveKeys(activeTools));
   }
 };
 


### PR DESCRIPTION
This PR fixes the initial `ToolMenu` state by applying `application.toolConfig[].config.active` during bootstrap.

Previously, tool visibility from app config was respected, but `active: true` was ignored on startup.
As a result, tools had to be opened manually by users even when configured as `active`.

@terrestris/devs please review