### PR TITLE
test: improve element selection in e2e-tests

### DIFF
--- a/src/e2e-tests/draw-annotation.spec.ts
+++ b/src/e2e-tests/draw-annotation.spec.ts
@@ -38,7 +38,10 @@ const annotations = async (page: any, workerInfo: any) => {
   await closeWelcomeScreen(page);
   await page.waitForLoadState('networkidle');
   await page.getByRole('button', { name: 'Zeichnen' }).click();
-  await page.getByRole('button', { name: 'Anmerkung' }).click();
+  await page.getByRole('button', {
+    name: 'Anmerkung',
+    exact: true
+  }).click();
   await page.screenshot({
     path: './src/e2e-tests/additional-files/screenshots/draw-annotation-'
       + workerInfo.project.name + '-linux.png'

--- a/src/e2e-tests/draw.spec.ts
+++ b/src/e2e-tests/draw.spec.ts
@@ -14,22 +14,70 @@ test.use({
 });
 
 export const draw = async (page: any) => {
-  await expect(page.getByRole('button', { name: 'Point' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Point' }));
-  await expect(page.getByRole('button', { name: 'Line' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Line' }));
-  await expect(page.getByRole('button', { name: 'Polygon' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Polygon' }));
-  await expect(page.getByRole('button', { name: 'Circle' }).first()).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Circle' }).first());
-  await expect(page.getByRole('button', { name: 'Rectangle' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Rectangle' }));
-  await expect(page.getByRole('button', { name: 'Annotation' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Annotation' }));
-  await expect(page.getByRole('button', { name: 'Edit' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Edit' }));
-  await expect(page.getByRole('button', { name: 'Upload' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Upload' }));
+  await expect(page.getByRole('button', {
+    name: 'Point',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', { 
+    name: 'Point',
+    exact: true
+  }));
+  await expect(page.getByRole('button', { 
+    name: 'Line',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', { 
+    name: 'Line',
+    exact: true
+  }));
+  await expect(page.getByRole('button', { 
+    name: 'Polygon',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', { 
+    name: 'Polygon',
+    exact: true
+  }));
+  await expect(page.getByRole('button', { 
+    name: 'Circle',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', { 
+    name: 'Circle',
+    exact: true
+  }));
+  await expect(page.getByRole('button', { 
+    name: 'Rectangle',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', { 
+    name: 'Rectangle',
+    exact: true
+  }));
+  await expect(page.getByRole('button', { 
+    name: 'Annotation',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', { 
+    name: 'Annotation',
+    exact: true
+  }));
+  await expect(page.getByRole('button', { 
+    name: 'Edit',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', { 
+    name: 'Edit',
+    exact: true
+  }));
+  await expect(page.getByRole('button', { 
+    name: 'draw-upload',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', { 
+    name: 'draw-upload',
+    exact: true
+  }));
   await expect(page.getByRole('button', {
     name: 'Export',
     exact: true
@@ -46,10 +94,22 @@ export const draw = async (page: any) => {
     name: 'Delete',
     exact: true
   }));
-  await expect(page.getByRole('button', { name: 'Delete all' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Delete all' }));
-  await expect(page.getByRole('button', { name: 'Open color palette' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Open color palette' }));
+  await expect(page.getByRole('button', { 
+    name: 'Delete all',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', { 
+    name: 'Delete all',
+    exact: true
+  }));
+  await expect(page.getByRole('button', { 
+    name: 'Open color palette',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', { 
+    name: 'Open color palette',
+    exact: true
+  }));
 };
 
 test('draw', async ({

--- a/src/e2e-tests/draw.spec.ts
+++ b/src/e2e-tests/draw.spec.ts
@@ -18,63 +18,63 @@ export const draw = async (page: any) => {
     name: 'Point',
     exact: true
   })).toBeVisible();
-  await highlight(page.getByRole('button', { 
+  await highlight(page.getByRole('button', {
     name: 'Point',
     exact: true
   }));
-  await expect(page.getByRole('button', { 
+  await expect(page.getByRole('button', {
     name: 'Line',
     exact: true
   })).toBeVisible();
-  await highlight(page.getByRole('button', { 
+  await highlight(page.getByRole('button', {
     name: 'Line',
     exact: true
   }));
-  await expect(page.getByRole('button', { 
+  await expect(page.getByRole('button', {
     name: 'Polygon',
     exact: true
   })).toBeVisible();
-  await highlight(page.getByRole('button', { 
+  await highlight(page.getByRole('button', {
     name: 'Polygon',
     exact: true
   }));
-  await expect(page.getByRole('button', { 
+  await expect(page.getByRole('button', {
     name: 'Circle',
     exact: true
   })).toBeVisible();
-  await highlight(page.getByRole('button', { 
+  await highlight(page.getByRole('button', {
     name: 'Circle',
     exact: true
   }));
-  await expect(page.getByRole('button', { 
+  await expect(page.getByRole('button', {
     name: 'Rectangle',
     exact: true
   })).toBeVisible();
-  await highlight(page.getByRole('button', { 
+  await highlight(page.getByRole('button', {
     name: 'Rectangle',
     exact: true
   }));
-  await expect(page.getByRole('button', { 
+  await expect(page.getByRole('button', {
     name: 'Annotation',
     exact: true
   })).toBeVisible();
-  await highlight(page.getByRole('button', { 
+  await highlight(page.getByRole('button', {
     name: 'Annotation',
     exact: true
   }));
-  await expect(page.getByRole('button', { 
+  await expect(page.getByRole('button', {
     name: 'Edit',
     exact: true
   })).toBeVisible();
-  await highlight(page.getByRole('button', { 
+  await highlight(page.getByRole('button', {
     name: 'Edit',
     exact: true
   }));
-  await expect(page.getByRole('button', { 
+  await expect(page.getByRole('button', {
     name: 'draw-upload',
     exact: true
   })).toBeVisible();
-  await highlight(page.getByRole('button', { 
+  await highlight(page.getByRole('button', {
     name: 'draw-upload',
     exact: true
   }));
@@ -94,19 +94,19 @@ export const draw = async (page: any) => {
     name: 'Delete',
     exact: true
   }));
-  await expect(page.getByRole('button', { 
+  await expect(page.getByRole('button', {
     name: 'Delete all',
     exact: true
   })).toBeVisible();
-  await highlight(page.getByRole('button', { 
+  await highlight(page.getByRole('button', {
     name: 'Delete all',
     exact: true
   }));
-  await expect(page.getByRole('button', { 
+  await expect(page.getByRole('button', {
     name: 'Open color palette',
     exact: true
   })).toBeVisible();
-  await highlight(page.getByRole('button', { 
+  await highlight(page.getByRole('button', {
     name: 'Open color palette',
     exact: true
   }));

--- a/src/e2e-tests/drawCircle.spec.ts
+++ b/src/e2e-tests/drawCircle.spec.ts
@@ -9,7 +9,10 @@ import {
 } from './helpers';
 
 export const drawCircle = async (page: any, workerInfo: any) => {
-  await page.getByRole('button', { name: 'Circle' }).first().click();
+  await page.getByRole('button', {
+    name: 'Circle',
+    exact: true
+  }).click();
   await page.screenshot({
     path: './src/e2e-tests/additional-files/screenshots/draw-circle-'
       + workerInfo.project.name + '-linux.png'

--- a/src/e2e-tests/drawDelete.spec.ts
+++ b/src/e2e-tests/drawDelete.spec.ts
@@ -10,7 +10,10 @@ import {
 
 export const drawDelete = async (page: any, workerInfo: any) => {
   // add point to map
-  await page.getByRole('button', { name: 'Point' }).click();
+  await page.getByRole('button', { 
+    name: 'Point',
+    exact: true
+  }).click();
   await page.mouse.click(500, 300, { delay: 500 });
   await page.screenshot({
     path: './src/e2e-tests/additional-files/screenshots/draw-delete-'
@@ -18,7 +21,10 @@ export const drawDelete = async (page: any, workerInfo: any) => {
   });
 
   // delete point
-  await page.getByRole('button', { name: 'Delete all' }).click({ delay: 1000 });
+  await page.getByRole('button', { 
+    name: 'Delete all',
+    exact: true
+  }).click({ delay: 1000 });
   await page.mouse.click(500, 300, { delay: 500 });
 
   await expect(page).not.toHaveScreenshot('draw-delete-'

--- a/src/e2e-tests/drawDelete.spec.ts
+++ b/src/e2e-tests/drawDelete.spec.ts
@@ -10,7 +10,7 @@ import {
 
 export const drawDelete = async (page: any, workerInfo: any) => {
   // add point to map
-  await page.getByRole('button', { 
+  await page.getByRole('button', {
     name: 'Point',
     exact: true
   }).click();
@@ -21,7 +21,7 @@ export const drawDelete = async (page: any, workerInfo: any) => {
   });
 
   // delete point
-  await page.getByRole('button', { 
+  await page.getByRole('button', {
     name: 'Delete all',
     exact: true
   }).click({ delay: 1000 });

--- a/src/e2e-tests/drawEdit.spec.ts
+++ b/src/e2e-tests/drawEdit.spec.ts
@@ -18,8 +18,14 @@ export const drawEdit = async (page: any, workerInfo: any) => {
   });
 
   // modify point
-  await page.getByRole('button', { name: 'Edit' }).click({ delay: 1000 });
-  await expect(page.getByRole('button', { name: 'Edit' })).toHaveAttribute('aria-pressed', 'true');
+  await page.getByRole('button', {
+    name: 'Edit',
+    exact: true
+  }).click({ delay: 1000 });
+  await expect(page.getByRole('button', {
+    name: 'Edit',
+    exact: true
+  })).toHaveAttribute('aria-pressed', 'true');
   await page.mouse.click(500, 300, { delay: 500 });
 
   await page.mouse.move(500, 300);

--- a/src/e2e-tests/drawExport.spec.ts
+++ b/src/e2e-tests/drawExport.spec.ts
@@ -34,7 +34,10 @@ export const drawExport = async (page: any, workerInfo: any) => {
   await closeWelcomeScreen(page);
   await page.waitForLoadState('networkidle');
   await page.getByRole('button', { name: 'Draw' }).click();
-  await page.getByRole('button', { name: 'Upload' }).click();
+  await page.getByRole('button', {
+    name: 'draw-upload',
+    exact: true
+  }).click();
 
   const [fileChooser] = await Promise.all([
     page.waitForEvent('filechooser'),

--- a/src/e2e-tests/drawLine.spec.ts
+++ b/src/e2e-tests/drawLine.spec.ts
@@ -9,7 +9,10 @@ import {
 } from './helpers';
 
 export const drawLine = async (page: any, workerInfo: any) => {
-  await page.getByRole('button', { name: 'Line' }).click();
+  await page.getByRole('button', {
+    name: 'Line',
+    exact: true
+  }).click();
   await page.screenshot({
     path: './src/e2e-tests/additional-files/screenshots/draw-line-'
       + workerInfo.project.name + '-linux.png'

--- a/src/e2e-tests/drawPoint.spec.ts
+++ b/src/e2e-tests/drawPoint.spec.ts
@@ -9,7 +9,10 @@ import {
 } from './helpers';
 
 export const drawPoint = async (page: any, workerInfo: any) => {
-  await page.getByRole('button', { name: 'Point' }).click();
+  await page.getByRole('button', {
+    name: 'Point',
+    exact: true
+  }).click();
   await page.screenshot({
     path: './src/e2e-tests/additional-files/screenshots/draw-point-'
       + workerInfo.project.name + '-linux.png'

--- a/src/e2e-tests/drawPolygon.spec.ts
+++ b/src/e2e-tests/drawPolygon.spec.ts
@@ -9,7 +9,10 @@ import {
 } from './helpers';
 
 export const drawPolygon = async (page: any, workerInfo: any) => {
-  await page.getByRole('button', { name: 'Polygon' }).click();
+  await page.getByRole('button', {
+    name: 'Polygon',
+    exact: true
+  }).click();
   await page.screenshot({
     path: './src/e2e-tests/additional-files/screenshots/draw-polygon-'
       + workerInfo.project.name + '-linux.png'

--- a/src/e2e-tests/drawRectangle.spec.ts
+++ b/src/e2e-tests/drawRectangle.spec.ts
@@ -9,7 +9,10 @@ import {
 } from './helpers';
 
 export const drawRectangle = async (page: any, workerInfo: any) => {
-  await page.getByRole('button', { name: 'Rectangle' }).click();
+  await page.getByRole('button', {
+    name: 'Rectangle',
+    exact: true
+  }).click();
   await page.screenshot({
     path: './src/e2e-tests/additional-files/screenshots/draw-rectangle-'
       + workerInfo.project.name + '-linux.png'

--- a/src/e2e-tests/drawUpload.spec.ts
+++ b/src/e2e-tests/drawUpload.spec.ts
@@ -13,7 +13,10 @@ export const drawUpload = async (page: any, workerInfo: any) => {
     path: './src/e2e-tests/additional-files/screenshots/draw-upload-'
       + workerInfo.project.name + '-linux.png'
   });
-  await page.getByRole('button', { name: 'Upload' }).click();
+  await page.getByRole('button', {
+    name: 'draw-upload',
+    exact: true
+  }).click();
 
   const [fileChooser] = await Promise.all([
     page.waitForEvent('filechooser'),

--- a/src/e2e-tests/measure.spec.ts
+++ b/src/e2e-tests/measure.spec.ts
@@ -10,12 +10,27 @@ import {
 } from './helpers';
 
 export const measure = async (page: any) => {
-  await expect(page.getByRole('button', { name: 'Distance' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Distance' }));
-  await expect(page.getByRole('button', { name: 'Area' })).toBeVisible();
-  await highlight(page.getByRole('button', { name: 'Area' }));
+  await expect(page.getByRole('button', {
+    name: 'Distance',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', {
+    name: 'Distance',
+    exact: true
+  }));
+  await expect(page.getByRole('button', {
+    name: 'Area',
+    exact: true
+  })).toBeVisible();
+  await highlight(page.getByRole('button', {
+    name: 'Area',
+    exact: true
+  }));
 
-  await page.getByRole('button', { name: 'Distance' }).click();
+  await page.getByRole('button', {
+    name: 'Distance',
+    exact: true
+  }).click();
   await page.mouse.move(500, 300);
   await page.mouse.click(500, 300);
   await page.mouse.move(500, 400);
@@ -23,11 +38,17 @@ export const measure = async (page: any) => {
   await page.mouse.move(600, 200);
   await page.mouse.dblclick(600, 200);
   await expect(page.locator('.react-geo-measure-tooltip').first()).toBeVisible();
-  await page.getByRole('button', { name: 'Distance' }).click();
+  await page.getByRole('button', {
+    name: 'Distance',
+    exact: true
+  }).click();
   await expect(page.locator('.react-geo-measure-tooltip').first()).toBeHidden();
 
   // testing area-tool
-  await page.getByRole('button', { name: 'Area' }).click();
+  await page.getByRole('button', {
+    name: 'Area',
+    exact: true
+  }).click();
   await page.mouse.move(500, 300);
   await page.mouse.click(500, 300);
   await page.mouse.move(500, 400);
@@ -35,7 +56,10 @@ export const measure = async (page: any) => {
   await page.mouse.move(600, 200);
   await page.mouse.dblclick(600, 200);
   await expect(page.locator('.react-geo-measure-tooltip').first()).toBeVisible();
-  await page.getByRole('button', { name: 'Area' }).click();
+  await page.getByRole('button', {
+    name: 'Area',
+    exact: true
+  }).click();
   await expect(page.locator('.react-geo-measure-tooltip').first()).toBeHidden();
 };
 

--- a/src/e2e-tests/scaleCombo.spec.ts
+++ b/src/e2e-tests/scaleCombo.spec.ts
@@ -3,7 +3,9 @@ import {
   expect
 } from '@playwright/test';
 
-import { closeWelcomeScreen, highlight } from './helpers';
+import {
+  closeWelcomeScreen, highlight
+} from './helpers';
 
 export const scaleCombo = async (page: any) => {
   const initialScaleCombo = await page.getByLabel('scale-combo').innerText();


### PR DESCRIPTION
This pull request updates the e2e-tests to use stricter role queries for button selection by adding the `exact: true` option to all `getByRole('button', { name: ... })` calls. This change ensures that the tests interact with the intended buttons only, reducing the risk of false positives.
