### PR TITLE
Enable tracking for GeoLocationButton

### DIFF
--- a/src/components/MapToolbar/index.tsx
+++ b/src/components/MapToolbar/index.tsx
@@ -114,6 +114,7 @@ export const MapToolbar: FC<MapToolbarProps> = (): JSX.Element => {
           <GeoLocationButton
             aria-label="geolocation"
             follow={true}
+            enableTracking={true}
             icon={
               <FontAwesomeIcon
                 icon={faLocation}


### PR DESCRIPTION
This PR fixes the `GeoLocationButton` in the `MapToolbar`.

The button was rendered and its pressed state changed visually, but geolocation tracking was not started. As a result, the browser did not request location access and no position update was triggered.

@terrestris/devs pleae review