### PR TITLE
chore: enable certain automerge presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,12 @@
   "extends": [
     "config:best-practices",
     ":prHourlyLimitNone",
-    ":prConcurrentLimit20"
+    ":prConcurrentLimit20",
+    ":automergeTesters",
+    ":automergeMinor",
+    ":automergeDigest",
+    ":automergeStableNonMajor",
+    ":automergeTypes"
   ],
   "labels": ["renovate"]
 }


### PR DESCRIPTION
In particular:

* `automergeTesters`: Update testing packages automatically if tests pass.
* `automergeMinor`: Automerge patch and minor upgrades if they pass tests.
* `automergeDigest`: Automerge docker digest upgrades if they pass tests.
* `automergeStableNonMajor`: Automerge non-major upgrades for semver stable packages if they pass tests.
* `automergeTypes`: Update `@types/*` packages automatically if tests pass.

Please review @terrestris/devs 