### PR TITLE
test: add testIgnore for e2e-tests

### DIFF
--- a/global-setup.ts
+++ b/global-setup.ts
@@ -11,6 +11,7 @@ async function globalSetup(config: FullConfig) {
     process.env.ADMIN_LOGIN =  process.env.ADMIN_LOGIN;
     process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
     process.env.HEADLESS = process.env.HEADLESS ?? 'true';
+    process.env.TEST_IGNORE = process.env.TEST_IGNORE ?? '';
 }
 
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,6 +3,12 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   globalSetup: require.resolve("./global-setup.ts"),
   testDir: "./src/e2e-tests",
+  testIgnore: process.env.TEST_IGNORE
+    ? process.env.TEST_IGNORE.split(',').map(f => {
+        const name = f.trim().replace(/^src\/e2e-tests\//, '');
+        return `**/${name}`;
+      })
+    : [],
   snapshotPathTemplate: "./src/e2e-tests/additional-files/screenshots/{arg}{ext}",
   timeout: 120 * 1000,
   expect: {

--- a/src/e2e-tests/draw.spec.ts
+++ b/src/e2e-tests/draw.spec.ts
@@ -20,8 +20,8 @@ export const draw = async (page: any) => {
   await highlight(page.getByRole('button', { name: 'Line' }));
   await expect(page.getByRole('button', { name: 'Polygon' })).toBeVisible();
   await highlight(page.getByRole('button', { name: 'Polygon' }));
-  await expect(page.getByRole('button', { name: 'Circle' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Circle' }));
+  await expect(page.getByRole('button', { name: 'Circle' }).first()).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Circle' }).first());
   await expect(page.getByRole('button', { name: 'Rectangle' })).toBeVisible();
   await highlight(page.getByRole('button', { name: 'Rectangle' }));
   await expect(page.getByRole('button', { name: 'Annotation' })).toBeVisible();

--- a/src/e2e-tests/drawCircle.spec.ts
+++ b/src/e2e-tests/drawCircle.spec.ts
@@ -9,7 +9,7 @@ import {
 } from './helpers';
 
 export const drawCircle = async (page: any, workerInfo: any) => {
-  await page.getByRole('button', { name: 'Circle' }).click();
+  await page.getByRole('button', { name: 'Circle' }).first().click();
   await page.screenshot({
     path: './src/e2e-tests/additional-files/screenshots/draw-circle-'
       + workerInfo.project.name + '-linux.png'


### PR DESCRIPTION
This pull request introduces a way to dynamically ignore specific e2e-tests based on an environment variable.

**Example:** 
`TEST_IGNORE=draw-annotation.spec.ts,draw.spec.ts,drawCircle.spec.ts npm run e2e-tests`
