### PR TITLE
test: add json reporter for e2e-tests

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -25,6 +25,7 @@ export default defineConfig({
         open: "never",
       },
     ],
+    ["json", { outputFile: "./src/e2e-tests/test-results/gis-client-results.json" }],
   ],
   use: {
     headless: process.env.CI ? true : Boolean(process.env.HEADLESS),


### PR DESCRIPTION
This pull request adds a json reporter for the e2e-tests. The change enables test results to be output in JSON format for easier use of the test results.