### PR TITLE
fix: variable name of docker registry password

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -12,7 +12,7 @@ on:
     secrets:
       docker_registry_user:
         required: true
-      docker_registry_pass:
+      docker_registry_password:
         required: true
 
 env:
@@ -33,7 +33,7 @@ jobs:
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.docker_registry_user }}
-          password: ${{ secrets.docker_registry_pass }}
+          password: ${{ secrets.docker_registry_password }}
 
       - name: Build docker image (latest)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7


### PR DESCRIPTION
Renamed `docker_registry_pass` to `docker_registry_password` in `release_docker.yml` (both in the `workflow_call` secret definition and its usage in the Docker login step). This makes it consistent with how all callers (`release.yml` and `update_base_images.yaml`) pass the secret.

Plz review @terrestris/devs 