### PR TITLE
test: update e2e-tests

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -73,7 +73,7 @@ jobs:
           file: Dockerfile.e2e
           context: .
           tags: |
-            ${{ env.DOCKER_REGISTRY }}/shogun-gis-client-client-e2e-tests:latest
+            ${{ env.DOCKER_REGISTRY }}/shogun-gis-client-e2e-tests:latest
           load: true
 
       - name: Build docker image e2e-tests (version) 🏗️
@@ -83,7 +83,7 @@ jobs:
           file: Dockerfile.e2e
           context: .
           tags: |
-            ${{ env.DOCKER_REGISTRY }}/shogun-gis-client-client-e2e-tests:${{ inputs.release_version }}
+            ${{ env.DOCKER_REGISTRY }}/shogun-gis-client-e2e-tests:${{ inputs.release_version }}
           load: true
 
       - name: Push e2e-tests docker image to Docker registry (latest) 📠

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -12,3 +12,6 @@ COPY playwright.config.js ./
 COPY global-setup.ts ./
 COPY ./src/e2e-tests ./src/e2e-tests
 COPY ./playwright ./playwright
+
+CMD [ "npm", "run", "e2e-tests" ]
+

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -1,7 +1,15 @@
-// this is needed for playwright to access the .env file
-import 'dotenv/config';
+import {
+    chromium, FullConfig
+} from '@playwright/test';
 
-async function globalSetup() {
+async function globalSetup(config: FullConfig) {
+    process.env.ID = '21';
+    process.env.HOST = 'https://shogun.intranet.terrestris.de';
+    process.env.ADMIN_LOGIN = 'shogun';
+    process.env.ADMIN_PASSWORD = 'shogun';
 }
 
+
+
 export default globalSetup;
+

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -3,10 +3,10 @@ import {
 } from '@playwright/test';
 
 const DEFAULT_HOST = 'https://localhost:8080';
-
+const DEFAULT_ID = '21';
 
 async function globalSetup(config: FullConfig) {
-    process.env.ID = '21';
+    process.env.ID = process.env.ID ?? DEFAULT_ID;
     process.env.HOST = process.env.HOST ?? DEFAULT_HOST;
     process.env.ADMIN_LOGIN =  process.env.ADMIN_LOGIN;
     process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -2,11 +2,14 @@ import {
     chromium, FullConfig
 } from '@playwright/test';
 
+const DEFAULT_HOST = 'https://localhost:8080';
+
+
 async function globalSetup(config: FullConfig) {
     process.env.ID = '21';
-    process.env.HOST = 'https://shogun.intranet.terrestris.de';
-    process.env.ADMIN_LOGIN = 'shogun';
-    process.env.ADMIN_PASSWORD = 'shogun';
+    process.env.HOST = process.env.HOST ?? DEFAULT_HOST;
+    process.env.ADMIN_LOGIN =  process.env.ADMIN_LOGIN;
+    process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
 }
 
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "prepare": "husky",
     "start": "rspack serve --config rspack.dev.js",
     "test": "jest --maxWorkers=50% --coverage",
+    "e2e-tests": "npx playwright test",
     "tsc": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "watch:buildto": "node watchBuild.js"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,49 +1,58 @@
-import {
-  defineConfig
-} from '@playwright/test';
+import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  globalSetup: './global-setup',
-  testDir: './src/e2e-tests',
-  snapshotPathTemplate: './e2e-tests/additional-files/screenshots/{arg}{ext}',
-  timeout: 30 * 1000,
+  globalSetup: require.resolve("./global-setup.ts"),
+  testDir: "./src/e2e-tests",
+  snapshotPathTemplate: "./e2e-tests/additional-files/screenshots/{arg}{ext}",
+  timeout: 120 * 1000,
   expect: {
-    timeout: 5000
+    timeout: 120 * 1000,
   },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: 4,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: [['html', {
-    open: 'never'
-  }]],
+  retries: 0,
+  workers: 1,
+  reporter: [
+    [
+      "html",
+      {
+        open: "never",
+      },
+    ],
+  ],
   use: {
-    baseURL: `https://${process.env.HOST}`,
+    headless: false,
+    // launchOptions: {
+    //   slowMo: 300
+    // },
+    // video: 'on',
+    baseURL: process.env.HOST,
     actionTimeout: 0,
-    trace: 'on-first-retry',
-    permissions: ['geolocation'],
+    trace: "on-first-retry",
+    permissions: ["geolocation"],
 
     ignoreHTTPSErrors: true,
 
     viewport: {
       width: 1200,
-      height: 800
+      height: 800,
     }
   },
-
   projects: [
     {
-      name: 'setup',
-      testMatch: /auth.setup\.ts/
+      name: "setup",
+      testMatch: /.*\.setup\.ts/,
     },
     {
-      name: 'chromium',
+      name: "chromium",
       use: {
-        browserName: 'chromium',
-        locale: 'en-EN'
+        browserName: "chromium",
+        locale: "en-EN",
+        viewport: { width: 1400, height: 850 },
+        storageState: "playwright/.auth/admin.json",
       },
-      dependencies: ['setup']
-    }
+      dependencies: ["setup"],
+    },
 
     // {
     //   name: 'firefox',
@@ -65,5 +74,5 @@ export default defineConfig({
   ],
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
-  outputDir: './src/e2e-tests/test-results/'
+  outputDir: "./src/e2e-tests/test-results/",
 });

--- a/src/e2e-tests/auth.setup.ts
+++ b/src/e2e-tests/auth.setup.ts
@@ -6,21 +6,24 @@ const adminFile = 'playwright/.auth/admin.json';
 
 setup('authenticate as admin', async ({ page }) => {
 
-  await page.goto(`https://${process.env.HOST}/auth/realms/SHOGun`
-    + '/protocol/openid-connect/auth?client_id=shogun-client'
-    + `&redirect_uri=https%3A%2F%2F${process.env.HOST}%2Fclient%2F%3FapplicationId%3D${process.env.ID}`
-    + '&state=9a983abe-3b0c-41cb-9b7e-1d9120956959&response_mode=fragment&response_type'
-    + '=code&scope=openid&nonce=72884466-0535-4a24-8c15-9e7f14d88a65');
+  await page.goto(`/admin`);
 
-  await page.getByLabel('Username or email').fill(`${process.env.ADMIN_LOGIN}`);
-  await page.getByLabel('Password', { exact: true }).fill(`${process.env.ADMIN_PASSWORD}`);
-  await page.getByRole('button', {
-    name: 'Sign in'
-  }).click();
-  // Save signed-in state to 'storageState.json'.
-  await page.context().storageState({
-    path: adminFile
-  });
+  if (await page.getByLabel('Username or email').isVisible()) {
+    await page.getByLabel('Username or email').fill(`${process.env.ADMIN_LOGIN}`);
+    await page.getByLabel('Password', { exact: true }).fill(`${process.env.ADMIN_PASSWORD}`);
+    await page.getByRole('button', {
+      name: 'Sign in'
+    }).click();
+
+    await page.waitForURL(`/admin/**`, { timeout: 15000 });
+    await page.waitForLoadState('networkidle');
+
+    await page.waitForSelector('.header-logo');
+
+    await page.context().storageState({
+      path: adminFile
+    });
+  }
 });
 
 // More Users can be added here

--- a/src/e2e-tests/auth.setup.ts
+++ b/src/e2e-tests/auth.setup.ts
@@ -6,7 +6,7 @@ const adminFile = 'playwright/.auth/admin.json';
 
 setup('authenticate as admin', async ({ page }) => {
 
-  await page.goto(`/admin`);
+  await page.goto('/admin');
 
   if (await page.getByLabel('Username or email').isVisible()) {
     await page.getByLabel('Username or email').fill(`${process.env.ADMIN_LOGIN}`);
@@ -15,7 +15,7 @@ setup('authenticate as admin', async ({ page }) => {
       name: 'Sign in'
     }).click();
 
-    await page.waitForURL(`/admin/**`, { timeout: 15000 });
+    await page.waitForURL('/admin/**', { timeout: 15000 });
     await page.waitForLoadState('networkidle');
 
     await page.waitForSelector('.header-logo');

--- a/src/e2e-tests/draw-annotation.spec.ts
+++ b/src/e2e-tests/draw-annotation.spec.ts
@@ -1,18 +1,73 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { annotations } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/annotation';
+import {
+  closeWelcomeScreen,
+  highlight,
+  switchLanguage
+} from './helpers';
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
 });
 
+const annotations = async (page: any, workerInfo: any) => {
+  await page.getByRole('button', { name: 'Anmerkung' }).click();
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-annotation-'
+      + workerInfo.project.name + '-linux.png'
+  });
+  await page.mouse.click(500, 300, { delay: 500 });
+  await expect(page.getByRole('dialog').filter({ hasText: 'Text eingeben' })).toBeVisible();
+  await highlight(page.getByRole('dialog').filter({ hasText: 'Text eingeben' }));
+  await expect(page.getByRole('button').filter({ hasText: 'Ok' })).toBeVisible();
+  await highlight(page.getByRole('button').filter({ hasText: 'Ok' }));
+  await expect(page.getByRole('button').filter({ hasText: 'Abbrechen' })).toBeVisible();
+  await highlight(page.getByRole('button').filter({ hasText: 'Abbrechen' }));
+
+  (await page.waitForSelector('.ant-input')).fill('test');
+
+  await page.getByRole('button').filter({ hasText: 'Ok' }).click();
+  await expect(page).not.toHaveScreenshot('draw-annotation-'
+    + workerInfo.project.name
+    + '-linux.png');
+
+  page.reload();
+  await closeWelcomeScreen(page);
+  await page.waitForLoadState('networkidle');
+  await page.getByRole('button', { name: 'Zeichnen' }).click();
+  await page.getByRole('button', { name: 'Anmerkung' }).click();
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-annotation-'
+      + workerInfo.project.name + '-linux.png'
+  });
+  await page.mouse.click(500, 300, { delay: 500 });
+  await expect(page.getByRole('dialog').filter({ hasText: 'Text eingeben' })).toBeVisible();
+  await highlight(page.getByRole('dialog').filter({ hasText: 'Text eingeben' }));
+  await expect(page.getByRole('button').filter({ hasText: 'Ok' })).toBeVisible();
+  await highlight(page.getByRole('button').filter({ hasText: 'Ok' }));
+  await expect(page.getByRole('button').filter({ hasText: 'Abbrechen' })).toBeVisible();
+  await highlight(page.getByRole('button').filter({ hasText: 'Abbrechen' }));
+
+  (await page.waitForSelector('.ant-input')).fill('test');
+
+  await page.getByRole('button').filter({ hasText: 'Abbrechen' }).click();
+  await expect(page).not.toHaveScreenshot('draw-annotation-'
+    + workerInfo.project.name
+    + '-linux.png');
+};
+
 test('draw-annotation', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
-  await page.getByRole('button', { name: 'Draw' }).click();
+  await switchLanguage(page, 'DE');
+  await page.getByRole('button', { name: 'Zeichnen' }).click();
   await annotations(page, workerInfo);
 });

--- a/src/e2e-tests/draw.spec.ts
+++ b/src/e2e-tests/draw.spec.ts
@@ -1,17 +1,66 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { draw } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/draw';
+import {
+  closeWelcomeScreen,
+  highlight,
+  switchLanguage
+} from './helpers';
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
 });
 
+export const draw = async (page: any) => {
+  await expect(page.getByRole('button', { name: 'Point' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Point' }));
+  await expect(page.getByRole('button', { name: 'Line' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Line' }));
+  await expect(page.getByRole('button', { name: 'Polygon' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Polygon' }));
+  await expect(page.getByRole('button', { name: 'Circle' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Circle' }));
+  await expect(page.getByRole('button', { name: 'Rectangle' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Rectangle' }));
+  await expect(page.getByRole('button', { name: 'Annotation' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Annotation' }));
+  await expect(page.getByRole('button', { name: 'Edit' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Edit' }));
+  await expect(page.getByRole('button', { name: 'Upload' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Upload' }));
+  await expect(page.getByRole('button', {
+    name: 'Export',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', {
+    name: 'Export',
+    exact: true
+  }));
+  await expect(page.getByRole('button', {
+    name: 'Delete',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', {
+    name: 'Delete',
+    exact: true
+  }));
+  await expect(page.getByRole('button', { name: 'Delete all' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Delete all' }));
+  await expect(page.getByRole('button', { name: 'Open color palette' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Open color palette' }));
+};
+
 test('draw', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
-  await page.getByRole('button', {name: 'draw'}).click();
+  await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
+  await page.getByRole('button', { name: 'draw' }).click();
   await draw(page);
 });

--- a/src/e2e-tests/drawCircle.spec.ts
+++ b/src/e2e-tests/drawCircle.spec.ts
@@ -1,6 +1,26 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { drawCircle } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/drawCircle';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
+
+export const drawCircle = async (page: any, workerInfo: any) => {
+  await page.getByRole('button', { name: 'Circle' }).click();
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-circle-'
+      + workerInfo.project.name + '-linux.png'
+  });
+  await page.mouse.click(500, 300, { delay: 500 });
+  await page.mouse.click(500, 500, { delay: 500 });
+
+  await expect(page).not.toHaveScreenshot('draw-circle-'
+    + workerInfo.project.name
+    + '-linux.png');
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +30,11 @@ test('draw-circle', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
-  await page.getByRole('button', { name: 'Draw' }).click();
+  await switchLanguage(page, 'EN');
+  await page.getByText('Draw').click();
   await drawCircle(page, workerInfo);
 });

--- a/src/e2e-tests/drawDelete.spec.ts
+++ b/src/e2e-tests/drawDelete.spec.ts
@@ -1,6 +1,30 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { drawDelete } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/drawDelete';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
+
+export const drawDelete = async (page: any, workerInfo: any) => {
+  // add point to map
+  await page.getByRole('button', { name: 'Point' }).click();
+  await page.mouse.click(500, 300, { delay: 500 });
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-delete-'
+      + workerInfo.project.name + '-linux.png'
+  });
+
+  // delete point
+  await page.getByRole('button', { name: 'Delete all' }).click({ delay: 1000 });
+  await page.mouse.click(500, 300, { delay: 500 });
+
+  await expect(page).not.toHaveScreenshot('draw-delete-'
+    + workerInfo.project.name
+    + '-linux.png', { maxDiffPixels: 100 });
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +34,11 @@ test('draw-delete', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
-  await page.getByRole('button', { name: 'Draw' }).click();
+  await switchLanguage(page, 'EN');
+  await page.getByText('Draw').click();
   await drawDelete(page, workerInfo);
 });

--- a/src/e2e-tests/drawEdit.spec.ts
+++ b/src/e2e-tests/drawEdit.spec.ts
@@ -1,6 +1,40 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { drawEdit } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/drawEdit';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
+
+export const drawEdit = async (page: any, workerInfo: any) => {
+  function timeout(ms: any) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+  // add point to map
+  await page.getByRole('button', { name: 'Point' }).click();
+  await page.mouse.click(500, 300, { delay: 500 });
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-edit-'
+      + workerInfo.project.name + '-linux.png'
+  });
+
+  // modify point
+  await page.getByRole('button', { name: 'Edit' }).click({ delay: 1000 });
+  await page.mouse.click(500, 300, { delay: 500 });
+
+  await timeout(500);
+  await page.mouse.move(500, 300);
+  await page.mouse.down();
+  await page.mouse.move(500, 400, { steps: 5 });
+  await page.mouse.up();
+  await page.mouse.click(500, 300, { delay: 500 });
+
+  await expect(page).not.toHaveScreenshot('draw-edit-'
+    + workerInfo.project.name
+    + '-linux.png', { maxDiffPixels: 100 });
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +44,11 @@ test('draw-edit', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Draw' }).click();
   await drawEdit(page, workerInfo);
 });

--- a/src/e2e-tests/drawExport.spec.ts
+++ b/src/e2e-tests/drawExport.spec.ts
@@ -1,6 +1,51 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { drawExport } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/drawExport';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
+
+export const drawExport = async (page: any, workerInfo: any) => {
+  await page.getByRole('button', { name: 'Rectangle' }).click();
+  await page.mouse.click(500, 300, { delay: 500 });
+  await page.mouse.click(400, 500, { delay: 500 });
+  await page.getByRole('button', { name: 'Rectangle' }).click();
+
+  await page.waitForLoadState('networkidle');
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-export-'
+      + workerInfo.project.name + '-linux.png'
+  });
+
+  // Export file
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', {
+    name: 'Export',
+    exact: true
+  }).click();
+  const download = await downloadPromise;
+  // console.log(await download.path());
+  await download.saveAs('./additional-files/download-example.geojson');
+
+  await page.reload();
+  await closeWelcomeScreen(page);
+  await page.waitForLoadState('networkidle');
+  await page.getByRole('button', { name: 'Draw' }).click();
+  await page.getByRole('button', { name: 'Upload' }).click();
+
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.getByText('Click or drag file to this').click()
+  ]);
+
+  await fileChooser.setFiles('./additional-files/download-example.geojson');
+  await expect(page).toHaveScreenshot('draw-export-'
+    + workerInfo.project.name
+    + '-linux.png', { maxDiffPixelRatio: 0.04 });
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +55,11 @@ test('draw-export', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Draw' }).click();
   await drawExport(page, workerInfo);
 });

--- a/src/e2e-tests/drawLine.spec.ts
+++ b/src/e2e-tests/drawLine.spec.ts
@@ -1,6 +1,26 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { drawLine } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/drawLine';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
+
+export const drawLine = async (page: any, workerInfo: any) => {
+  await page.getByRole('button', { name: 'Line' }).click();
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-line-'
+      + workerInfo.project.name + '-linux.png'
+  });
+  await page.mouse.click(500, 300, { delay: 500 });
+  await page.mouse.dblclick(500, 500, { delay: 500 });
+
+  await expect(page).not.toHaveScreenshot('draw-line-'
+    + workerInfo.project.name
+    + '-linux.png');
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +30,11 @@ test('draw-line', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Draw' }).click();
   await drawLine(page, workerInfo);
 });

--- a/src/e2e-tests/drawModifyColorScheme.spec.ts
+++ b/src/e2e-tests/drawModifyColorScheme.spec.ts
@@ -1,6 +1,19 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { drawModifyColorScheme } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/drawModifyColorScheme';
+import {
+  closeWelcomeScreen,
+  highlight,
+  switchLanguage
+} from './helpers';
+
+export const drawModifyColorScheme = async (page: any) => {
+  await page.getByRole('button', { name: 'Open color palette' }).click();
+  await expect(page.getByRole('dialog').filter({ hasText: 'Style' })).toBeVisible();
+  await highlight(page.getByRole('dialog').filter({ hasText: 'Style' }));
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +23,11 @@ test('draw-modify', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Draw' }).click();
   await drawModifyColorScheme(page);
 });

--- a/src/e2e-tests/drawPoint.spec.ts
+++ b/src/e2e-tests/drawPoint.spec.ts
@@ -1,6 +1,25 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { drawPoint } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/drawPoint';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
+
+export const drawPoint = async (page: any, workerInfo: any) => {
+  await page.getByRole('button', { name: 'Point' }).click();
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-point-'
+      + workerInfo.project.name + '-linux.png'
+  });
+  await page.mouse.click(500, 300, { delay: 2000 });
+
+  await expect(page).not.toHaveScreenshot('draw-point-'
+    + workerInfo.project.name
+    + '-linux.png');
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +29,11 @@ test('draw-point', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Draw' }).click();
   await drawPoint(page, workerInfo);
 });

--- a/src/e2e-tests/drawPolygon.spec.ts
+++ b/src/e2e-tests/drawPolygon.spec.ts
@@ -1,6 +1,31 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { drawPolygon } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/drawPolygon';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
+
+export const drawPolygon = async (page: any, workerInfo: any) => {
+  await page.getByRole('button', { name: 'Polygon' }).click();
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-polygon-'
+      + workerInfo.project.name + '-linux.png'
+  });
+
+  await page.mouse.move(500, 300);
+  await page.mouse.click(500, 300);
+  await page.mouse.move(400, 300);
+  await page.mouse.click(400, 300);
+  await page.mouse.move(500, 500);
+  await page.mouse.click(500, 500);
+
+  await expect(page).not.toHaveScreenshot('draw-polygon-'
+    + workerInfo.project.name
+    + '-linux.png');
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +35,11 @@ test('draw-polygon', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Draw' }).click();
   await drawPolygon(page, workerInfo);
 });

--- a/src/e2e-tests/drawRectangle.spec.ts
+++ b/src/e2e-tests/drawRectangle.spec.ts
@@ -1,6 +1,29 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { drawRectangle } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/drawRectangle';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
+
+export const drawRectangle = async (page: any, workerInfo: any) => {
+  await page.getByRole('button', { name: 'Rectangle' }).click();
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-rectangle-'
+      + workerInfo.project.name + '-linux.png'
+  });
+
+  await page.mouse.move(500, 300);
+  await page.mouse.click(500, 300);
+  await page.mouse.move(400, 500);
+  await page.mouse.click(400, 500);
+
+  await expect(page).not.toHaveScreenshot('draw-rectangle-'
+    + workerInfo.project.name
+    + '-linux.png');
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +33,11 @@ test('draw-rectangle', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Draw' }).click();
   await drawRectangle(page, workerInfo);
 });

--- a/src/e2e-tests/drawUpload.spec.ts
+++ b/src/e2e-tests/drawUpload.spec.ts
@@ -1,6 +1,30 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { drawUpload } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/drawUpload';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
+
+export const drawUpload = async (page: any, workerInfo: any) => {
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/draw-upload-'
+      + workerInfo.project.name + '-linux.png'
+  });
+  await page.getByRole('button', { name: 'Upload' }).click();
+
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.getByText('Click or drag file to this').click()
+  ]);
+
+  await fileChooser.setFiles('node_modules/@terrestris/shogun-e2e-tests/dist/additional-files/download-example.geojson');
+  await expect(page).not.toHaveScreenshot('draw-upload-'
+    + workerInfo.project.name
+    + '-linux.png');
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +34,11 @@ test('draw-upload', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Draw' }).click();
   await drawUpload(page, workerInfo);
 });

--- a/src/e2e-tests/exportPrint.spec.ts
+++ b/src/e2e-tests/exportPrint.spec.ts
@@ -1,6 +1,38 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { exportPrint } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/exportPrint';
+import {
+  closeWelcomeScreen,
+  highlight,
+  switchLanguage
+} from './helpers';
+
+export const exportPrint = async (page: any) => {
+  await expect(page.getByLabel('print-title', { exact: true })).toBeVisible();
+  await highlight(page.getByLabel('print-title', { exact: true }));
+  await expect(page.getByLabel('print-comment', { exact: true })).toBeVisible();
+  await highlight(page.getByLabel('print-comment', { exact: true }));
+  await expect(page.getByLabel('print-layout', { exact: true })).toBeVisible();
+  await highlight(page.getByLabel('print-layout', { exact: true }));
+  await expect(page.getByLabel('print-scale', { exact: true })).toBeVisible();
+  await highlight(page.getByLabel('print-scale', { exact: true }));
+  await expect(page.getByLabel('print-dpi', { exact: true })).toBeVisible();
+  await highlight(page.getByLabel('print-dpi', { exact: true }));
+  await expect(page.getByLabel('print-format', { exact: true })).toBeVisible();
+  await highlight(page.getByLabel('print-format', { exact: true }));
+  await expect(page.getByLabel('create-print', { exact: true })).toBeVisible();
+  await highlight(page.getByLabel('create-print', { exact: true }));
+
+  await page.getByLabel('print-title-input').fill('My Test');
+  await page.getByLabel('print-comment-input').fill('My comment using special characters: öäü!"§²%&[}=?*#');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByLabel('create-print').click();
+  const download = await downloadPromise;
+  await download.saveAs('./additional-files/print-download-example.pdf');
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +42,11 @@ test('draw-print', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Export' }).click();
   await exportPrint(page);
 });

--- a/src/e2e-tests/footer.spec.ts
+++ b/src/e2e-tests/footer.spec.ts
@@ -1,6 +1,26 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { footer } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/footer/footer';
+import {
+  closeWelcomeScreen,
+  highlight,
+  switchLanguage
+} from './helpers';
+
+export const footer = async (page: any) => {
+  await page.getByText('Accept').click();
+
+  await expect(page.getByLabel('scale-line')).toBeVisible();
+  await highlight(page.getByLabel('scale-line'));
+  await expect(page.getByLabel('scale-combo')).toBeVisible();
+  await highlight(page.getByLabel('scale-combo'));
+  await expect(page.getByLabel('reference-system')).toBeVisible();
+  await highlight(page.getByLabel('reference-system'));
+  await expect(page.getByLabel('mouse-position')).toBeVisible();
+  await highlight(page.getByLabel('mouse-position'));
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,7 +30,13 @@ test('footer', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
+  await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
+  await page.waitForTimeout(500);
+  expect(page.getByText('Maps')).toBeVisible();
+  
   await footer(page);
 });

--- a/src/e2e-tests/footer.spec.ts
+++ b/src/e2e-tests/footer.spec.ts
@@ -37,6 +37,6 @@ test('footer', async ({
   await switchLanguage(page, 'EN');
   await page.waitForTimeout(500);
   expect(page.getByText('Maps')).toBeVisible();
-  
+
   await footer(page);
 });

--- a/src/e2e-tests/header.spec.ts
+++ b/src/e2e-tests/header.spec.ts
@@ -3,7 +3,10 @@ import {
   expect
 } from '@playwright/test';
 
-import { closeWelcomeScreen, highlight } from './helpers';
+import {
+  closeWelcomeScreen,
+  highlight
+} from './helpers';
 
 export const header = async (page: any) => {
   await expect(page.locator('[data-testid="logo"]')).toBeVisible();

--- a/src/e2e-tests/header.spec.ts
+++ b/src/e2e-tests/header.spec.ts
@@ -1,6 +1,22 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { header } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/header/header';
+import { closeWelcomeScreen, highlight } from './helpers';
+
+export const header = async (page: any) => {
+  await expect(page.locator('[data-testid="logo"]')).toBeVisible();
+  await highlight(page.locator('[data-testid="logo"]'));
+  await expect(page.locator('[aria-label="title"]')).toBeVisible();
+  await highlight(page.locator('[aria-label="title"]'));
+  await expect(page.locator('[aria-label="search-field"]')).toBeVisible();
+  await highlight(page.locator('[aria-label="search-field"]'));
+  await expect(page.locator('[aria-label="documentation-button"]')).toBeVisible();
+  await highlight(page.locator('[aria-label="documentation-button"]'));
+  await expect(page.locator('[aria-label="user-menu"]')).toBeVisible();
+  await highlight(page.locator('[aria-label="user-menu"]'));
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,7 +26,8 @@ test('header', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await header(page);
 

--- a/src/e2e-tests/helpers.ts
+++ b/src/e2e-tests/helpers.ts
@@ -1,4 +1,7 @@
-import { Locator, Page } from '@playwright/test';
+import {
+  Locator,
+  Page
+} from '@playwright/test';
 
 export const switchLanguage = async (page: any, language: string) => {
   page.locator('.fa-language').click();

--- a/src/e2e-tests/helpers.ts
+++ b/src/e2e-tests/helpers.ts
@@ -1,0 +1,43 @@
+import { Locator, Page } from '@playwright/test';
+
+export const switchLanguage = async (page: any, language: string) => {
+  page.locator('.fa-language').click();
+  const languageIndicator = !(await page
+    .locator('#root')
+    .getByText(language)
+    .isVisible());
+  if (languageIndicator) {
+    await page.locator('.language-select').click();
+    await page
+      .locator('.ant-select-item-option-content')
+      .getByText(language, { exact: true })
+      .click();
+  }
+};
+
+export const closeWelcomeScreen = async (page: Page) => {
+  await page.waitForLoadState('networkidle');
+  const closeButton = page.locator('.ant-modal-close-x');
+  try {
+    await closeButton.waitFor({
+      state: 'visible',
+      timeout: 5000
+    });
+    await closeButton.click();
+  } catch {
+    // Modal did not appear, nothing to close
+  }
+};
+
+export async function highlight(locator: Locator) {
+  await locator.evaluate((el) => {
+    el.style.outline = '3px solid yellow';
+    el.style.backgroundColor = 'yellow';
+    setTimeout(() => {
+      el.style.outline = '';
+      el.style.backgroundColor = '';
+    }, 800);
+  });
+  await new Promise(resolve => setTimeout(resolve, 2000));
+}
+

--- a/src/e2e-tests/languageSelector.spec.ts
+++ b/src/e2e-tests/languageSelector.spec.ts
@@ -1,6 +1,12 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { languageSelector } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/languageSelector';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +16,12 @@ test('language-selector', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
-  await page.getByRole('button', { name: 'Language selector' }).click();
-  await languageSelector(page);
+  expect(page.getByText('Karten').first()).toBeVisible();
+  await switchLanguage(page, 'EN');
+  await page.waitForTimeout(500);
+  expect(page.getByText('Maps')).toBeVisible();
 });

--- a/src/e2e-tests/layertree.spec.ts
+++ b/src/e2e-tests/layertree.spec.ts
@@ -1,6 +1,129 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect,
+  Page
+} from '@playwright/test';
 
-import { layertree } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/layertree';
+import {
+  closeWelcomeScreen,
+  highlight,
+  switchLanguage
+} from './helpers';
+
+const openLayerContextMenu = async (page: Page) => {
+  const menuButton = page.getByLabel('layer-context-menu').first();
+  const menu = page.getByLabel('layer-context', { exact: true }).first();
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await menuButton.click();
+
+    if (await menu.isVisible()) {
+      return;
+    }
+  }
+
+  throw new Error('Layer context menu did not stay open.');
+};
+
+const clickLayerContextMenuItem = async (page: Page, itemName: string) => {
+  const menuButton = page.getByLabel('layer-context-menu').first();
+  const menuItem = page.getByRole('menuitem', { name: itemName });
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    await menuButton.click();
+
+    try {
+      await menuItem.click({ timeout: 1000 });
+      return;
+    } catch {
+      await page.keyboard.press('Escape');
+    }
+  }
+
+  throw new Error(`Could not click layer context menu item: ${itemName}`);
+};
+
+export const layertree = async (page: any, workerInfo: any) => {
+  await expect(page.getByLabel('layertree')).toBeVisible();
+  await expect(page.getByRole('button', { name: /Add WMS/ })).toBeVisible();
+  await page.getByRole('button', { name: /Add WMS/ }).click();
+
+  // add wms
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await highlight(page.getByRole('dialog'));
+  await expect(page.getByLabel('add-all')).toBeVisible();
+  await highlight(page.getByLabel('add-all'));
+  await expect(page.getByLabel('add-all')).toBeDisabled();
+  await expect(page.getByLabel('add-selected')).toBeVisible();
+  await highlight(page.getByLabel('add-selected'));
+  await expect(page.getByLabel('add-selected')).toBeDisabled();
+  await expect(page.getByLabel('Select all').nth(1)).toBeVisible();
+  await expect(page.getByLabel('input-search')).toBeVisible();
+  await expect(page.getByRole('combobox', { name: 'select-version' })).toBeVisible();
+  await highlight(page.getByRole('combobox', { name: 'select-version' }));
+  await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Close' }));
+
+  await page.getByLabel('input-search').fill('https://sgx.geodatenzentrum.de/wms_topplus_open');
+  await page.getByRole('button', {
+    name: 'search',
+    exact: true
+  }).click();
+  await page.getByRole('checkbox', { name: 'Select all' }).check();
+  await page.getByLabel('add-selected').click();
+
+  // test layertree
+  await expect(page.getByLabel('holder').first()).toBeVisible();
+  await highlight(page.getByLabel('holder').first());
+  await expect(page.getByLabel('caret-down').first()).toBeVisible();
+  await highlight(page.getByLabel('caret-down').first());
+  await expect(page.getByLabel('layer-group').filter({ hasText: 'External layers' })).toBeVisible();
+  await highlight(page.getByLabel('layer-group').filter({ hasText: 'External layers' }));
+
+  // test layertree-node
+  await page.getByLabel('caret-down').first().click();
+  await expect(page.getByLabel('layer-name').first()).toBeVisible();
+  await highlight(page.getByLabel('layer-name').first());
+  await expect(page.getByLabel('transparency-slider').first()).toBeVisible();
+  await highlight(page.getByLabel('transparency-slider').first());
+  await expect(page.getByLabel('layer-context-menu').first()).toBeVisible();
+  await highlight(page.getByLabel('layer-context-menu').first());
+  await openLayerContextMenu(page);
+  await expect(page.getByLabel('layer-context', { exact: true }).first()).toBeVisible();
+  await highlight(page.getByLabel('layer-context', { exact: true }).first());
+
+  // test layer context - zoom to extent
+  await page.waitForLoadState('networkidle');
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/zoom-'
+      + workerInfo.project.name + '-linux.png'
+  });
+  await clickLayerContextMenuItem(page, 'Zoom to layer extent');
+  await page.waitForLoadState('networkidle');
+  await expect(page).not.toHaveScreenshot('zoom-'
+    + workerInfo.project.name
+    + '-linux.png');
+
+  // test layer context - legend
+  await clickLayerContextMenuItem(page, 'Show legend');
+  await expect(page.getByAltText('TopPlusOpen Light Grau legend')).toBeVisible();
+  await highlight(page.getByAltText('TopPlusOpen Light Grau legend'));
+
+  // test layer context - remove layer
+  await expect(page.getByLabel('layer-name').filter({ hasText: 'TopPlusOpen Light Grau' })).toBeVisible();
+  await highlight(page.getByLabel('layer-name').filter({ hasText: 'TopPlusOpen Light Grau' }));
+  await page.waitForLoadState('networkidle');
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/delete-layer-'
+      + workerInfo.project.name + '-linux.png'
+  });
+  await clickLayerContextMenuItem(page, 'Remove layer');
+  await expect(page.getByLabel('layer-name').filter({ hasText: 'TopPlusOpen Light Grau' })).toBeHidden();
+  await page.waitForLoadState('networkidle');
+  await expect(page).not.toHaveScreenshot('delete-layer-'
+    + workerInfo.project.name
+    + '-linux.png');
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +133,11 @@ test('layertree', async ({
   page
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Maps' }).click();
   await layertree(page, workerInfo);
 });

--- a/src/e2e-tests/measure.spec.ts
+++ b/src/e2e-tests/measure.spec.ts
@@ -1,6 +1,43 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { measure } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/measure';
+import {
+  closeWelcomeScreen,
+  highlight,
+  switchLanguage
+} from './helpers';
+
+export const measure = async (page: any) => {
+  await expect(page.getByRole('button', { name: 'Distance' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Distance' }));
+  await expect(page.getByRole('button', { name: 'Area' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Area' }));
+
+  await page.getByRole('button', { name: 'Distance' }).click();
+  await page.mouse.move(500, 300);
+  await page.mouse.click(500, 300);
+  await page.mouse.move(500, 400);
+  await page.mouse.click(500, 400);
+  await page.mouse.move(600, 200);
+  await page.mouse.dblclick(600, 200);
+  await page.waitForSelector('.react-geo-measure-tooltip');
+  await page.getByRole('button', { name: 'Distance' }).click();
+  await page.waitForSelector('.react-geo-measure-tooltip', { state: 'hidden' });
+
+  // testing area-tool
+  await page.getByRole('button', { name: 'Area' }).click();
+  await page.mouse.move(500, 300);
+  await page.mouse.click(500, 300);
+  await page.mouse.move(500, 400);
+  await page.mouse.click(500, 400);
+  await page.mouse.move(600, 200);
+  await page.mouse.dblclick(600, 200);
+  await page.waitForSelector('.react-geo-measure-tooltip');
+  await page.getByRole('button', { name: 'Area' }).click();
+  await page.waitForSelector('.react-geo-measure-tooltip', { state: 'hidden' });
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,9 +47,11 @@ test('measure', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Measure' }).click();
   await measure(page);
 });

--- a/src/e2e-tests/queryMapFeatures.spec.ts
+++ b/src/e2e-tests/queryMapFeatures.spec.ts
@@ -1,6 +1,43 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect,
+  Page
+} from '@playwright/test';
 
-import { queryMapFeatures } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/queryMapFeatures';
+import {
+  closeWelcomeScreen,
+  highlight,
+  switchLanguage
+} from './helpers';
+
+const isGetFeatureInfoRequest = (url: string) => {
+  try {
+    const parsedUrl = new URL(url);
+    const requestParam = parsedUrl.searchParams.get('REQUEST') || parsedUrl.searchParams.get('request');
+    return requestParam?.toLowerCase() === 'getfeatureinfo';
+  } catch {
+    return /getfeatureinfo/i.test(url);
+  }
+};
+
+export const queryMapFeatures = async (page: Page) => {
+  await page.waitForLoadState('networkidle');
+
+  await page.getByRole('button', { name: 'Query map features' }).click();
+  await expect(page.getByText('Click on the map to get details about the clicked coordinate.')).toBeVisible();
+  await highlight(page.getByText('Click on the map to get details about the clicked coordinate.'));
+
+  const getFeatureInfoRequest = page.waitForRequest(req => {
+    return isGetFeatureInfoRequest(req.url());
+  }, {
+    timeout: 10000
+  });
+
+  await page.mouse.click(500, 300, { delay: 500 });
+  await getFeatureInfoRequest;
+  await expect(page.locator('.feature-info-tabs')).toBeVisible();
+  await highlight(page.locator('.feature-info-tabs'));
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,7 +47,11 @@ test('query-map-features', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
+
+  await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
 
   await queryMapFeatures(page);
 });

--- a/src/e2e-tests/scaleCombo.spec.ts
+++ b/src/e2e-tests/scaleCombo.spec.ts
@@ -1,6 +1,53 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { scaleCombo } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/footer/scaleCombo';
+import { closeWelcomeScreen, highlight } from './helpers';
+
+export const scaleCombo = async (page: any) => {
+  const initialScaleCombo = await page.getByLabel('scale-combo').innerText();
+  const initialScaleLine = await page.getByLabel('scale-line').innerText();
+
+  await expect(page.getByLabel('scale-combo').filter({
+    hasText: initialScaleCombo[0].toString()
+  })).toBeVisible();
+  await highlight(page.getByLabel('scale-combo').filter({
+    hasText: initialScaleCombo[0].toString()
+  }));
+  await expect(page.getByLabel('scale-line').filter({
+    hasText: initialScaleLine[0].toString()
+  })).toBeVisible();
+  await highlight(page.getByLabel('scale-line').filter({
+    hasText: initialScaleLine[0].toString()
+  }));
+
+  await page.getByText('Akzeptieren').click();
+  await page.getByLabel('scalecombo-dropdown').filter({
+    hasText: /1:/
+  }).click();
+  await page.keyboard.press('ArrowUp');
+  await page.keyboard.press('Enter');
+
+  const changedScaleCombo = await page.getByLabel('scale-combo').innerText();
+  const changedScaleLine = await page.getByLabel('scale-line').innerText();
+
+  await expect(page.getByLabel('scale-combo').filter({
+    hasText: changedScaleCombo[0].toString()
+  })).toBeVisible();
+  await highlight(page.getByLabel('scale-combo').filter({
+    hasText: changedScaleCombo[0].toString()
+  }));
+  await expect(page.getByLabel('scale-line').filter({
+    hasText: changedScaleLine[0].toString()
+  })).toBeVisible();
+  await highlight(page.getByLabel('scale-line').filter({
+    hasText: changedScaleLine[0].toString()
+  }));
+
+  await expect(initialScaleCombo).not.toEqual(changedScaleCombo);
+  await expect(initialScaleLine).not.toEqual(changedScaleLine);
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,7 +57,10 @@ test('scale-combo', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
+
+  await page.waitForLoadState('networkidle');
 
   await scaleCombo(page);
 });

--- a/src/e2e-tests/searchBar.spec.ts
+++ b/src/e2e-tests/searchBar.spec.ts
@@ -1,6 +1,14 @@
-import { test } from '@playwright/test';
+import {
+  test
+} from '@playwright/test';
 
-import { searchBar } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/header/searchBar';
+import { closeWelcomeScreen } from './helpers';
+
+const searchBar = async (page: any) => {
+  await page.locator('.ant-input').fill('Bonn');
+  await page.getByText('Bonn, North Rhine-Westphalia, Germany').first().click({ delay: 500 });
+  await page.waitForLoadState('networkidle');
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,7 +18,10 @@ test('search-bar', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
+
+  await page.waitForLoadState('networkidle');
 
   await searchBar(page);
 });

--- a/src/e2e-tests/share.spec.ts
+++ b/src/e2e-tests/share.spec.ts
@@ -1,6 +1,48 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { share } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/toolbox/share';
+import {
+  closeWelcomeScreen,
+  switchLanguage
+} from './helpers';
+
+const share = async (page: any, context: any, workerInfo: any) => {
+  function timeout(ms: any) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+  await expect(page.getByLabel('whats-app')).toBeVisible();
+  await expect(page.getByLabel('mail')).toBeVisible();
+  await expect(page.getByLabel('copy')).toBeVisible();
+  await expect(page.getByLabel('permalink-url')).toBeVisible();
+
+  // test whats-app
+  const whatsAppPromise = context.waitForEvent('page');
+  await page.getByLabel('whats-app').click();
+  const whatsApp = await whatsAppPromise;
+  await expect(whatsApp).toHaveURL(/whatsapp.com/);
+  whatsApp.close();
+
+  await page.waitForLoadState('networkidle');
+
+  await timeout(5000);
+  await page.screenshot({
+    path: './e2e-tests/additional-files/screenshots/permalink-'
+      + workerInfo.project.name + '-linux.png'
+  });
+
+  const url = await page.locator('#app input[type="text"]').nth(1).inputValue();
+
+  await page.goto(`${url}`);
+  await closeWelcomeScreen(page);
+  await page.waitForLoadState('networkidle');
+
+  await timeout(5000);
+  await expect(page).toHaveScreenshot('permalink-'
+    + workerInfo.project.name
+    + '-linux.png', { maxDiffPixelRatio: 0.05 });
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -11,9 +53,11 @@ test('share', async ({
   context
 }, workerInfo) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Share' }).click();
   await share(page, context, workerInfo);
 });

--- a/src/e2e-tests/userMenu.spec.ts
+++ b/src/e2e-tests/userMenu.spec.ts
@@ -1,6 +1,25 @@
-import { test } from '@playwright/test';
+import {
+  test,
+  expect
+} from '@playwright/test';
 
-import { userMenu } from '@terrestris/shogun-e2e-tests/dist/shogun-gis-client/header/userMenu';
+import {
+  closeWelcomeScreen,
+  highlight,
+  switchLanguage
+} from './helpers';
+
+export const userMenu = async (page: any) => {
+  await page.getByLabel('user-menu').click();
+  await expect(page.getByRole('menu')).toBeVisible();
+  await highlight(page.getByRole('menu'));
+  await expect(page.getByText('Edit profile')).toBeVisible();
+  await highlight(page.getByText('Edit profile'));
+  await expect(page.getByText('Logout')).toBeVisible();
+  await highlight(page.getByText('Logout'));
+  await page.getByText('Logout').click();
+  await expect(page).toHaveURL(/auth/);
+};
 
 test.use({
   storageState: 'playwright/.auth/admin.json'
@@ -10,7 +29,10 @@ test('user-menu', async ({
   page
 }) => {
 
-  await page.goto(`https://${process.env.HOST}/client/?applicationId=${process.env.ID}`);
+  await page.goto(`/client/?applicationId=${process.env.ID}`);
+  await closeWelcomeScreen(page);
 
+  await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await userMenu(page);
 });


### PR DESCRIPTION
This updates the e2e-tests for the latest version of the client.

They now run on "localhost:8080" by default and thus depend on a running local setup. This can be changed in `global-setup.ts` or by setting the "HOST"-variable.

The tests can be run with `npm run e2e-tests`.