### PR TITLE
fix: update dockerfile for e2e-tests

### DIFF
--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -62,18 +62,18 @@ jobs:
       run: |
         docker push ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:main
 
-    - name: Build docker image e2e-tests (main) 🏗️
+    - name: Build docker image e2e-tests (latest) 🏗️
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         file: Dockerfile.e2e
         context: .
         tags: |
-          ${{ env.DOCKER_REGISTRY }}/shogun-gis-client-e2e-tests:main
+          ${{ env.DOCKER_REGISTRY }}/shogun-gis-client-e2e-tests:latest
         load: true
 
-    - name: Push docker image to Docker Registry (main) 📠
+    - name: Push docker image e2e-tests to Docker Registry (latest) 📠
       run: |
-        docker push ${{ env.DOCKER_REGISTRY }}/shogun-gis-client-e2e-tests:main
+        docker push ${{ env.DOCKER_REGISTRY }}/shogun-gis-client-e2e-tests:latest
 
   sonarqube:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -8,6 +8,7 @@ RUN npm ci
 COPY playwright.config.ts ./
 COPY global-setup.ts ./
 COPY ./src/e2e-tests ./src/e2e-tests
+COPY ./playwright ./playwright
 
 CMD [ "npm", "run", "e2e-tests" ]
 

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -2,16 +2,13 @@ FROM mcr.microsoft.com/playwright:v1.62.0-jammy@sha256:b012874f829d2987304112566
 
 WORKDIR /app
 
-RUN npm install -D @playwright/test@v1.36.1
+COPY package.json package-lock.json ./
+RUN npm ci
 
-# Need to be installed since the package.json is not copied
-RUN npm i @terrestris/shogun-e2e-tests@v1.0.8
-RUN npm i dotenv@v16.3.1
-
-COPY playwright.config.js ./
+COPY playwright.config.ts ./
 COPY global-setup.ts ./
 COPY ./src/e2e-tests ./src/e2e-tests
-COPY ./playwright ./playwright
 
 CMD [ "npm", "run", "e2e-tests" ]
+
 


### PR DESCRIPTION
This updates the dockerfile for the e2e-tests to install the correct dependencies.
Additionally the e2e-test image (latest) is now pushed on push to main.