### PR TITLE
fix: adjust e2e-tests

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -25,7 +25,7 @@ export default defineConfig({
         open: "never",
       },
     ],
-    ["json", { outputFile: "./src/e2e-tests/test-results/gis-client-results.json" }],
+    ["json", { outputFile: "./playwright-report/gis-client-results.json" }],
   ],
   use: {
     headless: process.env.CI ? true : Boolean(process.env.HEADLESS),

--- a/src/e2e-tests/drawExport.spec.ts
+++ b/src/e2e-tests/drawExport.spec.ts
@@ -33,6 +33,7 @@ export const drawExport = async (page: any, workerInfo: any) => {
   await page.reload();
   await closeWelcomeScreen(page);
   await page.waitForLoadState('networkidle');
+  await switchLanguage(page, 'EN');
   await page.getByRole('button', { name: 'Draw' }).click();
   await page.getByRole('button', {
     name: 'draw-upload',

--- a/src/e2e-tests/layertree.spec.ts
+++ b/src/e2e-tests/layertree.spec.ts
@@ -57,8 +57,8 @@ export const layertree = async (page: any, workerInfo: any) => {
   await expect(page.getByLabel('add-selected')).toBeVisible();
   await highlight(page.getByLabel('add-selected'));
   await expect(page.getByLabel('add-selected')).toBeDisabled();
-  await expect(page.getByLabel('Select all').nth(1)).toBeVisible();
-  await expect(page.getByLabel('input-search')).toBeVisible();
+  await expect(page.locator('input[aria-label="Select all"]').last()).toBeVisible();
+  await expect(page.locator('input[aria-label="input-search"]')).toBeVisible();
   await expect(page.getByRole('combobox', { name: 'select-version' })).toBeVisible();
   await highlight(page.getByRole('combobox', { name: 'select-version' }));
   await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();


### PR DESCRIPTION
This adjusts some e2e-tests so that they run more relyably in different instances of the client.