### PR TITLE
fix: unify path of authentication state in e2e-tests

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -5,10 +5,9 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
-COPY playwright.config.ts ./
+COPY playwright.config.js ./
 COPY global-setup.ts ./
 COPY ./src/e2e-tests ./src/e2e-tests
-COPY ./playwright ./playwright
 
 CMD [ "npm", "run", "e2e-tests" ]
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -49,7 +49,7 @@ export default defineConfig({
         browserName: "chromium",
         locale: "en-EN",
         viewport: { width: 1400, height: 850 },
-        storageState: "playwright/.auth/admin.json",
+        storageState: './src/e2e-tests/.auth/admin.json',
       },
       dependencies: ["setup"],
     },

--- a/src/e2e-tests/auth.setup.ts
+++ b/src/e2e-tests/auth.setup.ts
@@ -2,7 +2,7 @@ import {
   test as setup
 } from '@playwright/test';
 
-const adminFile = 'playwright/.auth/admin.json';
+const adminFile = './src/e2e-tests/.auth/admin.json';
 
 setup('authenticate as admin', async ({ page }) => {
 

--- a/src/e2e-tests/draw-annotation.spec.ts
+++ b/src/e2e-tests/draw-annotation.spec.ts
@@ -10,7 +10,7 @@ import {
 } from './helpers';
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 const annotations = async (page: any, workerInfo: any) => {

--- a/src/e2e-tests/draw.spec.ts
+++ b/src/e2e-tests/draw.spec.ts
@@ -10,7 +10,7 @@ import {
 } from './helpers';
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 export const draw = async (page: any) => {

--- a/src/e2e-tests/drawCircle.spec.ts
+++ b/src/e2e-tests/drawCircle.spec.ts
@@ -23,7 +23,7 @@ export const drawCircle = async (page: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-circle', async ({

--- a/src/e2e-tests/drawDelete.spec.ts
+++ b/src/e2e-tests/drawDelete.spec.ts
@@ -27,7 +27,7 @@ export const drawDelete = async (page: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-delete', async ({

--- a/src/e2e-tests/drawEdit.spec.ts
+++ b/src/e2e-tests/drawEdit.spec.ts
@@ -37,7 +37,7 @@ export const drawEdit = async (page: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-edit', async ({

--- a/src/e2e-tests/drawExport.spec.ts
+++ b/src/e2e-tests/drawExport.spec.ts
@@ -48,7 +48,7 @@ export const drawExport = async (page: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-export', async ({

--- a/src/e2e-tests/drawLine.spec.ts
+++ b/src/e2e-tests/drawLine.spec.ts
@@ -23,7 +23,7 @@ export const drawLine = async (page: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-line', async ({

--- a/src/e2e-tests/drawModifyColorScheme.spec.ts
+++ b/src/e2e-tests/drawModifyColorScheme.spec.ts
@@ -16,7 +16,7 @@ export const drawModifyColorScheme = async (page: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-modify', async ({

--- a/src/e2e-tests/drawPoint.spec.ts
+++ b/src/e2e-tests/drawPoint.spec.ts
@@ -22,7 +22,7 @@ export const drawPoint = async (page: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-point', async ({

--- a/src/e2e-tests/drawPolygon.spec.ts
+++ b/src/e2e-tests/drawPolygon.spec.ts
@@ -28,7 +28,7 @@ export const drawPolygon = async (page: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-polygon', async ({

--- a/src/e2e-tests/drawRectangle.spec.ts
+++ b/src/e2e-tests/drawRectangle.spec.ts
@@ -26,7 +26,7 @@ export const drawRectangle = async (page: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-rectangle', async ({

--- a/src/e2e-tests/drawUpload.spec.ts
+++ b/src/e2e-tests/drawUpload.spec.ts
@@ -27,7 +27,7 @@ export const drawUpload = async (page: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-upload', async ({

--- a/src/e2e-tests/exportPrint.spec.ts
+++ b/src/e2e-tests/exportPrint.spec.ts
@@ -35,7 +35,7 @@ export const exportPrint = async (page: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('draw-print', async ({

--- a/src/e2e-tests/footer.spec.ts
+++ b/src/e2e-tests/footer.spec.ts
@@ -23,7 +23,7 @@ export const footer = async (page: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('footer', async ({

--- a/src/e2e-tests/header.spec.ts
+++ b/src/e2e-tests/header.spec.ts
@@ -22,7 +22,7 @@ export const header = async (page: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('header', async ({

--- a/src/e2e-tests/languageSelector.spec.ts
+++ b/src/e2e-tests/languageSelector.spec.ts
@@ -9,7 +9,7 @@ import {
 } from './helpers';
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('language-selector', async ({

--- a/src/e2e-tests/layertree.spec.ts
+++ b/src/e2e-tests/layertree.spec.ts
@@ -126,7 +126,7 @@ export const layertree = async (page: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('layertree', async ({

--- a/src/e2e-tests/measure.spec.ts
+++ b/src/e2e-tests/measure.spec.ts
@@ -40,7 +40,7 @@ export const measure = async (page: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('measure', async ({

--- a/src/e2e-tests/queryMapFeatures.spec.ts
+++ b/src/e2e-tests/queryMapFeatures.spec.ts
@@ -40,7 +40,7 @@ export const queryMapFeatures = async (page: Page) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('query-map-features', async ({

--- a/src/e2e-tests/scaleCombo.spec.ts
+++ b/src/e2e-tests/scaleCombo.spec.ts
@@ -50,7 +50,7 @@ export const scaleCombo = async (page: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('scale-combo', async ({

--- a/src/e2e-tests/searchBar.spec.ts
+++ b/src/e2e-tests/searchBar.spec.ts
@@ -11,7 +11,7 @@ const searchBar = async (page: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('search-bar', async ({

--- a/src/e2e-tests/share.spec.ts
+++ b/src/e2e-tests/share.spec.ts
@@ -45,7 +45,7 @@ const share = async (page: any, context: any, workerInfo: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('share', async ({

--- a/src/e2e-tests/userMenu.spec.ts
+++ b/src/e2e-tests/userMenu.spec.ts
@@ -22,7 +22,7 @@ export const userMenu = async (page: any) => {
 };
 
 test.use({
-  storageState: 'playwright/.auth/admin.json'
+  storageState: './src/e2e-tests/.auth/admin.json'
 });
 
 test('user-menu', async ({


### PR DESCRIPTION
This pull request standardizes the storage location for Playwright authentication state files across all e2e-tests.